### PR TITLE
SqlString - improved speed

### DIFF
--- a/lib/sql_string.js
+++ b/lib/sql_string.js
@@ -20,13 +20,13 @@ SqlString.escape = function(val, stringifyObjects, timeZone) {
   if (val instanceof Date) {
     val = SqlString.dateToString(val, timeZone || "Z");
   }
+  
+   if (Array.isArray(val)) {
+    return '(' + SqlString.arrayToList(val, timeZone) + ')';
+  }
 
   if (Buffer.isBuffer(val)) {
     return SqlString.bufferToString(val);
-  }
-
-  if (Array.isArray(val)) {
-    return SqlString.arrayToList(val, timeZone);
   }
 
   if (typeof val === 'object') {
@@ -52,10 +52,14 @@ SqlString.escape = function(val, stringifyObjects, timeZone) {
 };
 
 SqlString.arrayToList = function(array, timeZone) {
-  return array.map(function(v) {
-    if (Array.isArray(v)) return '(' + SqlString.arrayToList(v) + ')';
-    return SqlString.escape(v, true, timeZone);
-  }).join(', ');
+ var arrLength = array.length,
+     values = [];
+  
+  for (var i = 0; i < arrLength; i++) {
+    values.push(SqlString.escape(array[i], true, timeZone));
+  }
+  
+  return values.join(', ');
 };
 
 SqlString.format = function(sql, values, timeZone) {


### PR DESCRIPTION
Benchmarks:

**Format regular insert query**
Before: 362,899 ops/sec ±5.60% (86 runs sampled)
After: 611,534 ops/sec ±4.20% (86 runs sampled)

**Format bulk insert**
Before: 59,775 ops/sec ±6.43% (79 runs sampled)
After: 114,782 ops/sec ±5.58% (91 runs sampled)

**SqlString.arrayToList**
Before: 748,544 ops/sec ±5.95% (77 runs sampled)
After: 3,443,988 ops/sec ±5.53% (83 runs sampled)

I think that whole `SqlString` should be highly optimized. Functions are called hundreds to millions of times. It will make a big difference if you are working with a lot of data. (Many inserts etc...)