### PR TITLE
Improve parameter handling in Server.listen.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -25,7 +25,7 @@ Server.prototype._handleConnection = function(socket) {
 };
 
 Server.prototype.listen = function(port, host, backlog, callback) {
-  this._server.listen(port, host, backlog, callback);
+  this._server.listen.apply(this._server, arguments);
 };
 
 module.exports = Server;

--- a/test/common.js
+++ b/test/common.js
@@ -105,7 +105,7 @@ module.exports.createServer = function(cb) {
     });
     //conn.on('end', );
   });
-  server.listen(3307, undefined, undefined, cb);
+  server.listen(3307, cb);
   return server;
 }
 

--- a/test/integration/connection/test-server-listen.js
+++ b/test/integration/connection/test-server-listen.js
@@ -1,0 +1,35 @@
+var assert = require('assert');
+var mysql = require('../../../index.js')
+
+// Verifies that the Server.listen can be called with any combination of
+// pararameters valid for net.Server.listen.
+
+var server = mysql.createServer();
+var serverListenCallbackFired = false;
+
+function testListen(argsDescription, listenCaller) {
+  var server = mysql.createServer();
+  var listenCallbackFired = false;
+
+  listenCaller(server, function() {
+    listenCallbackFired = true;
+  });
+  setTimeout(function() {
+    assert.ok(
+      listenCallbackFired,
+      'Callback for call with ' + argsDescription + ' did not fire');
+    server._server.close();
+  }, 100);
+}
+
+testListen('port', function(server, callback) {
+  server.listen(0, callback);
+});
+
+testListen('port, host', function(server, callback) {
+  server.listen(0, '127.0.0.1', callback);
+});
+
+testListen('port, host, backlog', function(server, callback) {
+  server.listen(0, '127.0.0.1', 50, callback);
+});


### PR DESCRIPTION
As `Server.listen` forwards all its arguments to `net.Server.listen`, it would be reasonable to expect that it behaves in the same way as `net.Server.listen`. However, due to specifics of argument forwarding, the callback does not currently fire if one calls `server.listen(port, callback)`. This change modifies the forwarding so that any combination of parameters valid for `net.server.listen` will make the callback fire.
