### PR TITLE
Date type column ends up with decoding trouble.

### DIFF
--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -34,6 +34,7 @@ function readCodeFor(type, charset) {
   case Types.DECIMAL:
   case Types.NEWDECIMAL:
     return "packet.readLengthCodedString(); //" + type + ' ' + charset;
+  case Types.DATE: // Fix for (TypeError: Unknown encoding: 10) on Date column
   case Types.DATETIME:
   case Types.TIMESTAMP:
     return "new Date(packet.readLengthCodedString());";


### PR DESCRIPTION
The missing case handle for DATE type was landing the column value decoding into trouble. Fixed the same. Please review the same.
