### PR TITLE
Use rowsAsArray instead rowsAsHash for statementKey and keyFromFields Evaluation

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -461,7 +461,7 @@ Connection.prototype.resume= function resume() {
 };
 
 Connection.prototype.keyFromFields = function keyFromFields(fields, options) {
-  var res = (typeof options.nestTables) + '/' + options.nestTables + '/' + options.rowsAsHash;
+  var res = (typeof options.nestTables) + '/' + options.nestTables + '/' + options.rowsAsArray;
   for (var i=0; i < fields.length; ++i)
     res += '/' + fields[i].name + ':' + fields[i].columnType + ':' + fields[i].flags;
   return res;
@@ -469,7 +469,7 @@ Connection.prototype.keyFromFields = function keyFromFields(fields, options) {
 
 function statementKey(options) {
   return (typeof options.nestTables) +
-    '/' + options.nestTables + '/' + options.rowsAsHash + options.sql;
+    '/' + options.nestTables + '/' + options.rowsAsArray + options.sql;
 }
 
 // TODO: named placeholders support


### PR DESCRIPTION
As I mentioned in #245, non-existent options field `rowsAsHash` was used for key evaluation for statement and fields.

This actually fixes some weird behavior when same prepared statement executed with `rowsAsArray` option variable set to `true` lead to mixed results, when sometime you've got rows as array, and other times – as `BinaryRow` objects, e.g.:

```js
var files = pool.executeAsync({
          sql: `SELECT id FROM ... `,
          rowsAsArray: true
        }, [id]);
```
produces mixed results when executed multiple times using pool of connections (console.log output on query result):
```
row [ [ 22500 ] ]
row [ BinaryRow { id: 1000307 } ]
row [ BinaryRow { id: 1000307 } ]
row [ [ 22500 ] ]
row [ [ 22500 ] ]
row [ [ 1000307 ] ]
row [ [ 1000302 ] ]
row [ [ 1000270 ] ]
row []
row [ BinaryRow { id: 1000274 } ]
row [ [ 1000274 ] ]
row [ BinaryRow { id: 1000274 } ]
row [ [ 1000270 ] ]
row [ [ 1000267 ] ]
```

Bug was initially observed on Node v 5.3.0.

It fixes #245.