### PR TITLE
fix header2 and header3 states lengtgh calculation

### DIFF
--- a/lib/packet_parser.js
+++ b/lib/packet_parser.js
@@ -28,7 +28,7 @@ function readPacketLength(b,off) {
 }
 
 //
-PacketParser.prototype.executeStart = function(chunk) {
+PacketParser.prototype.executeStart = function executeStart(chunk) {
   var start = 0;
   var end = chunk.length;
   // if (start-end === 0) return;
@@ -57,7 +57,7 @@ PacketParser.prototype.executeStart = function(chunk) {
   }
 }
 
-PacketParser.prototype.executePayload = function(chunk) {
+PacketParser.prototype.executePayload = function executePayload(chunk) {
   var start = 0;
   var end = chunk.length;
   var remainingPayload = this.length - this.bufferLength + 1;
@@ -83,7 +83,7 @@ PacketParser.prototype.executePayload = function(chunk) {
   }
 }
 
-PacketParser.prototype.executeHeader2 = function(chunk) {
+PacketParser.prototype.executeHeader2 = function executeHeader2(chunk) {
   this.length += chunk[0] << 8;
   if (chunk.length > 1) {
     this.length += chunk[1] << 16;
@@ -94,7 +94,7 @@ PacketParser.prototype.executeHeader2 = function(chunk) {
   }
 }
 
-PacketParser.prototype.executeHeader3 = function(chunk) {
+PacketParser.prototype.executeHeader3 = function executeHeader3(chunk) {
   this.length += chunk[0] << 16;
   this.execute = PacketParser.prototype.executePayload;
   return this.executePayload(chunk.slice(1));

--- a/lib/packet_parser.js
+++ b/lib/packet_parser.js
@@ -49,7 +49,7 @@ PacketParser.prototype.executeStart = function(chunk) {
     this.headerLen = end - start; // 1 or 2 bytes
     this.length = chunk[start];
     if (this.headerLen == 2) {
-      this.length += chunk[start] >> 8;
+      this.length = chunk[start] + (chunk[start+1] << 8);
       this.execute = PacketParser.prototype.executeHeader3;
     } else {
       this.execute = PacketParser.prototype.executeHeader2;
@@ -84,9 +84,9 @@ PacketParser.prototype.executePayload = function(chunk) {
 }
 
 PacketParser.prototype.executeHeader2 = function(chunk) {
-  this.length += chunk[0] >> 8;
+  this.length += chunk[0] << 8;
   if (chunk.length > 1) {
-    this.length += chunk[1] >> 16;
+    this.length += chunk[1] << 16;
     this.execute = PacketParser.prototype.executePayload;
     return this.executePayload(chunk.slice(2));
   } else {
@@ -95,7 +95,7 @@ PacketParser.prototype.executeHeader2 = function(chunk) {
 }
 
 PacketParser.prototype.executeHeader3 = function(chunk) {
-  this.length += chunk[0] >> 16;
+  this.length += chunk[0] << 16;
   this.execute = PacketParser.prototype.executePayload;
   return this.executePayload(chunk.slice(1));
 }

--- a/test/unit/test-packet-parser.js
+++ b/test/unit/test-packet-parser.js
@@ -1,4 +1,6 @@
 var PacketParser = require('../../lib/packet_parser.js');
+var Packet       = require('../../lib/packets/packet.js');
+
 var assert = require('assert');
 
 var pp;
@@ -8,14 +10,12 @@ function reset() {
   packets = [];
 }
 var handler = function(p) {
-  p.dump();
   packets.push(p);
 }
 
 function execute(str, verify) {
   reset();
   var buffers = str.split('|').map(function(sb) { return sb.split(',').map(Number) });
-  console.log(str);
   for(var i=0; i < buffers.length; ++i)
     pp.execute(new Buffer(buffers[i]));
   verify();
@@ -78,3 +78,50 @@ execute("5,0,0,122,1,2,3,4,5,6,0,0|123,1,2,3,4,5,6", p122_123);
 execute("5,0,0,122,1,2,3,4,5,6,0,0,123|1,2,3,4,5,6", p122_123);
 execute("5,0,0,122,1,2,3,4,5,6,0,0,123,1|2,3,4,5,6", p122_123);
 execute("5,0,0,122,1,2,3,4,5,6,0,0,123,1|2,3|4,5,6", p122_123);
+
+// test packet > 65536 lengt
+// TODO combine with "execute" function
+
+var length = 123000
+var pbuff = new Buffer(length+4);
+pbuff[4] = 123;
+pbuff[5] = 124;
+pbuff[6] = 125;
+var p = new Packet(144, pbuff, 4, pbuff.length - 4);
+p.writeHeader(42);
+
+function testBigPackets(chunks, cb) {
+  var packets = [];
+  var pp = new PacketParser(function(p) {
+    packets.push(p);
+  });
+  chunks.forEach(function(ch) {
+    pp.execute(ch);
+  });
+  cb(packets);
+}
+
+function assert2FullPackets(packets) {
+  function assertPacket(p) {
+    assert.equal(p.length(), length);
+    assert.equal(p.sequenceId, 42);
+    assert.equal(p.readInt8(), 123);
+    assert.equal(p.readInt8(), 124);
+    assert.equal(p.readInt8(), 125);
+  }
+  //assert.equal(packets[0].buffer.slice(0, 8).toString('hex'), expectation);
+  //assert.equal(packets[1].buffer.slice(0, 8).toString('hex'), expectation);
+  assert.equal(packets.length, 2);
+  assertPacket(packets[0]);
+  assertPacket(packets[1]);
+}
+
+// 2 full packets in 2 chunks
+testBigPackets( [ pbuff, pbuff ], assert2FullPackets);
+
+testBigPackets( [ pbuff.slice(0, 120000), pbuff.slice(120000, 123004), pbuff ], assert2FullPackets);
+var frameEnd = 120000
+testBigPackets( [ pbuff.slice(0, frameEnd), Buffer.concat([pbuff.slice(frameEnd, 123004), pbuff]) ], assert2FullPackets);
+for(var frameStart=1; frameStart < 100; frameStart++) {
+  testBigPackets([ Buffer.concat([pbuff, pbuff.slice(0, frameStart)]), pbuff.slice(frameStart, 123004) ], assert2FullPackets);
+}


### PR DESCRIPTION
fixed a bug where parser incorrectly handles network frame crossing first 2 or 3 bytes of mysql packet

see #113