### PR TITLE
Use SQL_MODE=ALLOW_INVALID_DATES to test invalid timestamp in MySQL 5.7

### DIFF
--- a/test/integration/connection/test-timestamp.js
+++ b/test/integration/connection/test-timestamp.js
@@ -2,6 +2,7 @@ var common     = require('../../common');
 var connection = common.createConnection();
 var assert     = require('assert');
 
+connection.query('SET SQL_MODE="ALLOW_INVALID_DATES";');
 connection.query('CREATE TEMPORARY TABLE t (f TIMESTAMP)');
 connection.query('INSERT INTO t VALUES(\'0000-00-00 00:00:00\')');
 connection.query('INSERT INTO t VALUES(\'2013-01-22 01:02:03\')');


### PR DESCRIPTION
http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_allow_invalid_dates