### PR TITLE
Emit enqueue event if conn is queued (closes #177)

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -63,6 +63,7 @@ Pool.prototype.getConnection = function (cb) {
     return cb(new Error('Queue limit reached.'));
   }
 
+  this.emit('enqueue');
   this._connectionQueue.push(cb);
 };
 


### PR DESCRIPTION
One liner to fix incompatibility noted in #177.