### PR TITLE
multiple results support in prepared statements

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -1,6 +1,7 @@
 var util    = require('util');
 
 var Command  = require('./command.js');
+var Query    = require('./query.js');
 var Packets  = require('../packets/index.js');
 
 var compileParser = require('../compile_binary_parser.js');
@@ -13,112 +14,64 @@ function Execute(options, callback)
   this.onResult = callback;
   this.parameters = options.values;
 
-  this.resultFields = [];
-  this.resultFieldCount = 0;
   this.insertId = 0;
 
-  this.rows   = [];
+  this._rows   = [];
+  this._fields = [];
+  this._result = [];
+  this._fieldCount = 0;
+  this._rowParser  = null;
   this.options = options;
+  this._resultIndex = 0;
+  this._localStream = null;
+  this._streamFactory = options.infileStreamFactory;
 }
 util.inherits(Execute, Command);
 
 Execute.prototype.buildParserFromFields = function(fields, connection) {
-  var parserKey;
-  if (!this.statement.parser) {
-    // compile row parser
-    parserKey = connection.keyFromFields(fields, this.options);
-    this.statement.parser = connection.binaryProtocolParsers[parserKey];
-    if (!this.statement.parser) {
-      this.statement.parser = compileParser(fields, this.options, connection.config);
-      connection.binaryProtocolParsers[parserKey] = this.statement.parser;
-    }
+  var parserKey = connection.keyFromFields(fields, this.options);
+  var parser = connection.binaryProtocolParsers[parserKey];
+  if (!parser) {
+    parser = compileParser(fields, this.options, connection.config);
+    connection.binaryProtocolParsers[parserKey] = parser;
   }
-}
-
-function statementKey(query, options) {
-  return (typeof options.nestTables) +
-    '/' + options.nestTables + '/' + options.rowsAsHash
-        + query;
+  return parser;
 }
 
 Execute.prototype.start = function(packet, connection) {
-  var cachedStatement = connection._statements[statementKey(this.query, this.options)];
   var executePacket = new Packets.Execute(this.statement.id, this.parameters);
   connection.writePacket(executePacket.toPacket(1));
   return Execute.prototype.resultsetHeader;
 };
 
-Execute.prototype.resultsetHeader = function(packet) {
-  var self = this;
-  var header = new Packets.ResultSetHeader(packet);
-  this.resultFieldCount = header.fieldCount;
-  // we'll re-create row parser if schema reported by
-  // prepare is different from one in result set
-  if (this.statement.columns.length != this.resultFieldCount)
-    this.statement.parser = null;
-  this.insertId = header.insertId;
-  if (this.resultFieldCount === 0) {
-    if (this.onResult)
-      process.nextTick(function() {
-        self.onResult(null, header, []);
-      });
-    return null;
+Execute.prototype.done = Query.prototype.done;
+Execute.prototype.doneInsert = Query.prototype.doneInsert;
+Execute.prototype.resultsetHeader = Query.prototype.resultsetHeader;
+Execute.prototype._findOrCreateReadStream = Query.prototype._findOrCreateReadStream
+Execute.prototype._streamLocalInfile = Query.prototype._streamLocalInfile;
+Execute.prototype.row = Query.prototype.row;
+
+Execute.prototype.readField = function(packet, connection) {
+  var def, fields;
+  // perfomance optimisation: if we already have this field parsed in statement header, use one from header
+  var field = this.statement.columns.length == this._fieldCount ?
+    this.statement.columns[this._receivedFieldsCount] : new Packets.ColumnDefinition(packet);
+
+  this._receivedFieldsCount++;
+  this._fields[this._resultIndex].push(field);
+  if (this._receivedFieldsCount == this._fieldCount) {
+    fields = this._fields[this._resultIndex];
+    this.emit('fields', fields, this._resultIndex);
+    return Execute.prototype.fieldsEOF;
   }
-  return Execute.prototype.readResultField;
+  return Execute.prototype.readField;
 };
 
-Execute.prototype.readResultField = function(packet, connection) {
-  var def;
-
-  // TODO: this used to be performance optimisation (don't parse column def if we
-  // already have one in statement info, but since we can't 100% trust statement info
-  // column defs it's probably bettery to always use fields from result header.
-  // config option to ignore this?
-
-  // ignore result fields definition, we are reusing fields from prepare response
-  if (this.statement.parser)
-    this.resultFields.push(null);
-  else {
-    def = new Packets.ColumnDefinition(packet);
-    this.resultFields.push(def);
-  }
-  if (this.resultFields.length == this.resultFieldCount) {
-    return Execute.prototype.resultFieldsEOF;
-  }
-  return Execute.prototype.readResultField;
-};
-
-Execute.prototype.resultFieldsEOF = function(packet, connection) {
+Execute.prototype.fieldsEOF = function(packet, connection) {
   // check EOF
   if (!packet.isEOF())
     return connection.protocolError("Expected EOF packet");
-
-  if (!this.statement.parser)
-    this.buildParserFromFields(this.resultFields, connection)
-  return Execute.prototype.row;
-};
-
-Execute.prototype.row = function(packet, connection)
-{
-  var self = this;
-  // TODO: refactor to share code with Query::row
-  if (packet.isEOF()) {
-
-    // TODO: multiple statements
-    //packet.eofStatusFlags() & ServerStatus.SERVER_MORE_RESULTS_EXISTS;
-
-    if (this.onResult)
-      process.nextTick(function() {
-        self.onResult(null, self.rows, self.resultFields);
-      })
-    return null;
-  }
-
-  var r = new this.statement.parser(packet);
-  if (this.onResult)
-    this.rows.push(r);
-  else
-    this.emit('result', r);
+  this._rowParser = this.buildParserFromFields(this._fields[this._resultIndex], connection)
   return Execute.prototype.row;
 };
 

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -49,11 +49,11 @@ Query.prototype.done = function() {
     }
     if (fields) {
       process.nextTick(function() {
-        self.onResult(null, rows, fields);
+        self.onResult(null, rows, fields, self._resultIndex + 1);
       });
     } else {
       process.nextTick(function() {
-        self.onResult(null, rows);
+        self.onResult(null, rows, void(0), self._resultIndex + 1);
       });
     }
   }
@@ -75,7 +75,7 @@ Query.prototype.doneInsert = function(rs) {
   this.emit('fields', void(0), this._resultIndex);
   if (rs.serverStatus & ServerStatus.SERVER_MORE_RESULTS_EXISTS) {
     this._resultIndex++;
-    return Query.prototype.resultsetHeader;
+    return this.resultsetHeader;
   }
   return this.done();
 };
@@ -93,22 +93,14 @@ Query.prototype.resultsetHeader = function(packet, connection) {
     this._localStream = this._findOrCreateReadStream(rs.infileName);
     // start streaming, after last packet expect OK
     this._streamLocalInfile(connection);
-    return Query.prototype.infileOk;
+    return this.infileOk;
   }
 
   this._receivedFieldsCount = 0;
   this._rows.push([]);
   this._fields.push([]);
-  return Query.prototype.readField;
+  return this.readField;
 };
-
-// TODO: move to connection.js ?
-function getFieldsKey(fields, options) {
-  var res = (typeof options.nestTables) + '/' + options.nestTables + '/' + options.rowsAsHash;
-  for (var i=0; i < fields.length; ++i)
-    res += '/' + fields[i].name + ':' + fields[i].columnType + ':' + fields[i].flags;
-  return res;
-}
 
 // some code taken from https://github.com/felixge/node-mysql/pull/668
 Query.prototype._findOrCreateReadStream = function(path) {
@@ -167,10 +159,10 @@ Query.prototype.readField = function(packet, connection) {
   if (this._receivedFieldsCount == this._fieldCount) {
     var fields = this._fields[this._resultIndex];
     this.emit('fields', fields, this._resultIndex);
-    var parserKey = getFieldsKey(fields, this.options);
-    this.rowParser = connection.textProtocolParsers[parserKey];
-    if (!this.rowParser) {
-      this.rowParser = compileParser(fields, this.options, connection.config);
+    var parserKey = connection.keyFromFields(fields, this.options);
+    this._rowParser = connection.textProtocolParsers[parserKey];
+    if (!this._rowParser) {
+      this._rowParser = compileParser(fields, this.options, connection.config);
       connection.textProtocolParsers[parserKey] = this.rowParser;
     }
     return Query.prototype.fieldsEOF;
@@ -178,11 +170,11 @@ Query.prototype.readField = function(packet, connection) {
   return Query.prototype.readField;
 };
 
-Query.prototype.fieldsEOF = function(packet) {
+Query.prototype.fieldsEOF = function(packet, connection) {
   // check EOF
   if (!packet.isEOF())
-    throw "Expected EOF packet"; // !!!TODO don't crash if there is a protocol error
-  return Query.prototype.row;
+    return connection.protocolError("Expected EOF packet");
+  return this.row;
 };
 
 Query.prototype.row = function(packet)
@@ -197,7 +189,7 @@ Query.prototype.row = function(packet)
     return this.done();
   }
 
-  var row = new this.rowParser(packet);
+  var row = new this._rowParser(packet);
   if (this.onResult)
     this._rows[this._resultIndex].push(row);
   else

--- a/test/integration/connection/test-binary-multiple-results.js
+++ b/test/integration/connection/test-binary-multiple-results.js
@@ -1,0 +1,160 @@
+var mysql = require('../../common.js').createConnection({multipleStatements: true});
+var assert = require('assert');
+mysql.query('CREATE TEMPORARY TABLE no_rows (test int)');
+mysql.query('CREATE TEMPORARY TABLE some_rows (test int)');
+mysql.query('INSERT INTO some_rows values(0)');
+mysql.query('INSERT INTO some_rows values(42)');
+mysql.query('INSERT INTO some_rows values(314149)');
+
+var clone = function(obj) { return JSON.parse(JSON.stringify(obj)); };
+
+var rs1 = {
+  affectedRows: 0,
+  fieldCount: 0,
+  insertId: 0,
+  serverStatus: 10,
+  warningStatus: 0
+};
+var rs2 = clone(rs1);
+rs2.serverStatus = 2;
+var rs3 = clone(rs1);
+rs3.serverStatus = 34;
+
+var twoInsertResult = [[rs1, rs2], [undefined, undefined], 2];
+var select1 = [{"1":"1"}];
+var select2 = [{"2":"2"}];
+var fields1 = [{
+  catalog: "def",
+  characterSet: 63,
+  columnLength: 1,
+  columnType: 8,
+  decimals: 0,
+  flags: 129,
+  name: "1",
+  orgName: "",
+  orgTable: "",
+  schema: "",
+  table: ""
+}];
+var nr_fields = [{
+  catalog: "def",
+  characterSet: 63,
+  columnLength: 11,
+  columnType: 3,
+  decimals: 0,
+  flags: 0,
+  name: "test",
+  orgName: "test",
+  orgTable: "no_rows",
+  schema: "test",
+  table: "no_rows"
+}];
+
+var sr_fields = clone(nr_fields);
+sr_fields[0].orgTable = "some_rows";
+sr_fields[0].table = "some_rows";
+var select3 = [{"test":0},{"test":42},{"test":314149}];
+
+var fields2 = clone(fields1);
+fields2[0].name = "2";
+
+var tests = [
+  ["select * from some_rows", [[select3,rs3],[sr_fields,undefined],2]], //  select 3 rows
+  ["SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT; SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS", [rs2, undefined, 1]],
+  ["set @a = 1", [rs2, undefined, 1]],
+  ["set @a = 1; set @b = 2", [rs2, undefined, 1]],
+  ["select 1; select 2", [[select1,select2,rs2],[fields1,fields2,undefined], 3]],
+  ["set @a = 1; select 1", [[select1,rs2], [fields1,undefined], 2]],
+  ["select 1; set @a = 1", [[select1, rs2], [fields1, undefined], 2]],
+  ["select * from no_rows", [[[], rs3], [nr_fields, undefined], 2]],    // select 0 rows"
+  ["set @a = 1; select * from no_rows", [[[], rs3], [nr_fields, undefined], 2]], // insert + select 0 rows
+  ["select * from no_rows; set @a = 1", [[[], rs3], [nr_fields, undefined], 2]], //  select 0 rows + insert
+  ["set @a = 1; select * from some_rows", [[select3, rs3],[sr_fields,undefined],2]], // insert + select 3 rows
+  ["select * from some_rows; set @a = 1", [[select3, rs3],[sr_fields,undefined],2]] //  select 3 rows + insert
+];
+
+function procedurise(sql) {
+  return [
+    'DROP PROCEDURE IF EXISTS _as_sp_call;',
+    'CREATE PROCEDURE _as_sp_call()',
+    'BEGIN',
+     sql + ';',
+    'END',
+  ].join('\n');
+}
+
+function do_test(testIndex) {
+  var next = function() {
+    if (testIndex + 1 < tests.length)
+      do_test(testIndex + 1);
+    else {
+      mysql.end();
+    }
+  };
+
+  var entry = tests[testIndex];
+  var sql = entry[0];
+  var origSql = sql;
+  var expectation = entry[1];
+  // prepared statements do not support multiple statements itself, we need to wrap quey in a stored procedure
+  var sp = procedurise(sql);
+  mysql.query(sp, function(err) {
+    if (err)
+        throw(err);
+    sql = "CALL _as_sp_call()"; // this call is allowed with prepared statements, and result contain multiple statements
+    mysql.query(sql, function(err, _rows, _columns, _numResults) {
+      if (err)
+        throw err;
+
+      var arrOrColumn = function (c) {
+        if (Array.isArray(c))
+          return c.map(arrOrColumn);
+
+        if (typeof c == 'undefined')
+          return void(0);
+
+        return c.inspect();
+      };
+
+      assert.deepEqual(expectation[0], _rows);
+      assert.deepEqual(expectation[1], arrOrColumn(_columns));
+      assert.deepEqual(expectation[2], _numResults);
+
+      var q = mysql.execute(sql);
+      var resIndex = 0;
+      var rowIndex = 0;
+      function checkRow(row, index) {
+
+        if (_numResults == 1) {
+          assert.equal(index, 0);
+          if (row.constructor.name == 'ResultSetHeader')
+            assert.deepEqual(_rows, row);
+          else
+            assert.deepEqual(_rows[rowIndex], row);
+        } else {
+          if (resIndex != index) {
+            rowIndex = 0;
+            resIndex = index;
+          }
+          if (row.constructor.name == 'ResultSetHeader')
+            assert.deepEqual(_rows[index], row);
+          else
+            assert.deepEqual(_rows[index][rowIndex], row);
+        }
+        rowIndex++;
+      }
+      function checkFields(fields, index) {
+        if (_numResults == 1) {
+          assert.equal(index, 0);
+          assert.deepEqual(arrOrColumn(_columns), arrOrColumn(fields));
+        }
+        else
+          assert.deepEqual(arrOrColumn(_columns[index]), arrOrColumn(fields));
+      }
+      q.on('result', checkRow);
+      q.on('fields', checkFields);
+      q.on('end', next);
+    });
+  });
+}
+do_test(0);

--- a/test/integration/connection/test-binary-multiple-results.js
+++ b/test/integration/connection/test-binary-multiple-results.js
@@ -46,7 +46,7 @@ var nr_fields = [{
   name: "test",
   orgName: "test",
   orgTable: "no_rows",
-  schema: "test",
+  schema: mysql.config.database,
   table: "no_rows"
 }];
 


### PR DESCRIPTION
Note: prepared statements don't allow to have multiple statements, however, one statement execution can result in multiple results ( example: call to a stored procedure that contains "select1; select 2;" )

This logic ( http://dev.mysql.com/doc/internals/en/com-query-response.html ) is now implemented only in Command/Query code with Execute command states wired to corresponding Query states