### PR TITLE
Add .execute() shortcut to connection pools to match Pool.query()

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -136,6 +136,22 @@ Pool.prototype.query = function (sql, values, cb) {
   });
 };
 
+Pool.prototype.execute = function (sql, values, cb) {
+  if (typeof values === 'function') {
+    cb = values;
+    values = null;
+  }
+
+  this.getConnection(function (err, conn) {
+    if (err) return cb(err);
+
+    conn.execute(sql, values, function () {
+      conn.release();
+      cb.apply(this, arguments);
+    });
+  });
+};
+
 Pool.prototype._removeConnection = function(connection) {
   var i;
 


### PR DESCRIPTION
Title basically says it all. I've taken to using connection pools in place of individual connections, and being able to call execute directly without having to request a connection first just made sense to me.
