### PR TITLE
added server example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Every command packet received by the server will be emitted as a **packet** even
 
 In addition special events are emitted for [commands](https://dev.mysql.com/doc/internals/en/text-protocol.html) received from the client. If no listener is present a fallback behavior will be invoked.
 
-  *  **quit** - Default: close the connection
+  *  **quit**() - Default: close the connection
   *  **init_db**(schemaName: string) - Default: return OK
   *  **query**(sql: string) - Please attach a listener to this. Default: return HA_ERR_INTERNAL_ERROR
   *  **field_list**(table: string, fields: string) - Default: return ER_WARN_DEPRECATED_SYNTAX
@@ -322,8 +322,9 @@ In addition special events are emitted for [commands](https://dev.mysql.com/doc/
 
   - [Mysql-pg-proxy](https://github.com/sidorares/mysql-pg-proxy)  - mysql to postgres proxy server.
   - [Mysqlite.js](https://github.com/sidorares/mysqlite.js) - mysql server with JS-only (emscripten compiled) sqlite backend.
-  - [sql-engine](https://github.com/eugeneware/sql-engine) - mysql server with leveldb backend.
-  - [mysql-osquery-proxy](https://github.com/sidorares/mysql-osquery-proxy) - connect to [facebook osquery](https://osquery.io/) using mysql client
+  - [sql-engine](https://github.com/eugeneware/sql-engine) - mysql server with LevelDB backend.
+  - [mysql-osquery-proxy](https://github.com/sidorares/mysql-osquery-proxy) - connect to [facebook osquery](https://osquery.io/) using MySQL client
+  - [PlyQL](https://github.com/implydata/plyql) - connect to [Druid](http://druid.io/) using MySQL client 
 
 ## See also:
 


### PR DESCRIPTION
Hi @sidorares,
Wanted to share what I am using mysql2 for. Also I just published a [blog post](http://imply.io/post/2016/05/04/programmatic-plyql.html) about it.

Basically for a while now I have been developing [Plywood](http://plywood.imply.io/) which is an OLAP focused query planner. It provides a query layer to make it convenient to write [interactive applications](https://github.com/implydata/pivot/). While Plywood can and will eventually support many backends, currently it supports MySQL, Druid, and native JS.

[PlyQL](http://plywood.imply.io/plyql) is a MySQL compatible(ish) language that gets translated into Plywood. Recently I integrated mysql2 into [plyql](https://github.com/implydata/plyql), a command line tool, that effectively provides a SQL interface to Druid - Druid does not speak SQL natively.

plyql goes far to support all sorts of metadata queries that typical ODBC and JDBC drivers make, you know stuff like [this](https://github.com/implydata/plyql/blob/master/test/mysql-gateway.mocha.js#L84), [this](https://github.com/implydata/plyql/blob/master/test/mysql-gateway.mocha.js#L96), and [this](https://github.com/implydata/plywood/blob/master/test/parser/plyqlParser.mocha.js#L1363). I plan to continue developing plyql (and mysql2) to a point where most read-only operations in most MySQL clients will be supported.