### PR TITLE
fix error packet parsing

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -313,7 +313,7 @@ Packet.prototype.asError = function() {
   var errorCode = this.readInt16();
   var sqlState  = '';
   if (this.buffer[this.offset] == 0x23)
-    sqlState = this.readBuffer(5).toString();
+    sqlState = this.readBuffer(6).toString();
   var message = this.readString();
   var err = new Error(message);
   err.code = ErrorCodeToName[errorCode];


### PR DESCRIPTION
According to the MySQL protocol docs, it's '#' followed by 5 bytes for the sqlState, then the message follows. Before this, error messages contained the last character from the sqlState.
