### PR TITLE
64 bit long fixes

### DIFF
--- a/lib/compile_binary_parser.js
+++ b/lib/compile_binary_parser.js
@@ -72,7 +72,7 @@ function compile (fields, options, config) {
     result.push('  if (nullBitmaskByte' + nullByteIndex + ' & ' + currentFieldNullBit + ')');
     result.push('  ' + lvalue + ' = null;');
     result.push('  else');
-    result.push('  ' + lvalue + ' = ' + readCodeFor(fields[i], config));
+    result.push('  ' + lvalue + ' = ' + readCodeFor(fields[i], config, options));
     // }
     currentFieldNullBit *= 2;
     if (currentFieldNullBit == 0x100) {
@@ -95,7 +95,10 @@ function compile (fields, options, config) {
   return vm.runInThisContext(src);
 }
 
-function readCodeFor (field, config) {
+function readCodeFor (field, config, options) {
+  var supportBigNumbers = options.supportBigNumbers || config.supportBigNumbers;
+  var bigNumberStrings = options.bigNumberStrings || config.bigNumberStrings;
+
   var unsigned = field.flags & FieldFlags.UNSIGNED;
   switch (field.columnType) {
   case Types.TINY:
@@ -133,8 +136,16 @@ function readCodeFor (field, config) {
     return 'packet.parseGeometryValue();';
   case Types.JSON:
     return 'JSON.parse(packet.readLengthCodedString());';
-  case Types.LONGLONG: // TODO: 8 bytes. Implement as two 4 bytes read for now (it's out of JavaScript int precision!)
-    return unsigned ? 'packet.readInt64();' : 'packet.readSInt64();';
+  case Types.LONGLONG:
+    if (!supportBigNumbers) {
+      return unsigned ? 'packet.readInt64JSNumber();' : 'packet.readSInt64JSNumber();';
+    } else {
+      if (bigNumberStrings) {
+        return unsigned ? 'packet.readInt64String();' : 'packet.readSInt64String();';
+      } else {
+        return unsigned ? 'packet.readInt64();' : 'packet.readSInt64();';
+      }
+    }
   default:
     if (field.characterSet == Charsets.BINARY) {
       return 'packet.readLengthCodedBuffer();';

--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -73,7 +73,7 @@ function compile (fields, options, config) {
     } else {
       lvalue = '  this[' + srcEscape(fields[i].name) + ']';
     }
-    var readCode = readCodeFor(fields[i].columnType, fields[i].characterSet, config);
+    var readCode = readCodeFor(fields[i].columnType, fields[i].characterSet, config, options);
     if (typeof options.typeCast === 'function') {
       result.push(lvalue + ' = options.typeCast(wrap(fields[' + i + '], ' + srcEscape(typeNames[fields[i].columnType]) + ', packet), function() { return ' + readCode + ';})');
     } else if (options.typeCast === false) {
@@ -98,19 +98,22 @@ function compile (fields, options, config) {
   return vm.runInThisContext(src);
 }
 
-function readCodeFor (type, charset, config) {
+function readCodeFor (type, charset, config, options) {
+  var supportBigNumbers = options.supportBigNumbers || config.supportBigNumbers;
+  var bigNumberStrings = options.bigNumberStrings || config.bigNumberStrings;
+
   switch (type) {
   case Types.TINY:
   case Types.SHORT:
   case Types.LONG:
   case Types.INT24:
   case Types.YEAR:
-    return 'packet.parseLengthCodedInt()';
+    return 'packet.parseLengthCodedIntNoBigCheck()';
   case Types.LONGLONG:
-    if (config.supportBigNumbers && config.bigNumberStrings) {
+    if (supportBigNumbers && bigNumberStrings) {
       return 'packet.parseLengthCodedIntString()';
     }
-    return 'packet.parseLengthCodedInt()';
+    return 'packet.parseLengthCodedInt(' + supportBigNumbers + ')';
   case Types.FLOAT:
   case Types.DOUBLE:
     return 'packet.parseLengthCodedFloat()';

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -382,7 +382,8 @@ Connection.prototype.resume = function resume () {
 };
 
 Connection.prototype.keyFromFields = function keyFromFields (fields, options) {
-  var res = (typeof options.nestTables) + '/' + options.nestTables + '/' + options.rowsAsArray;
+  var res = (typeof options.nestTables) + '/' + options.nestTables + '/' + options.rowsAsArray +
+    + options.supportBigNumbers + '/' + options.bigNumberStrings;
   for (var i = 0; i < fields.length; ++i) {
     res += '/' + fields[i].name + ':' + fields[i].columnType + ':' + fields[i].flags;
   }

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -374,16 +374,20 @@ Packet.prototype.readString = function (len) {
   return this.buffer.utf8Slice(this.offset - len, this.offset);
 };
 
-var minus = '-'.charCodeAt(0);
-var plus = '+'.charCodeAt(0);
-
 // The whole reason parse* function below exist
-// is because String creation is relatively expensive, and if we have
+// is because String creation is relatively expensive (at least with V8), and if we have
 // a buffer with "12345" content ideally we would like to bypass intermediate
 // "12345" string creation and directly build 12345 number out of
 // <Buffer 31 32 33 34 35> data.
-// In my benchmarks "parse" methods
+// In my benchmarks the difference is ~25M 8-digit numbers per second vs
+// 4.5 M using Number(packet.readLengthCodedString())
+// not used when size is close to max precision as series of *10 accumulate error
+// and approximate result mihgt be diffreent from (approximate as well) Number(bigNumStringValue))
+// In the futire node version if speed difference is smaller parse* functions might be removed
+// don't consider them as Packet public API
 
+var minus = '-'.charCodeAt(0);
+var plus = '+'.charCodeAt(0);
 
 Packet.prototype.parseInt = function (len, supportBigNumbers) {
 
@@ -475,7 +479,7 @@ Packet.prototype.parseIntNoBigCheck = function (len) {
     result += this.buffer[this.offset] - 48;
     this.offset++;
   }
-  return result * sign;
+  return  result * sign;
 };
 
 // copy-paste from https://github.com/felixge/node-mysql/blob/master/lib/protocol/Parser.js

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -479,7 +479,7 @@ Packet.prototype.parseIntNoBigCheck = function (len) {
     result += this.buffer[this.offset] - 48;
     this.offset++;
   }
-  return  result * sign;
+  return result * sign;
 };
 
 // copy-paste from https://github.com/felixge/node-mysql/blob/master/lib/protocol/Parser.js

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -81,17 +81,63 @@ Packet.prototype.readSInt32 = function ()
   return this.buffer.readInt32LE(this.offset - 4, true);
 };
 
-Packet.prototype.readInt64 = function () {
-  return this.readInt32() + 0x100000000 * this.readInt32();
+Packet.prototype.readInt64JSNumber = function () {
+  var word0 = this.readInt32();
+  var word1 = this.readInt32();
+  var l = new Long(word0, word1, true);
+  return l.toNumber();
 };
 
-Packet.prototype.readSInt64 = function () {
+Packet.prototype.readSInt64JSNumber = function () {
   var word0 = this.readInt32();
   var word1 = this.readInt32();
   if (!(word1 & 0x80000000)) {
     return word0 + 0x100000000 * word1;
   }
-  return -((((~word1) >>> 0) * 0x100000000) + ((~word0) >>> 0) + 1);
+  var l = new Long(word0, word1, false);
+  return l.toNumber();
+};
+
+Packet.prototype.readInt64String = function () {
+  var word0 = this.readInt32();
+  var word1 = this.readInt32();
+  var res = new Long(word0, word1, true);
+  return res.toString();
+};
+
+Packet.prototype.readSInt64String = function () {
+  var word0 = this.readInt32();
+  var word1 = this.readInt32();
+  var res = new Long(word0, word1, false);
+  return res.toString();
+};
+
+Packet.prototype.readInt64 = function () {
+  var word0 = this.readInt32();
+  var word1 = this.readInt32();
+  var res = new Long(word0, word1, true);
+  var resNumber = res.toNumber()
+    , resString = res.toString();
+
+  res = resNumber.toString() === resString
+          ? resNumber
+          : resString;
+
+  return res;
+};
+
+Packet.prototype.readSInt64 = function () {
+  var word0 = this.readInt32();
+  var word1 = this.readInt32();
+  var res = new Long(word0, word1, false);
+  var resNumber = res.toNumber()
+    , resString = res.toString();
+
+  res = resNumber.toString() === resString
+          ? resNumber
+          : resString;
+
+  return res;
 };
 
 Packet.prototype.isEOF = function () {
@@ -330,15 +376,29 @@ Packet.prototype.readString = function (len) {
 
 var minus = '-'.charCodeAt(0);
 var plus = '+'.charCodeAt(0);
-// TODO: faster versions of parseInt for smaller types?
-// discard overflow checks if we know from type definition it's safe so
-Packet.prototype.parseInt = function (len) {
+
+// The whole reason parse* function below exist
+// is because String creation is relatively expensive, and if we have
+// a buffer with "12345" content ideally we would like to bypass intermediate
+// "12345" string creation and directly build 12345 number out of
+// <Buffer 31 32 33 34 35> data.
+// In my benchmarks "parse" methods
+
+
+Packet.prototype.parseInt = function (len, supportBigNumbers) {
 
   if (len === null) {
     return null;
   }
 
+  if (len >= 14 && !supportBigNumbers) {
+    var s = this.buffer.toString('ascii', this.offset, this.offset + len);
+    this.offset += len;
+    return Number(s);
+  }
+
   var result = 0;
+  var start = this.offset;
   var end = this.offset + len;
   var sign = 1;
   if (len === 0) {
@@ -351,23 +411,62 @@ Packet.prototype.parseInt = function (len) {
   }
 
   // max precise int is 9007199254740992
-  // note that we are here after handling optional +/-
-  // treat everything above 9000000000000000 as potential overflow
   var str;
   var numDigits = end - this.offset;
-  if (numDigits == 16 && (this.buffer[this.offset] - 48) > 8) {
-    str = this.readString(end - this.offset);
-    result = parseInt(str, 10);
-    if (result.toString() == str) {
-      return sign * result;
-    } else {
+  if (supportBigNumbers) {
+    if (numDigits >= 15) {
+      str = this.readString(end - this.offset);
+      result = parseInt(str, 10);
+      if (result.toString() == str) {
+        return sign * result;
+      } else {
+        return sign == -1 ? '-' + str : str;
+      }
+    } else if (numDigits > 16) {
+      str = this.readString(end - this.offset);
       return sign == -1 ? '-' + str : str;
     }
-  } else if (numDigits > 16) {
-    str = this.readString(end - this.offset);
-    return sign == -1 ? '-' + str : str;
   }
 
+  if (this.buffer[this.offset] == plus) {
+    this.offset++; // just ignore
+  }
+  while (this.offset < end) {
+    result *= 10;
+    result += this.buffer[this.offset] - 48;
+    this.offset++;
+  }
+  var num = result * sign;
+  if (!supportBigNumbers) {
+    return num;
+  }
+  str = this.buffer.toString('ascii', start, end);
+  if (num.toString() == str) {
+    return num;
+  } else {
+    return str;
+  }
+};
+
+// note that if value of inputNumberAsString is bigger than MAX_SAFE_INTEGER
+// ( or smaller than MIN_SAFE_INTEGER ) the parseIntNoBigCheck result might be
+// different from what you would get from Number(inputNumberAsString)
+// String(parseIntNoBigCheck) <> String(Number(inputNumberAsString)) <> inputNumberAsString
+Packet.prototype.parseIntNoBigCheck = function (len) {
+  if (len === null) {
+    return null;
+  }
+  var result = 0;
+  var end = this.offset + len;
+  var sign = 1;
+  if (len === 0) {
+    return 0; // TODO: assert? exception?
+  }
+
+  if (this.buffer[this.offset] == minus) {
+    this.offset++;
+    sign = -1;
+  }
   if (this.buffer[this.offset] == plus) {
     this.offset++; // just ignore
   }
@@ -515,8 +614,12 @@ Packet.prototype.parseFloat = function (len) {
   return result / factor;
 };
 
-Packet.prototype.parseLengthCodedInt = function () {
-  return this.parseInt(this.readLengthCodedNumber());
+Packet.prototype.parseLengthCodedIntNoBigCheck = function () {
+  return this.parseIntNoBigCheck(this.readLengthCodedNumber());
+};
+
+Packet.prototype.parseLengthCodedInt = function (supportBigNumbers) {
+  return this.parseInt(this.readLengthCodedNumber(), supportBigNumbers);
 };
 
 Packet.prototype.parseLengthCodedIntString = function () {

--- a/test/integration/connection/test-binary-longlong.js
+++ b/test/integration/connection/test-binary-longlong.js
@@ -1,0 +1,107 @@
+var assert = require('assert');
+
+var FieldFlags = require('../../../lib/constants/field_flags.js');
+//var common = require('../../common');
+var mysql = require('../../../index.js')
+//var conn = common.createConnection();
+var conn = mysql.createConnection({
+  password: 'mycause',
+  user: 'mycause_dev',
+  //supportBigNumbers: true,
+  //bigNumberStrings: true,
+  database: 'test',
+  //debug: 1
+});
+
+conn.query('CREATE TEMPORARY TABLE `tmp_longlong` ( ' +
+  ' `id` int(11) NOT NULL AUTO_INCREMENT, ' +
+  ' `ls` BIGINT SIGNED NOT NULL, ' +
+  ' `lu` BIGINT UNSIGNED NOT NULL, ' +
+  ' PRIMARY KEY (`id`) ' +
+  ' ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8');
+
+var values = [
+  ['10', '10'],
+  ['-11', '11'],
+  ['965432100123456789', '1965432100123456789'],
+  ['-965432100123456789', '2965432100123456789']
+];
+
+conn.connect(function (err) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+
+  for (var i=0; i < values.length; ++i) {
+    conn.query("INSERT INTO `tmp_longlong` VALUES (?, ?, ?)", [i+1, values[i][0], values[i][1]]);
+  }
+
+  var bigNums_bnStringsFalse = [
+    { id: 1, ls: 10, lu: 10 },
+    { id: 2, ls: -11, lu: 11 },
+    { id: 3, ls: 965432100123456800, lu: 1965432100123456800 },
+    { id: 4, ls: -965432100123456800, lu: 2965432100123457000 }
+  ];
+
+  var bigNums_bnStringsTrueFalse = [
+    { id: 1, ls: 10, lu: 10 },
+    { id: 2, ls: -11, lu: 11 },
+    { id: 3, ls: '965432100123456789', lu: '1965432100123456789' },
+    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' }
+  ];
+
+  var bigNums_bnStringsTrueTrue = [
+    { id: 1, ls: 10, lu: 10 },
+    { id: 2, ls: -11, lu: 11 },
+    { id: 3, ls: '965432100123456789', lu: '1965432100123456789' },
+    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' }
+  ]
+
+  function check() {
+    completed++;
+    if (completed === started)
+      conn.end();
+  }
+
+  var completed = 0;
+  var started = 0;
+
+  function testQuery(supportBigNumbers, bigNumberStrings, expectation) {
+    started++;
+    conn.query({
+      sql: 'SELECT * from tmp_longlong',
+      supportBigNumbers: supportBigNumbers,
+      bigNumberStrings: bigNumberStrings
+    }, function (err, rows, fields) {
+      assert.ifError(err);
+      assert.deepEqual(rows, expectation);
+      completed++;
+      if (completed === started)
+        conn.end();
+    });
+  }
+
+  function testExecute(supportBigNumbers, bigNumberStrings, expectation) {
+    started++;
+    conn.execute({
+      sql: 'SELECT * from tmp_longlong',
+      supportBigNumbers: supportBigNumbers,
+      bigNumberStrings: bigNumberStrings
+    }, function (err, rows, fields) {
+      assert.ifError(err);
+      assert.deepEqual(rows, expectation);
+      completed++;
+      if (completed === started)
+        conn.end();
+    });
+  }
+
+  testQuery(false, false, bigNums_bnStringsFalse);
+  testQuery(true, false, bigNums_bnStringsTrueFalse);
+  testQuery(true, true, bigNums_bnStringsTrueTrue);
+
+  testExecute(false, false, bigNums_bnStringsFalse);
+  testExecute(true, false, bigNums_bnStringsTrueFalse);
+  testExecute(true, true, bigNums_bnStringsTrueTrue);
+});

--- a/test/integration/connection/test-binary-longlong.js
+++ b/test/integration/connection/test-binary-longlong.js
@@ -1,17 +1,8 @@
 var assert = require('assert');
 
 var FieldFlags = require('../../../lib/constants/field_flags.js');
-//var common = require('../../common');
-var mysql = require('../../../index.js')
-//var conn = common.createConnection();
-var conn = mysql.createConnection({
-  password: 'mycause',
-  user: 'mycause_dev',
-  //supportBigNumbers: true,
-  //bigNumberStrings: true,
-  database: 'test',
-  //debug: 1
-});
+var common = require('../../common');
+var conn = common.createConnection();
 
 conn.query('CREATE TEMPORARY TABLE `tmp_longlong` ( ' +
   ' `id` int(11) NOT NULL AUTO_INCREMENT, ' +

--- a/test/integration/connection/test-insert-bigint.js
+++ b/test/integration/connection/test-insert-bigint.js
@@ -30,7 +30,11 @@ connection.query('INSERT INTO bigs SET title=\'test1\'', function (err, result) 
       connection.query('INSERT INTO bigs SET title=\'test\', id=90071992547409924');
       connection.query('INSERT INTO bigs SET title=\'test4\'', function (err, result) {
         assert.strictEqual((Long.fromString('90071992547409925')).compare(result.insertId), 0);
-        connection.query('select * from bigs', function (err, result) {
+        connection.query({
+          sql: 'select * from bigs',
+          supportBigNumbers: true,
+          bigNumberString: false,
+        }, function (err, result) {
           assert.strictEqual(result[0].id, 123);
           assert.strictEqual(result[1].id, 124);
           assert.strictEqual(result[2].id, 123456789);


### PR DESCRIPTION
-  use supportBigNumbers and bigNumberStrings flags in parser
-  pass supportBigNumbers and bigNumberStrings from `query({sql, ...opts})` and `execute({sql, ...opts})` type of calls
-  use supportBigNumbers and bigNumberStrings as part of parser key
- binary protocol: use long.js to calculate resulting number from two 32 byte valuse
- text protocol: fix in detecting potentially big number. Split parseLong* into functions with and without big number checks, use no check version if type is < long