### PR TITLE
parseFloat on DECIMAL and NEWDECIMAL types to have them as numbers

### DIFF
--- a/lib/compile_binary_parser.js
+++ b/lib/compile_binary_parser.js
@@ -113,7 +113,7 @@ function readCodeFor(field, config) {
     return "packet.readTimeString()";
   case Types.DECIMAL:
   case Types.NEWDECIMAL:
-    return "packet.readLengthCodedString();";
+    return "parseFloat(packet.readLengthCodedString());";
   case Types.GEOMETRY:
     return "packet.parseGeometryValue();";
   case Types.LONGLONG: // TODO: 8 bytes. Implement as two 4 bytes read for now (it's out of JavaScript int precision!)

--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -76,7 +76,7 @@ function readCodeFor(type, charset, config) {
     return "null; packet.skip(1);";
   case Types.DECIMAL:
   case Types.NEWDECIMAL:
-    return "packet.readLengthCodedString(); //" + type + ' ' + charset;
+    return "parseFloat(packet.readLengthCodedString()); //" + type + ' ' + charset;
   case Types.DATE:
     if (config.dateStrings)
       return "packet.readLengthCodedString()";

--- a/test/integration/connection/type-casting-tests.js
+++ b/test/integration/connection/type-casting-tests.js
@@ -1,7 +1,7 @@
 module.exports = function(connection){
   return [
-    {type: 'decimal(4,3)', insert: '1.234'},
-//  {type: 'decimal(3,3)', insert: 0.33},
+    {type: 'decimal(4,3)', insert: 1.234},
+    {type: 'decimal(4,3)', insert: '0.230', expect: 0.23},
     {type: 'tinyint', insert: 1},
     {type: 'smallint', insert: 2},
     {type: 'int', insert: 3},


### PR DESCRIPTION
I suggest that we treat DECIMAL and NEWDECIMAL as numbers instead of strings. But as far as I can see, it is a string when it is coming from MySQL, so we still have to read it as a string.
