### PR TITLE
Fix node-mysql compatibility

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -53,11 +53,11 @@ Query.prototype.done = function() {
     }
     if (fields) {
       process.nextTick(function() {
-        self.onResult(null, rows, fields, self._resultIndex + 1);
+        self.onResult(null, rows, fields);
       });
     } else {
       process.nextTick(function() {
-        self.onResult(null, rows, void(0), self._resultIndex + 1);
+        self.onResult(null, rows);
       });
     }
   }
@@ -75,8 +75,8 @@ Query.prototype.doneInsert = function(rs) {
   }
   this._rows.push(rs);
   this._fields.push(void(0));
-  this.emit('result', rs, this._resultIndex);
-  this.emit('fields', void(0), this._resultIndex);
+  this.emit('result', rs);
+  this.emit('fields', void(0));
   if (rs.serverStatus & ServerStatus.SERVER_MORE_RESULTS_EXISTS) {
     this._resultIndex++;
     return this.resultsetHeader;
@@ -162,7 +162,7 @@ Query.prototype.readField = function(packet, connection) {
   // last field received
   if (this._receivedFieldsCount == this._fieldCount) {
     var fields = this._fields[this._resultIndex];
-    this.emit('fields', fields, this._resultIndex);
+    this.emit('fields', fields);
     var parserKey = connection.keyFromFields(fields, this.options);
     this._rowParser = connection.textProtocolParsers[parserKey];
     if (!this._rowParser) {
@@ -197,7 +197,7 @@ Query.prototype.row = function(packet)
   if (this.onResult)
     this._rows[this._resultIndex].push(row);
   else
-    this.emit('result', row, this._resultIndex);
+    this.emit('result', row);
 
   return Query.prototype.row;
 };
@@ -219,9 +219,9 @@ Query.prototype.stream = function(options) {
     self._connection && self._connection.resume();
   };
 
-  this.on('result',function(row,i) {
+  this.on('result',function(row) {
     if (!stream.push(row)) self._connection.pause();
-    stream.emit('result',row,i);  // replicate old emitter
+    stream.emit('result',row);  // replicate old emitter
   });
 
   this.on('error',function(err) {
@@ -233,8 +233,8 @@ Query.prototype.stream = function(options) {
     stream.push(null);  // pushing null, indicating EOF
   });
 
-  this.on('fields',function(fields,i) {
-    stream.emit('fields',fields,i);  // replicate old emitter
+  this.on('fields',function(fields) {
+    stream.emit('fields',fields);  // replicate old emitter
   });
 
   return stream;


### PR DESCRIPTION
This fixes issues when this module is used in conjunction with modules that check `arguments.length` of the callbacks, like the `async` module's `waterfall()`.

Ref #45 and #46