### PR TITLE
Support bigNumberStrings config

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ In addition to password `createConnection()`, `createPool()` and `changeUser()` 
 
 ## Known incompatibilities with node-mysql
 
-All numeric types converted to numbers. In contrast to node-mysql `zeroFill` flag is ignored in type conversion
+In contrast to node-mysql, `zeroFill` flag is ignored in type conversion.
 You need to check corresponding field zeroFill flag and convert to string manually if this is of importance to you.
 
 DECIMAL and NEWDECIMAL types always returned as string

--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -70,7 +70,11 @@ function readCodeFor(type, charset, config) {
   case Types.INT24:
   case Types.YEAR:
   case Types.LONG:
+    return "packet.parseLengthCodedInt();";
   case Types.LONGLONG:
+    if (config.supportBigNumbers && config.bigNumberStrings) {
+      return "packet.parseLengthCodedIntString();";
+    }
     return "packet.parseLengthCodedInt();";
   case Types.FLOAT:
   case Types.DOUBLE:

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -473,6 +473,10 @@ Packet.prototype.parseLengthCodedInt = function() {
   return this.parseInt(this.readLengthCodedNumber());
 };
 
+Packet.prototype.parseLengthCodedIntString = function() {
+  return this.readString(this.readLengthCodedNumber());
+};
+
 Packet.prototype.parseLengthCodedFloat = function() {
   return this.parseFloat(this.readLengthCodedNumber());
 };

--- a/test/common.js
+++ b/test/common.js
@@ -59,6 +59,8 @@ module.exports.createConnection = function(args, callback) {
     multipleStatements: args ? args.multipleStatements : false,
     port: (args && args.port) || config.port,
     debug: process.env.DEBUG,
+    supportBigNumbers: args && args.supportBigNumbers,
+    bigNumberStrings: args && args.bigNumberStrings,
     dateStrings: args && args.dateStrings
   });
 };

--- a/test/integration/connection/test-insert-bigint-big-number-strings.js
+++ b/test/integration/connection/test-insert-bigint-big-number-strings.js
@@ -1,9 +1,7 @@
 var common     = require('../../common');
-var connection = common.createConnection();
+var connection = common.createConnection({ supportBigNumbers: true, bigNumberStrings: true });
 var assert     = require('assert');
-var bn         = require('bn.js');
 
-var table = 'insert_test';
 connection.query([
   'CREATE TEMPORARY TABLE `bigs` (',
   '`id` bigint NOT NULL AUTO_INCREMENT,',
@@ -12,7 +10,6 @@ connection.query([
   ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
 ].join('\n'));
 
-var result, result2;
 connection.query("INSERT INTO bigs SET title='test', id=123");
 connection.query("INSERT INTO bigs SET title='test1'", function(err, result) {
   if (err) throw err;
@@ -24,16 +21,16 @@ connection.query("INSERT INTO bigs SET title='test1'", function(err, result) {
     // big int
     connection.query("INSERT INTO bigs SET title='test', id=9007199254740992");
     connection.query("INSERT INTO bigs SET title='test3'", function(err, result) {
-      assert.strictEqual((new bn("9007199254740993")).cmp(result.insertId), 0);
+      assert.strictEqual(result.insertId, "9007199254740993");
       connection.query("INSERT INTO bigs SET title='test', id=90071992547409924");
       connection.query("INSERT INTO bigs SET title='test4'", function(err, result) {
-        assert.strictEqual((new bn("90071992547409925")).cmp(result.insertId), 0);
+        assert.strictEqual(result.insertId, "90071992547409925");
         connection.query("select * from bigs", function(err, result) {
-          assert.strictEqual(result[0].id, 123);
-          assert.strictEqual(result[1].id, 124);
-          assert.strictEqual(result[2].id, 123456789);
-          assert.strictEqual(result[3].id, 123456790);
-          assert.strictEqual(result[4].id, 9007199254740992);
+          assert.strictEqual(result[0].id, "123");
+          assert.strictEqual(result[1].id, "124");
+          assert.strictEqual(result[2].id, "123456789");
+          assert.strictEqual(result[3].id, "123456790");
+          assert.strictEqual(result[4].id, "9007199254740992");
           assert.strictEqual(result[5].id, "9007199254740993");
           assert.strictEqual(result[6].id, "90071992547409924");
           assert.strictEqual(result[7].id, "90071992547409925");


### PR DESCRIPTION
Adds support for the `bigNumberStrings` config option which fixes an incompatibility issue with node-mysql.

Previously, numbers <=2<sup>53</sup> were being returned as numbers for columns of type `BIGINT` even when `bigNumberStrings` was set to `true`. This PR aligns the node-mysql2 API with that of node-mysql so that `BIGINT` column values are always returned as strings when the `supportBigNumbers` and `bigNumberStrings` config options are `true`.