### PR TITLE
Fix a bug that caused dead connections to remain in a connection pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -187,11 +187,11 @@ Pool.prototype.escapeId = function escapeId (value) {
 function spliceConnection (queue, connection) {
   var len = queue.length;
   if (len) {
-    if (queue[len - 1] === connection) {
+    if (queue.get(len - 1) === connection) {
       queue.pop();
     } else {
       for (; --len;) {
-        if (queue[0] === connection) {
+        if (queue.get(0) === connection) {
           queue.shift();
           break;
         }


### PR DESCRIPTION
According to [the docs](https://github.com/petkaantonov/deque#getint-index---dynamic) for Dequeue, accessing the indexes directly is incorrect (and will produce inconsistent results). I replaced the indexers with calls to the `get()` method. This fixes the bug I reported in #325.