### PR TITLE
node-mysql api: Pool.on('connection')

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,9 +1,13 @@
-
 var mysql        = require('../index.js');
 var Connection   = mysql.Connection;
+var EventEmitter = require('events').EventEmitter;
+var Util         = require('util');
 
 module.exports = Pool;
+
+Util.inherits(Pool, EventEmitter);
 function Pool(options) {
+  EventEmitter.call(this);
   this.config = options.config;
   this.config.connectionConfig.pool = this;
 
@@ -35,6 +39,7 @@ Pool.prototype.getConnection = function(cb) {
       else if (err) {
         cb(err);
       } else {
+        self.emit('connection', connection);
         cb(null, connection);
       }
     });


### PR DESCRIPTION
Fix node-mysql api incompatibility: Pool.on('connection') 

Allow to listen "connection" event in pool, example:
pool.on('connection', function(connection) {
  connection.query('SET SESSION auto_increment_increment=1')
});
