### PR TITLE
print debug information if debug flag is on

### DIFF
--- a/lib/commands/command.js
+++ b/lib/commands/command.js
@@ -7,6 +7,14 @@ function Command() {
 }
 util.inherits(Command, EventEmitter);
 
+// slow. debug only
+Command.prototype.stateName = function() {
+  var state = this.next;
+  for (i in this)
+    if (this[i] == state && i != 'next')
+      return i;
+};
+
 Command.prototype.execute = function(packet, connection) {
   // TODO: hack
   if (!this.next) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -111,7 +111,12 @@ Connection.prototype.write = function(buffer) {
 // Needs benchmark.
 Connection.prototype.writePacket = function(packet) {
   packet.writeHeader(this.sequenceId);
+  if (this.config.debug) {
+    console.log(' <== ' + this._command._commandName + '#' + this._command.stateName() + '(' + [this.sequenceId, packet._name, packet.length()].join(',') + ')');
+  }
   this.sequenceId++;
+  if (this.sequenceId == 256)
+    this.sequenceId = 0
   if (!this.config.compress || !this.authorized) {
     this.write(packet.buffer);
   } else {
@@ -258,8 +263,14 @@ Connection.prototype.pipe = function() {
 
 Connection.prototype.handlePacket = function(packet) {
   // TODO: check packet sequenceId here
+  var packetType = '';
   if (packet)
     this.sequenceId = packet.sequenceId + 1;
+  if (this.config.debug) {
+    if (packet) {
+      console.log(' ==> ' + this._command._commandName + '#' + this._command.stateName() + '(' + [packet.sequenceId, packet.type(), packet.length()].join(',') + ')');
+    }
+  }
   var done = this._command.execute(packet, this);
   if (done) {
     this.sequenceId = 0;
@@ -270,6 +281,10 @@ Connection.prototype.handlePacket = function(packet) {
 };
 
 Connection.prototype.addCommand = function(cmd) {
+  if (this.config.debug) {
+    console.log('Add command: ' + arguments.callee.caller.name);
+    cmd._commandName = arguments.callee.caller.name;
+  }
   if (!this._command) {
     this._command = cmd;
     this.handlePacket();
@@ -298,7 +313,7 @@ function _domainify(callback) {
     return callback;
 }
 
-Connection.prototype.query = function(sql, values, cb) {
+Connection.prototype.query = function query(sql, values, cb) {
   // copy-paste from node-mysql/lib/Connection.js:createQuery
   var options = {};
   if (typeof sql === 'object') {
@@ -323,7 +338,7 @@ Connection.prototype.query = function(sql, values, cb) {
   return this.addCommand(new Commands.Query(rawSql, options, _domainify(cb)));
 };
 
-Connection.prototype.execute = function(sql, values, cb) {
+Connection.prototype.execute = function execute(sql, values, cb) {
   var options = {};
   if (typeof sql === 'object') {
     // execute(options, cb)
@@ -360,15 +375,15 @@ Connection.prototype.rollback = function(cb) {
   return this.query('ROLLBACK', cb);
 }
 
-Connection.prototype.ping = function(cb) {
+Connection.prototype.ping = function ping(cb) {
   return this.addCommand(new Commands.Ping(_domainify(cb)));
 };
 
-Connection.prototype._registerSlave = function(opts, cb) {
+Connection.prototype._registerSlave = function registerSlave(opts, cb) {
   return this.addCommand(new Commands.RegisterSlave(opts, _domainify(cb)));
 };
 
-Connection.prototype._binlogDump = function(opts, cb) {
+Connection.prototype._binlogDump = function binlogDump(opts, cb) {
   return this.addCommand(new Commands.BinlogDump(opts, _domainify(cb)));
 };
 
@@ -468,7 +483,7 @@ Connection.prototype.writeError = function(args) {
   this.writePacket(Packets.Error.toPacket(args));
 };
 
-Connection.prototype.serverHandshake = function(args) {
+Connection.prototype.serverHandshake = function serverHandshake(args) {
   return this.addCommand(new Commands.ServerHandshake(args));
 };
 

--- a/lib/packets/index.js
+++ b/lib/packets/index.js
@@ -1,6 +1,17 @@
 "binlog_dump register_slave ssl_request handshake handshake_response query resultset_header column_definition text_row binary_row prepare_statement prepared_statement_header execute".split(' ').forEach(function(name) {
   var ctor = require('./' + name);
   module.exports[ctor.name] = ctor;
+  // monkey-patch it to include name if debug is on
+  if (process.env.NODE_DEBUG) {
+    if (ctor.prototype.toPacket) {
+      var old = ctor.prototype.toPacket;
+      ctor.prototype.toPacket = function() {
+        var p = old.call(this);
+        p._name = ctor.name;
+        return p;
+      }
+    }
+  }
 });
 
 // simple packets:
@@ -20,6 +31,7 @@ module.exports.OK.toPacket = function(args) {
   packet.writeLengthCodedNumber(args.affectedRows);
   if (args.insertId)
     packet.writeLengthCodedNumber(args.insertId);
+  packet._name = "OK";
   return packet;
 };
 
@@ -37,6 +49,7 @@ module.exports.EOF.toPacket = function(warnings, statusFlags) {
   packet.writeInt8(0xfe);
   packet.writeInt16(warnings);
   packet.writeInt16(statusFlags);
+  packet._name = "EOF";
   return packet;
 };
 
@@ -50,5 +63,6 @@ module.exports.Error.toPacket = function(args) {
   packet.writeInt16(args.code);
   packet.writeString('#_____');
   packet.writeString(args.message);
+  packet._name = "Error";
   return packet;
 };

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -594,4 +594,13 @@ Packet.prototype.clone = function() {
   return other;
 };
 
+Packet.prototype.type = function() {
+  if (this.isEOF())
+    return 'EOF';
+  if (this.isError())
+    return 'Error';
+  if (this.buffer[this.offset] == 0)
+    return 'maybeOK'; // could be other packet types as well
+  return '';
+};
 module.exports = Packet;


### PR DESCRIPTION
note: packet name is only set if NODE_DEBUG variable is set

would be good to benchmark if there is any visible performance impact if debug flag is _not_ on

TODO: add output format to readme
Incoming packet:
 `==> CommandName#stateName(seqNo, packetType, packetLen)`
Outgoing packet:
 `<== CommandName#stateName(seqNo, packetName, packetLen)`

(packet type in the incoming packet is because we only can reliably know from packet header if it's Error or EOF packet, other types depend on state and cannot be detected using packet content. For outgoing packet we know name )
