### PR TITLE
Add functionality to auto-expire pool connections

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -29,8 +29,13 @@ Pool.prototype.getConnection = function (cb) {
 
   var connection;
 
-  if (this._freeConnections.length > 0) {
+  while (this._freeConnections.length > 0) {
     connection = this._freeConnections.shift();
+
+    if (connection._expires && connection._expires < Date.now()) {
+      connection.destroy();
+      continue;
+    }
 
     return process.nextTick(function () {
       return cb(null, connection);
@@ -39,6 +44,10 @@ Pool.prototype.getConnection = function (cb) {
 
   if (this.config.connectionLimit === 0 || this._allConnections.length < this.config.connectionLimit) {
     connection = new PoolConnection(this, {config: this.config.connectionConfig});
+
+    if (this.config.connectionExpiry) {
+      connection._expires = Date.now() + this.config.connectionExpiry;
+    }
 
     this._allConnections.push(connection);
 
@@ -79,6 +88,8 @@ Pool.prototype.releaseConnection = function (connection) {
 
       process.nextTick(this.getConnection.bind(this, cb));
     }
+  } else if (connection._expires && connection._expires < Date.now()) {
+    connection.destroy();
   } else if (this._connectionQueue.length) {
     cb = this._connectionQueue.shift();
 

--- a/lib/pool_connection.js
+++ b/lib/pool_connection.js
@@ -9,6 +9,7 @@ inherits(PoolConnection, Connection);
 function PoolConnection (pool, options) {
   Connection.call(this, options);
   this._pool = pool;
+  this._expires = false;
 
   // When a fatal error occurs the connection's protocol ends, which will cause
   // the connection to end as well, thus we only need to watch for the end event


### PR DESCRIPTION
Any connection older than `connectionExpiry` will be terminated upon release or when next reached in the queue.

I've now run up against an issue in two different companies where long living mysql connections have a chance to become stale, and upon doing so end up triggering an error the next time a query tries to run on them.  In both cases we've resolved this by forcing the pool to close every 15 minutes, or by regularly pinging open connections to make sure they haven't gone bad.  It would be more ideal if the pool just supported killing off a connection after a certain length of time.
