### PR TITLE
Solve incompatibility with autoload

### DIFF
--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -30,7 +30,7 @@ Execute.prototype.toPacket = function()
     for (i=0; i < this.parameters.length; i++)
     {
       if (this.parameters[i] !== null) {
-        if (toString.call(this.parameters[i]) == '[object Date]') {
+        if (Object.prototype.toString.call(this.parameters[i]) == '[object Date]') {
           var d = this.parameters[i];
           // TODO: move to asMysqlDateTime()
           this.parameters[i] = [d.getFullYear(), d.getMonth() + 1, d.getDate()].join('-') +


### PR DESCRIPTION
Fix for a small compatibility problem with the autoload plugin of Daniel Ennis (https://github.com/aikar/autoloader)

In lib/packets/execute.js at line 33, the code:

```
    if (toString.call(this.parameters[i]) == '[object Date]') {
```

confuses autoloader, because the context is missing.

I changed it to:

```
     if (Object.prototype.toString.call(this.parameters[i]) == '[object Date]') {
```
