### PR TITLE
Fix another 'mysql' incompatibility

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -26,10 +26,18 @@ Query.prototype.start = function(packet, connection) {
 
 Query.prototype.done = function() {
   if (this.onResult) {
+    var rows, fields;
     if (this._resultIndex === 0) {
-      this.onResult(null, this._rows[0], this._fields[0]);
+      rows = this._rows[0];
+      fields = this._fields[0];
     } else {
-      this.onResult(null, this._rows, this._fields);
+      rows = this._rows;
+      fields = this._fields;
+    }
+    if (fields) {
+      this.onResult(null, rows, fields);
+    } else {
+      this.onResult(null, rows);
     }
   }
   return null;


### PR DESCRIPTION
This is similar to the previous incompatibility fix, with the same use case with the 'async' module. This however is mainly for queries that do not have fields (e.g. INSERT and UPDATE).
