### PR TITLE
Make SSL ciphers configurable

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -179,7 +179,8 @@ Connection.prototype.startTLS = function(onSecure) {
     key: config.ssl.key,
     cert: config.ssl.cert,
     passphrase: config.ssl.passphrase,
-    ca: config.ssl.ca
+    ca: config.ssl.ca,
+    ciphers: config.ssl.ciphers
   });
   var securePair = tls.createSecurePair(credentials, false);
   if (stream.ondata)


### PR DESCRIPTION
On the Debian production environment which I am using some combination of OpenSSL and MySQL updates caused connecting via SSL to become impossible, error yilded was

> Error: 139693901379552:error:14082174:SSL routines:SSL3_CHECK_CERT_AND_ALGORITHM:dh key too small:s3_clnt.c:3331:

I figured out that this is likely related to [this](https://bugzilla.redhat.com/show_bug.cgi?id=1228755).

For us to be able to get connecting to the MySQL database working again on our current production setup we needed to control what SSL cipher was being used. (Especially we wanted a cipher which didn't use the *Diffie Hellman protocol*)

This change makes possible to tell which ciphers to use when connecting with SSL. Not sure if this is something you'd like to have, or is this properly prepared for merging, but here it is - just in case. 

(I'm surprised that no-one else hasn't bumped into this problem)