### PR TITLE
Adds the XidEvent to binlog, and handles non-blocking stream ends

### DIFF
--- a/lib/commands/binlog_dump.js
+++ b/lib/commands/binlog_dump.js
@@ -43,7 +43,6 @@ function FormatDescriptionEvent(packet) {
   this.name = 'FormatDescriptionEvent';
 }
 
-
 function QueryEvent(packet) {
   
   var parseStatusVars = require('../packets/binlog_query_statusvars.js');
@@ -63,17 +62,25 @@ function QueryEvent(packet) {
   this.name = 'QueryEvent';
 }
 
+function XidEvent(packet) {
+  this.binlogVersion = packet.readInt16();
+  this.xid = packet.readInt64();
+  this.name = 'XidEvent';
+}
+
 var eventParsers = [];
 
 eventParsers[2]  = QueryEvent;
 eventParsers[4]  = RotateEvent;
 eventParsers[15] = FormatDescriptionEvent;
+eventParsers[16] = XidEvent;
 
 BinlogDump.prototype.binlogData = function(packet) {
   // ok - continue consuming events
   // error - error
   // eof - end of binlog
   if (packet.isEOF()) {
+    this.emit('eof');
     return null;
   }
   

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -390,6 +390,14 @@ Connection.prototype.createBinlogStream = function(opts) {
     dumpCmd.on('event', function(ev) {
       stream.push(ev);
     });
+    dumpCmd.on('eof', function() {
+      stream.push(null);
+      // if non-blocking, then close stream to prevent errors
+      if (opts.flags && (opts.flags & 0x01)) {
+        connection._closing = true;
+        connection.stream.end();
+      }
+    });
     // TODO: pipe errors as well
   })
   return stream;


### PR DESCRIPTION
The XidEvent (type=16) is currently not handled This PR adds support for it.

When you create a non-blocking binlog stream, the stream currently ends and 
throw errors. This PR fixes this by closing the stream gracefully.

Eg:

``` js
var binlogStream = conn.createBinlogStream({
  serverId: 3,
  masterId: 1,
  filename: 'mysql-bin.000002',
  binlogPos: 958,
  flags: 1, // 1 = "non-blocking mode"
});

// will throw an error as the stream ends
binlogStream.on('data', console.log);
```
