### PR TITLE
Update travis to stop sending email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ matrix:
         - addons:
              mariadb: 10.1
           node_js: '5.4'
+
+notifications:
+    email: false


### PR DESCRIPTION
Travis CI is bombing me (and everyone else) with email notifications. I personally prefer to track Travis build status via the travis-ci.org and the badge thats part of the README.md already.

This setting (https://docs.travis-ci.com/user/notifications/#Email-notifications) disables email notifications.