### PR TITLE
pool connection time error is not propagated correctly to users and as a result process crashes

### DIFF
--- a/lib/commands/client_handshake.js
+++ b/lib/commands/client_handshake.js
@@ -75,6 +75,7 @@ ClientHandshake.prototype.handshakeInit = function (helloPacket, connection) {
   var command = this;
 
   this.on('error', function (e) {
+    connection._fatalError = e;
     connection._protocolError = e;
   });
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -108,6 +108,9 @@ function Connection (opts)
       connection.threadId = handshakeCommand.handshake.connectionId;
       connection.emit('connect', handshakeCommand.handshake);
     });
+    handshakeCommand.on('error', function(err) {
+      connection._notifyError(err);
+    });
     this.addCommand(handshakeCommand);
   }
 }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -130,9 +130,10 @@ Pool.prototype.query = function (sql, values, cb) {
 
   this.getConnection(function (err, conn) {
     if (err) {
-      cmdQuery.emit('error', err);
       if (typeof cmdQuery.onResult === 'function') {
         cmdQuery.onResult(err);
+      } else {
+        cmdQuery.emit('error', err);
       }
       return;
     }

--- a/lib/pool_connection.js
+++ b/lib/pool_connection.js
@@ -13,8 +13,13 @@ function PoolConnection (pool, options) {
   // When a fatal error occurs the connection's protocol ends, which will cause
   // the connection to end as well, thus we only need to watch for the end event
   // and we will be notified of disconnects.
-  this.on('end', this._removeFromPool);
-  this.on('error', this._removeFromPool);
+  var connection = this;
+  this.on('end', function(err) {
+    this._removeFromPool();
+  });
+  this.on('error', function(err) {
+    this._removeFromPool();
+  });
 }
 
 PoolConnection.prototype.release = function () {
@@ -38,11 +43,11 @@ PoolConnection.prototype.end = function () {
 };
 
 PoolConnection.prototype.destroy = function () {
-  this._removeFromPool(this);
+  this._removeFromPool();
   return Connection.prototype.destroy.apply(this, arguments);
 };
 
-PoolConnection.prototype._removeFromPool = function (connection) {
+PoolConnection.prototype._removeFromPool = function () {
   if (!this._pool || this._pool._closed) {
     return;
   }

--- a/test/integration/test-pool-connect-error.js
+++ b/test/integration/test-pool-connect-error.js
@@ -32,7 +32,7 @@ portfinder.getPort(function (err, port) {
     port: port
   });
   conn.on('error', function (err) {
-    err1 = err
+    err1 = err;
   });
 
   var pool = mysql.createPool({
@@ -44,6 +44,8 @@ portfinder.getPort(function (err, port) {
 
   pool.query('test sql', function (err, res, rows) {
     err2 = err;
+    pool.end();
+    server.close();
   });
 
 });

--- a/test/integration/test-pool-connect-error.js
+++ b/test/integration/test-pool-connect-error.js
@@ -1,0 +1,54 @@
+var util = require('util');
+var mysql = require('../../index.js');
+var Command = require('../../lib/commands/command.js');
+var Packets = require('../../lib/packets/index.js');
+
+var assert = require('assert');
+
+var server = mysql.createServer(function (conn) {
+  conn.serverHandshake({
+    protocolVersion: 10,
+    serverVersion: '5.6.10', //'node.js rocks',
+    connectionId: 1234,
+    statusFlags: 2,
+    characterSet: 8,
+    capabilityFlags: 0xffffff,
+    authCallback: function(params, cb) {
+      cb(null, { message: 'too many connections', code: 1040});
+    }
+  });
+});
+
+var err1, err2;
+
+var portfinder = require('portfinder');
+portfinder.getPort(function (err, port) {
+
+  server.listen(port);
+  var conn = mysql.createConnection({
+    user: 'test_user',
+    password: 'test',
+    database: 'test_database',
+    port: port
+  });
+  conn.on('error', function (err) {
+    err1 = err
+  });
+
+  var pool = mysql.createPool({
+    user: 'test_user',
+    password: 'test',
+    database: 'test_database',
+    port: port
+  });
+
+  pool.query('test sql', function (err, res, rows) {
+    err2 = err;
+  });
+
+});
+
+process.on('exit', function() {
+  assert.equal(err1.errno, 1040);
+  assert.equal(err2.errno, 1040);
+});

--- a/test/integration/test-pool-connect-error.js
+++ b/test/integration/test-pool-connect-error.js
@@ -8,13 +8,13 @@ var assert = require('assert');
 var server = mysql.createServer(function (conn) {
   conn.serverHandshake({
     protocolVersion: 10,
-    serverVersion: '5.6.10', //'node.js rocks',
+    serverVersion: '5.6.10',
     connectionId: 1234,
     statusFlags: 2,
     characterSet: 8,
     capabilityFlags: 0xffffff,
-    authCallback: function(params, cb) {
-      cb(null, { message: 'too many connections', code: 1040});
+    authCallback: function (params, cb) {
+      cb(null, {message: 'too many connections', code: 1040});
     }
   });
 });
@@ -50,7 +50,7 @@ portfinder.getPort(function (err, port) {
 
 });
 
-process.on('exit', function() {
+process.on('exit', function () {
   assert.equal(err1.errno, 1040);
   assert.equal(err2.errno, 1040);
 });


### PR DESCRIPTION
see test

might be a side effect of #356,  CCing @sushantdhiman

during `pool.query` or `pool.getConnection` if connection is created (e.i not reused) this part of code is executed: https://github.com/sidorares/node-mysql2/blob/26748034feef277d56f5d97907c4790591f307ec/lib/pool.js#L46

but for some reason, if there is connect time error (bad password or 'too many connections' error from ClientHandshake command is not returned - "error" is emitted on ClientHandshake and there is no error listener there, thus crashing process 

see also:
commands error handling: https://github.com/sidorares/node-mysql2/blob/26748034feef277d56f5d97907c4790591f307ec/lib/commands/command.js#L29-L33
Initial ClientHandshake command: https://github.com/sidorares/node-mysql2/blob/master/lib/connection.js#L105-L110

I think previously for commands with no error handler (and no onResult callback) error would be routed to connection