### PR TITLE
WIP: allow named parameters in queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,5 @@ language: node_js
 before_script:
   - mysql -e 'create database if not exists test;'
 node_js:
-  - "0.8"
   - "0.10"
   - "0.11"

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -10,6 +10,7 @@ var Commands     = require('./commands/index.js');
 var SqlString    = require('./sql_string');
 
 var _connectionId = 0;
+var convertNamedParameters;
 
 function Connection(opts)
 {
@@ -344,6 +345,7 @@ Connection.prototype.query = function query(sql, values, cb) {
 
 Connection.prototype.execute = function execute(sql, values, cb) {
   var options = {};
+  var unnamed;
   if (typeof sql === 'object') {
     // execute(options, cb)
     options = sql;
@@ -363,6 +365,14 @@ Connection.prototype.execute = function execute(sql, values, cb) {
     options.values = values;
   }
 
+  if (this.config.namedParameters) {
+    if (!convertNamedParameters)
+       convertNamedParameters =  require('named-placeholders')();
+    unnamed = convertNamedParameters(options.sql, options.values);
+    debugger;
+    options.sql = unnamed[0];
+    options.values = unnamed[1];
+  }
   return this.addCommand(new Commands.Execute(options, _domainify(cb)));
 };
 

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -25,6 +25,7 @@ function ConnectionConfig(options) {
   this.insecureAuth       = options.insecureAuth || false;
   this.supportBigNumbers  = options.supportBigNumbers || false;
   this.bigNumberStrings   = options.bigNumberStrings || false;
+  this.namedParameters    = options.namedParameters || false;
   this.dateStrings        = options.dateStrings || false;
   this.debug              = options.debug;
   this.trace              = options.trace !== false;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "bn.js": "0.11.7",
     "cardinal": "0.4.4",
-    "fastqueue": "~0.1.0"
+    "fastqueue": "~0.1.0",
+    "named-placeholders": "^0.1.1"
   },
   "devDependencies": {
     "urun": "0.0.8",

--- a/test/integration/connection/test-execute-named.js
+++ b/test/integration/connection/test-execute-named.js
@@ -1,0 +1,31 @@
+var common     = require('../../common');
+var connection = common.createConnection();
+var assert     = require('assert');
+
+connection.config.namedParameters = true;
+
+connection.query([
+  'CREATE TEMPORARY TABLE `test_table` (',
+  '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+  '`num` int(15),',
+  '`l` long,',
+  'PRIMARY KEY (`id`)',
+  ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+].join('\n'));
+
+connection.query('insert into test_table(num,l) values(?, 3)', [1]);
+connection.query('insert into test_table(num,l) values(3-?, -10)', [5]);
+connection.query('insert into test_table(num,l) values(4+?, 4000000-?)', [-5, 8000000]);
+connection.query('insert into test_table(num,l) values(?, ?)', [-5, 8000000]);
+
+connection.execute('SELECT * from test_table where num < :numParam and l > :lParam', {lParam: 100, numParam: 2}, function(err, rows, fields) {
+  if (err) throw err;
+  assert.deepEqual(rows, [ { id: 1, num: 1, l: '3' }, { id: 4, num: -5, l: '8000000' } ]);
+});
+
+connection.execute('SELECT :a + :a as sum', {a: 2}, function(err, rows, fields) {
+  if (err) throw err;
+  assert.deepEqual(rows, [{"sum":4}]);
+});
+
+connection.end();


### PR DESCRIPTION
Currently only for server-side processed parameters. Named to unnamed happens on the client if `namedParameters` flag is set to true:

```
   db.execute("select foo from bar where id > :id", { id: 123 }, callback);
   // is the same as
   db.execute("select foo from bar where id > ?", [123], callback)
```