### PR TITLE
Allow to use pool.query(opts, cb) similar to conn.query()

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -10,12 +10,11 @@ var ServerStatus = require('../constants/server_status.js');
 
 var EmptyPacket = new Packets.Packet(0, new Buffer(4), 0, 4);
 
-function Query(sql, options, callback)
+function Query(options, callback)
 {
   Command.call(this);
-  this.query = sql;
-  // node-mysql compatibility: query.sql as alias to query.query #121
-  this.sql = this.query;
+  this.sql = options.sql;
+  this.values = options.values;
   this.options = options;
   this.onResult = callback;
   this._fieldCount = 0;
@@ -32,10 +31,10 @@ util.inherits(Query, Command);
 
 Query.prototype.start = function(packet, connection) {
   if (connection.config.debug) {
-    console.log('        Sending query command: %s', this.query);
+    console.log('        Sending query command: %s', this.sql);
   }
   this._connection = connection;
-  var cmdPacket = new Packets.Query(this.query);
+  var cmdPacket = new Packets.Query(this.sql);
   connection.writePacket(cmdPacket.toPacket(1));
   return Query.prototype.resultsetHeader;
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -407,15 +407,15 @@ Connection.prototype._resolveNamedPlaceholders = function(options) {
   }
 };
 
-Connection.prototype.query = function query(sql, values, cb) {
-  // copy-paste from node-mysql/lib/Connection.js:createQuery
+Connection.createQuery = function createQuery(sql, values, cb) {
+  debugger;
   var options = {};
   if (typeof sql === 'object') {
     // query(options, cb)
     options = sql;
     if (typeof values === 'function') {
       cb = values;
-    } else {
+    } else if (values !== undefined) {
       options.values = values;
     }
   } else if (typeof values === 'function') {
@@ -428,10 +428,21 @@ Connection.prototype.query = function query(sql, values, cb) {
     options.sql    = sql;
     options.values = values;
   }
+  return new Commands.Query(options, _domainify(cb));
+}
 
-  this._resolveNamedPlaceholders(options);
-  var rawSql = this.format(options.sql, options.values || []);
-  return this.addCommand(new Commands.Query(rawSql, options, _domainify(cb)));
+Connection.prototype.query = function query(sql, values, cb) {
+  var cmdQuery;
+  if (sql.constructor == Commands.Query) {
+    cmdQuery = sql;
+  } else {
+    cmdQuery = Connection.createQuery(sql, values, cb);
+  }
+  debugger;
+  this._resolveNamedPlaceholders(cmdQuery);
+  var rawSql = this.format(cmdQuery.sql, cmdQuery.values || []);
+  cmdQuery.sql = rawSql;
+  return this.addCommand(cmdQuery);
 };
 
 Connection.prototype.pause = function pause() {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -408,7 +408,6 @@ Connection.prototype._resolveNamedPlaceholders = function(options) {
 };
 
 Connection.createQuery = function createQuery(sql, values, cb) {
-  debugger;
   var options = {};
   if (typeof sql === 'object') {
     // query(options, cb)
@@ -438,7 +437,6 @@ Connection.prototype.query = function query(sql, values, cb) {
   } else {
     cmdQuery = Connection.createQuery(sql, values, cb);
   }
-  debugger;
   this._resolveNamedPlaceholders(cmdQuery);
   var rawSql = this.format(cmdQuery.sql, cmdQuery.values || []);
   cmdQuery.sql = rawSql;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,9 +1,10 @@
-var mysql        = require('../index.js');
+var mysql          = require('../index.js');
 
 var EventEmitter   = require('events').EventEmitter;
 var Util           = require('util');
 var PoolConnection = require('./pool_connection.js');
 var Queue          = require('double-ended-queue');
+var Connection     = require('./connection.js');
 
 module.exports = Pool;
 
@@ -122,19 +123,20 @@ Pool.prototype.end = function (cb) {
 };
 
 Pool.prototype.query = function (sql, values, cb) {
-  if (typeof values === 'function') {
-    cb = values;
-    values = null;
-  }
-
+  var cmdQuery = Connection.createQuery(sql, values);
   this.getConnection(function (err, conn) {
     if (err) return cb(err);
 
-    conn.query(sql, values, function () {
+    conn._resolveNamedPlaceholders(cmdQuery);
+    var rawSql = conn.format(cmdQuery.sql, cmdQuery.values || []);
+    cmdQuery.sql = rawSql;
+
+    conn.query(cmdQuery, function () {
       conn.release();
       cb.apply(this, arguments);
     });
   });
+  return cmdQuery;
 };
 
 Pool.prototype.execute = function (sql, values, cb) {

--- a/test/integration/connection/test-named-paceholders.js
+++ b/test/integration/connection/test-named-paceholders.js
@@ -35,7 +35,7 @@ var qCmd = connection.query('SELECT * from test_table where num1 < :numParam and
   assert.deepEqual(rows, [ { id: 4, num1: -5, num2: 8000000 } ]);
 });
 assert.equal(qCmd.sql, 'SELECT * from test_table where num1 < 2 and num2 > 100');
-assert.equal(typeof qCmd.values, 'undefined');
+assert.deepEqual(qCmd.values, [2, 100]);
 
 connection.query('SELECT :a + :a as sum', {a: 2}, function(err, rows, fields) {
   if (err) throw err;


### PR DESCRIPTION
Refactored code to use connection.createQuery from both connection.query and pool.query

Also pool.query now returns query command object, so should be possible to chain events:

```js
pool.query({ sql: 'select 1 + ?', values: [1] }).on('end', function() { console.log('done') });
```

see #216 for example code

need to add pool tests before merging this