### PR TITLE
Failing test for geometry typeCast issue

### DIFF
--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -21,8 +21,8 @@ function compile (fields, options, config) {
       table: field.table,
       name: field.name,
       string: function() { return packet.readLengthCodedString(); },
-      buffer: function () { return this.parser.parseLengthCodedBuffer(); },
-      geometry: function () { return this.parser.parseGeometryValue(); }
+      buffer: function () { return packet.parseLengthCodedBuffer(); },
+      geometry: function () { return packet.parseGeometryValue(); }
     };
   };
 

--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -21,7 +21,7 @@ function compile (fields, options, config) {
       table: field.table,
       name: field.name,
       string: function() { return packet.readLengthCodedString(); },
-      buffer: function () { return packet.parseLengthCodedBuffer(); },
+      buffer: function () { return packet.readLengthCodedBuffer(); },
       geometry: function () { return packet.parseGeometryValue(); }
     };
   };

--- a/test/integration/connection/test-typecast-geometry.js
+++ b/test/integration/connection/test-typecast-geometry.js
@@ -15,4 +15,17 @@ connection.query({
   assert.deepEqual(res[0].foo, { x: 11, y: 0 });
 });
 
+connection.query({
+  sql: 'select GeomFromText(\'POINT(11 0)\') as foo',
+  typeCast: function (field, next) {
+    if (field.type === 'GEOMETRY') {
+      return field.buffer();
+    }
+    return next();
+  }
+}, function(err, res) {
+  assert.ifError(err);
+  assert.equal(Buffer.isBuffer(res[0].foo), true);
+});
+
 connection.end();

--- a/test/integration/connection/test-typecast-geometry.js
+++ b/test/integration/connection/test-typecast-geometry.js
@@ -5,23 +5,14 @@ var assert = require('assert');
 connection.query({
   sql: 'select GeomFromText(\'POINT(11 0)\') as foo',
   typeCast: function (field, next) {
-    if (field.type == 'GEOMETRY') {
+    if (field.type === 'GEOMETRY') {
       return field.geometry();
     }
     return next();
   }
 }, function(err, res) {
   assert.ifError(err);
-  assert(Buffer.isBuffer(res[0].foo));
-});
-
-
-connection.query({
-  sql: 'select GeomFromText(\'POINT(11 0)\') as foo',
-  typeCast: false
-}, function(err, res) {
-  assert.ifError(err);
-  assert(Buffer.isBuffer(res[0].foo));
+  assert.deepEqual(res[0].foo, { x: 11, y: 0 });
 });
 
 connection.end();

--- a/test/integration/connection/test-typecast-geometry.js
+++ b/test/integration/connection/test-typecast-geometry.js
@@ -1,0 +1,27 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+connection.query({
+  sql: 'select GeomFromText(\'POINT(11 0)\') as foo',
+  typeCast: function (field, next) {
+    if (field.type == 'GEOMETRY') {
+      return field.geometry();
+    }
+    return next();
+  }
+}, function(err, res) {
+  assert.ifError(err);
+  assert(Buffer.isBuffer(res[0].foo));
+});
+
+
+connection.query({
+  sql: 'select GeomFromText(\'POINT(11 0)\') as foo',
+  typeCast: false
+}, function(err, res) {
+  assert.ifError(err);
+  assert(Buffer.isBuffer(res[0].foo));
+});
+
+connection.end();


### PR DESCRIPTION
`Work in Progress + Test Case`

While parsing the Geometry values using the `typeCast` some odd error occurs.

```js
> node ./test/run.js && MYSQL_USE_COMPRESSION=1 node ./test/run.js

[0:00:00 0 0/1 0.0% node test/integration/connection/test-typecast-geometry.js]
  
  evalmachine.<anonymous>:11
        geometry: function () { return this.parser.parseGeometryValue(); }
                                                  ^
  
  TypeError: Cannot read property 'parseGeometryValue' of undefined
      at Object.geometry (evalmachine.<anonymous>:11:49)
      at Object.connection.query.typeCast (/var/www/node-mysql2/test/integration/connection/test-typecast-geometry.js:9:20)
      at new TextRow (evalmachine.<anonymous>:15:25)
      at Query.row (/var/www/node-mysql2/lib/commands/query.js:197:13)
      at Query.Command.execute (/var/www/node-mysql2/lib/commands/command.js:38:20)
      at Connection.handlePacket (/var/www/node-mysql2/lib/connection.js:263:28)
      at PacketParser.onPacket (/var/www/node-mysql2/lib/connection.js:95:66)
      at PacketParser.executeStart (/var/www/node-mysql2/lib/packet_parser.js:44:12)
      at Socket.<anonymous> (/var/www/node-mysql2/lib/connection.js:97:29)
      at emitOne (events.js:96:13)
  
[0:00:00 1 0/1 100.0% node test/integration/connection/test-typecast-geometry.js]
```

As per my understandings, this error occurs when we try to call `field.value(), field.buffer(), field.geometry()` more than one time. But as you can see in test case I have called `field.geometry()` exactly one time.

This issue doesn't appear with other datatypes afaik.