### PR TITLE
Add some parameter type checking for prepared statements

### DIFF
--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -99,8 +99,13 @@ Execute.prototype.toPacket = function ()
         case 'object':
           if (this.parameters instanceof Date) {
             packet.writeInt16(Types.DATETIME);
+          } else if (
+            Array.isArray(this.parameter[i]) ||
+            this.parameters[i].constructor === Object ||
+            typeof this.parameters[i].toJSON === 'function'
+          ) {
+            packet.writeInt16(Types.JSON);
           } else {
-            // packet.writeInt16(Types.JSON); - Requires MySQL 5.7+
             packet.writeInt16(Types.VAR_STRING);
           }
           break;

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -88,11 +88,7 @@ Execute.prototype.toPacket = function ()
       if (this.parameters[i] !== null) {
         switch (typeof this.parameters[i]) {
         case 'number':
-          if (this.parameters[i] === parseInt(this.parameters[i], 10)) {
-            packet.writeInt16(Types.INT24);
-          } else {
-            packet.writeInt16(Types.DECIMAL);
-          }
+          packet.writeInt16(Types.NEWDECIMAL);
           break;
 
         case 'boolean':

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -100,7 +100,7 @@ Execute.prototype.toPacket = function ()
           if (this.parameters instanceof Date) {
             packet.writeInt16(Types.DATETIME);
           } else if (
-            Array.isArray(this.parameter[i]) ||
+            Array.isArray(this.parameters[i]) ||
             this.parameters[i].constructor === Object ||
             typeof this.parameters[i].toJSON === 'function'
           ) {

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -82,11 +82,32 @@ Execute.prototype.toPacket = function ()
     // if not, previous execution types are used (TODO prooflink)
     packet.writeInt8(1); // new-params-bound-flag
 
-    // TODO: don't typecast always to sting, use parameters type
+    // TODO: verify/modify parameter types
     for (i = 0; i < this.parameters.length; i++)
     {
       if (this.parameters[i] !== null) {
-        packet.writeInt16(Types.VAR_STRING);
+        switch (typeof this.parameters[i]) {
+        case 'number':
+          packet.writeInt16(Types.DECIMAL);
+          break;
+
+        case 'boolean':
+          this.parameters[i] = +this.parameters[i];
+          packet.writeInt16(Types.TINY);
+          break;
+
+        case 'object':
+          if (this.parameters instanceof Date) {
+            packet.writeInt16(Types.DATETIME);
+          } else {
+            // packet.writeInt16(Types.JSON); - Requires MySQL 5.7+
+            packet.writeInt16(Types.VAR_STRING);
+          }
+          break;
+
+        default:
+          packet.writeInt16(Types.VAR_STRING);
+        }
       } else {
         packet.writeInt16(Types.NULL);
       }

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -88,7 +88,11 @@ Execute.prototype.toPacket = function ()
       if (this.parameters[i] !== null) {
         switch (typeof this.parameters[i]) {
         case 'number':
-          packet.writeInt16(Types.DECIMAL);
+          if (this.parameters[i] === parseInt(this.parameters[i], 10)) {
+            packet.writeInt16(Types.INT24);
+          } else {
+            packet.writeInt16(Types.DECIMAL);
+          }
           break;
 
         case 'boolean':


### PR DESCRIPTION
Whenever I use anything besides `Types.DECIMAL` for number type, I get `Error: Incorrect arguments to mysqld_stmt_execute`.

Related to: #348
