### PR TITLE
Fix pool namedplaceholders on execute

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -145,11 +145,6 @@ Pool.prototype.query = function (sql, values, cb) {
 };
 
 Pool.prototype.execute = function (sql, values, cb) {
-  if (typeof values === 'function') {
-    cb = values;
-    values = null;
-  }
-
   var useNamedPlaceholders = this.config.connectionConfig.namedPlaceholders;
 
   this.getConnection(function (err, conn) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -126,7 +126,7 @@ Pool.prototype.end = function (cb) {
 
 Pool.prototype.query = function (sql, values, cb) {
   var cmdQuery = Connection.createQuery(sql, values, cb, this.config.connectionConfig);
-  cmdQuery.namedPlaceholders = this.config.namedPlaceholders;
+  cmdQuery.namedPlaceholders = this.config.connectionConfig.namedPlaceholders;
 
   this.getConnection(function (err, conn) {
     if (err) {
@@ -150,7 +150,7 @@ Pool.prototype.execute = function (sql, values, cb) {
     values = null;
   }
 
-  var useNamedPlaceholders = this.config.namedPlaceholders;
+  var useNamedPlaceholders = this.config.connectionConfig.namedPlaceholders;
 
   this.getConnection(function (err, conn) {
     if (err) {

--- a/test/integration/connection/test-named-paceholders.js
+++ b/test/integration/connection/test-named-paceholders.js
@@ -56,7 +56,7 @@ assert.equal(sql, 'SELECT * from test_table where num1 < 2 and num2 > 100');
 connection.end();
 
 var pool = common.createPool();
-pool.config.namedPlaceholders = true;
+pool.config.connectionConfig.namedPlaceholders = true;
 pool.query('SELECT :a + :a as sum', {a: 2}, function (err, rows, fields) {
   pool.end();
   if (err) {


### PR DESCRIPTION
Fix for issue #315 

`this.config` on a pool does not contain the namedPlaceholders option, it now lives inside `this.config.connectionConfig`. Thus, namedPlaceholders was always being set to undefined.

I also removed the argument swapping in Pool.execute. This conversion occurs inside connection.execute and does not need to be performed at the pool level. Doing it there actually breaks passing an options object instead of a query.