### PR TITLE
Replace bn.js with Long

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -1,7 +1,7 @@
 // var BigNumber = require("bignumber.js");
 var ErrorCodeToName = require('../constants/errors.js');
 
-var bn = require('bn.js');
+var Long = require('long');
 
 function Packet (id, buffer, start, end)
 {
@@ -106,15 +106,19 @@ Packet.prototype.eofWarningCount = function () {
   return this.buffer.readInt16LE(this.offset + 1);
 };
 
-Packet.prototype.readLengthCodedNumber = function (bigNumberStrings) {
+Packet.prototype.readLengthCodedNumber = function (bigNumberStrings, signed) {
   var byte1 = this.buffer[this.offset++];
   if (byte1 < 251) {
     return byte1;
   }
-  return this.readLengthCodedNumberExt(byte1, bigNumberStrings);
+  return this.readLengthCodedNumberExt(byte1, bigNumberStrings, signed);
 };
 
-Packet.prototype.readLengthCodedNumberExt = function (tag, bigNumberStrings) {
+Packet.prototype.readLengthCodedNumberSigned = function (bigNumberStrings) {
+  return this.readLengthCodedNumber(bigNumberStrings, true);
+};
+
+Packet.prototype.readLengthCodedNumberExt = function (tag, bigNumberStrings, signed) {
   var word0, word1;
   var res;
   if (tag == 0xfb) {
@@ -142,7 +146,7 @@ Packet.prototype.readLengthCodedNumberExt = function (tag, bigNumberStrings) {
       return word1 * 0x100000000 + word0;
     }
 
-    res = (new bn(word1)).ishln(32).iaddn(word0);
+    res = new Long(word0, word1, signed);
 
     return bigNumberStrings ? res.toString() : res;
   }

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -9,7 +9,7 @@ function ResultSetHeader (packet, bigNumberStrings)
   } else {
     this.fieldCount = packet.readInt8(); // skip OK byte
     this.affectedRows = packet.readLengthCodedNumber(bigNumberStrings);
-    this.insertId = packet.readLengthCodedNumber(bigNumberStrings);
+    this.insertId = packet.readLengthCodedNumberSigned(bigNumberStrings);
     this.serverStatus = packet.readInt16();
     this.warningStatus = packet.readInt16();
   }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "author": "Andrey Sidorov <sidorares@yandex.ru>",
   "license": "MIT",
   "dependencies": {
-    "bn.js": "4.11.4",
     "cardinal": "0.7.0",
     "double-ended-queue": "2.1.0-0",
+    "long": "^3.1.0",
     "named-placeholders": "1.1.1",
     "readable-stream": "2.1.4",
     "seq-queue": "0.0.5",
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",
-    "eslint": "^3.0.0",
+    "eslint": "2.13.1",
     "portfinder": "^1.0.3",
     "progress": "1.1.8",
     "urun": "0.0.8",

--- a/test/integration/connection/test-insert-bigint.js
+++ b/test/integration/connection/test-insert-bigint.js
@@ -1,7 +1,7 @@
 var common = require('../../common');
 var connection = common.createConnection();
 var assert = require('assert');
-var bn = require('bn.js');
+var Long = require('long');
 
 var table = 'insert_test';
 connection.query([
@@ -26,10 +26,10 @@ connection.query('INSERT INTO bigs SET title=\'test1\'', function (err, result) 
     // big int
     connection.query('INSERT INTO bigs SET title=\'test\', id=9007199254740992');
     connection.query('INSERT INTO bigs SET title=\'test3\'', function (err, result) {
-      assert.strictEqual((new bn('9007199254740993')).cmp(result.insertId), 0);
+      assert.strictEqual((Long.fromString('9007199254740993')).compare(result.insertId), 0);
       connection.query('INSERT INTO bigs SET title=\'test\', id=90071992547409924');
       connection.query('INSERT INTO bigs SET title=\'test4\'', function (err, result) {
-        assert.strictEqual((new bn('90071992547409925')).cmp(result.insertId), 0);
+        assert.strictEqual((Long.fromString('90071992547409925')).compare(result.insertId), 0);
         connection.query('select * from bigs', function (err, result) {
           assert.strictEqual(result[0].id, 123);
           assert.strictEqual(result[1].id, 124);

--- a/test/integration/connection/test-insert-negative-ai.js
+++ b/test/integration/connection/test-insert-negative-ai.js
@@ -1,0 +1,35 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+// common.useTestDb(connection);
+
+var table = 'insert_negative_ai_test';
+var text = ' test test test ';
+connection.query([
+  'CREATE TEMPORARY TABLE `' + table + '` (',
+  '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+  '`title` varchar(255),',
+  'PRIMARY KEY (`id`)',
+  ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+].join('\n'));
+
+var result, result2;
+connection.query('INSERT INTO ' + table + ' (id, title) values (-999, "' + text + '")', function (err, _result) {
+  if (err) {
+    throw err;
+  }
+  result = _result;
+  connection.query('SELECT * FROM ' + table + ' WHERE id = ' + result.insertId, function (err, _result2) {
+    result2 = _result2;
+    connection.end();
+  });
+});
+
+process.on('exit', function () {
+  assert.strictEqual(result.insertId, 1);
+  assert.strictEqual(result2.length, 1);
+  // TODO: type conversions
+  assert.equal(result2[0].id, String(result.insertId));
+  assert.equal(result2[0].title, text);
+});


### PR DESCRIPTION
For issue #336. Not sure if this was the intended change, but tests continue to pass (though lint fails on 0.10 and 0.12 for some reason?!).