### PR TITLE
Catching errors in once crashes process

### DIFF
--- a/lib/commands/client_handshake.js
+++ b/lib/commands/client_handshake.js
@@ -68,10 +68,10 @@ ClientHandshake.prototype.calculateNativePasswordAuthToken = function (authPlugi
 ClientHandshake.prototype.handshakeInit = function (helloPacket, connection) {
   var command = this;
 
-  this.on('error', function (err) {
-    connection._protocolError = err;
-    connection.emit('error', err);
+  this.on('error', function (e) {
+    connection._protocolError = e;
   });
+
   this.handshake = Packets.Handshake.fromPacket(helloPacket);
   if (connection.config.debug) {
     console.log('Server hello packet: capability flags:%d=(%s)', this.handshake.capabilityFlags,

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -103,19 +103,17 @@ function Connection (opts)
       return;
     }
 
-    // TODO: move to protocolError()
     if (!connection._protocolError) { // no particular error message before disconnect
-      connection._protocolError = 'PROTOCOL_CONNECTION_LOST';
+      connection._protocolError = new Error('Connection lost: The server closed the connection.');
+      connection._protocolError.fatal = true;
+      connection._protocolError.code = 'PROTOCOL_CONNECTION_LOST';
     }
-    var err = new Error('Connection lost: The server closed the connection.');
-    err.fatal = true;
-    err.code = connection._protocolError;
-    connection._notifyError(err);
+
+    connection._notifyError(connection._protocolError);
   });
   var handshakeCommand;
   if (!this.config.isServer) {
     handshakeCommand = new Commands.ClientHandshake(this.config.clientFlags);
-    handshakeCommand.on('error', function (e) { connection.emit('error', e); });
     handshakeCommand.on('end', function () {
       connection._handshakePacket = handshakeCommand.handshake;
       connection.threadId = handshakeCommand.handshake.connectionId;

--- a/test/integration/connection/test-error-events.js
+++ b/test/integration/connection/test-error-events.js
@@ -1,26 +1,33 @@
 var common = require('../../common');
 var assert = require('assert');
 
+var callCount = 0;
+var exceptionCount = 0;
+
 process.on('uncaughtException', function (err) {
   assert.ifError(err);
+  exceptionCount++;
 });
 
 var connection1 = common.createConnection({
-  username: 'wtf',
   password: 'lol'
 });
 
 // error will NOT bubble up to process level if `on` is used
-connection1.on('error', function (err) {
-  assert.ok(err);
+connection1.on('error', function () {
+  callCount++;
 });
 
 var connection2 = common.createConnection({
-  username: 'wtf',
   password: 'lol'
 });
 
 // error will bubble up to process level if `once` is used
-connection2.once('error', function (err) {
-  assert.ok(err);
+connection2.once('error', function () {
+  callCount++;
+});
+
+process.on('exit', function () {
+  assert.equal(callCount, 2);
+  assert.equal(exceptionCount, 0);
 });

--- a/test/integration/connection/test-invalid-credentials.js
+++ b/test/integration/connection/test-invalid-credentials.js
@@ -1,0 +1,26 @@
+var common = require('../../common');
+var assert = require('assert');
+
+process.on('uncaughtException', function (err) {
+  assert.ifError(err);
+});
+
+var connection1 = common.createConnection({
+  username: 'wtf',
+  password: 'lol'
+});
+
+// error will NOT bubble up to process level if `on` is used
+connection1.on('error', function (err) {
+  assert.ok(err);
+});
+
+var connection2 = common.createConnection({
+  username: 'wtf',
+  password: 'lol'
+});
+
+// error will bubble up to process level if `once` is used
+connection2.once('error', function (err) {
+  assert.ok(err);
+});


### PR DESCRIPTION
This will NOT crash the process
```js
var connection = mysql2.createConnection({ invalid credentials });
connection.on('error', handler);
```

But this will
```js
var connection = mysql2.createConnection({ invalid credentials });
connection.once('error', handler);
```

When error are handled in `once` they still bubble up to process level.

**Fixes**

- Handling errors in either `on` or `once` work now
- No multiple error events if handshake resulted in error

Closes #355 