### PR TITLE
Add .escapeId() to Connection and Pool

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -341,6 +341,10 @@ Connection.prototype.escape = function(value) {
   return SqlString.escape(value, false, this.config.timezone);
 };
 
+Connection.prototype.escapeId = function escapeId(value) {
+  return SqlString.escapeId(value, false);
+};
+
 function _domainify(callback) {
   var domain = process.domain;
   if (domain && callback)

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -174,3 +174,7 @@ Pool.prototype._removeConnection = function(connection) {
 Pool.prototype.escape = function(value) {
   return mysql.escape(value, this.config.connectionConfig.stringifyObjects, this.config.connectionConfig.timezone);
 };
+
+Pool.prototype.escapeId = function escapeId(value) {
+  return mysql.escapeId(value, false);
+};


### PR DESCRIPTION
This fixes an incompatibility with **node-mysql** since this is in the documentation [here](https://github.com/felixge/node-mysql#escaping-query-values) and [here](https://github.com/felixge/node-mysql#escaping-query-identifiers).