### PR TITLE
Save correctly compiled parser for re-use

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -22,7 +22,7 @@ function Execute (options, callback)
   this._result = [];
   this._fieldCount = 0;
   this._rowParser = null;
-  this.options = options;
+  this._executeOptions = options;
   this._resultIndex = 0;
   this._localStream = null;
   this._streamFactory = options.infileStreamFactory;
@@ -40,6 +40,7 @@ Execute.prototype.buildParserFromFields = function (fields, connection) {
 };
 
 Execute.prototype.start = function (packet, connection) {
+  this.options = Object.assign({}, connection.config, this._executeOptions);
   var executePacket = new Packets.Execute(this.statement.id, this.parameters, connection.config.charsetNumber);
   connection.writePacket(executePacket.toPacket(1));
   return Execute.prototype.resultsetHeader;

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -4,6 +4,8 @@ var Command = require('./command.js');
 var Query = require('./query.js');
 var Packets = require('../packets/index.js');
 
+var objectAssign = require('object-assign');
+
 var compileParser = require('../compile_binary_parser.js');
 
 function Execute (options, callback)
@@ -40,7 +42,7 @@ Execute.prototype.buildParserFromFields = function (fields, connection) {
 };
 
 Execute.prototype.start = function (packet, connection) {
-  this.options = Object.assign({}, connection.config, this._executeOptions);
+  this.options = objectAssign({}, connection.config, this._executeOptions);
   var executePacket = new Packets.Execute(this.statement.id, this.parameters, connection.config.charsetNumber);
   connection.writePacket(executePacket.toPacket(1));
   return Execute.prototype.resultsetHeader;

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -8,6 +8,7 @@ var Command = require('./command.js');
 var Packets = require('../packets/index.js');
 var compileParser = require('../compile_text_parser.js');
 var ServerStatus = require('../constants/server_status.js');
+var CharsetToEncoding = require('../constants/charset_encodings.js');
 
 var EmptyPacket = new Packets.Packet(0, Buffer.allocUnsafe(4), 0, 4);
 
@@ -16,7 +17,7 @@ function Query (options, callback)
   Command.call(this);
   this.sql = options.sql;
   this.values = options.values;
-  this.options = options;
+  this._queryOptions = options;
   this.onResult = callback;
   this._fieldCount = 0;
   this._rowParser = null;
@@ -35,6 +36,7 @@ Query.prototype.start = function (packet, connection) {
     console.log('        Sending query command: %s', this.sql);
   }
   this._connection = connection;
+  this.options = Object.assign({}, connection.config, this._queryOptions);
   var cmdPacket = new Packets.Query(this.sql, connection.config.charsetNumber);
   connection.writePacket(cmdPacket.toPacket(1));
   return Query.prototype.resultsetHeader;
@@ -168,7 +170,7 @@ Query.prototype.readField = function (packet, connection) {
     this._rowParser = connection.textProtocolParsers[parserKey];
     if (!this._rowParser) {
       this._rowParser = compileParser(fields, this.options, connection.config);
-      connection.textProtocolParsers[parserKey] = this.rowParser;
+      connection.textProtocolParsers[parserKey] = this._rowParser;
     }
     return Query.prototype.fieldsEOF;
   }
@@ -195,7 +197,8 @@ Query.prototype.row = function (packet)
     return this.done();
   }
 
-  var row = new this._rowParser(packet, this._fields[this._resultIndex], this.options);
+  debugger;
+  var row = new this._rowParser(packet, this._fields[this._resultIndex], this.options, CharsetToEncoding);
   if (this.onResult) {
     this._rows[this._resultIndex].push(row);
   } else {

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -197,7 +197,6 @@ Query.prototype.row = function (packet)
     return this.done();
   }
 
-  debugger;
   var row = new this._rowParser(packet, this._fields[this._resultIndex], this.options, CharsetToEncoding);
   if (this.onResult) {
     this._rows[this._resultIndex].push(row);

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -3,6 +3,7 @@ var util = require('util');
 var Buffer = require('safe-buffer').Buffer;
 
 var Readable = require('readable-stream');
+var objectAssign = require('object-assign');
 
 var Command = require('./command.js');
 var Packets = require('../packets/index.js');
@@ -36,7 +37,7 @@ Query.prototype.start = function (packet, connection) {
     console.log('        Sending query command: %s', this.sql);
   }
   this._connection = connection;
-  this.options = Object.assign({}, connection.config, this._queryOptions);
+  this.options = objectAssign({}, connection.config, this._queryOptions);
   var cmdPacket = new Packets.Query(this.sql, connection.config.charsetNumber);
   connection.writePacket(cmdPacket.toPacket(1));
   return Query.prototype.resultsetHeader;

--- a/lib/compile_binary_parser.js
+++ b/lib/compile_binary_parser.js
@@ -15,7 +15,7 @@ function compile (fields, options, config) {
   var result = [];
   var i = 0;
   var nullBitmapLength = Math.floor((fields.length + 7 + 2) / 8);
-  result.push('(function(){ return function BinaryRow(packet) {');
+  result.push('(function(){ return function BinaryRow(packet, fields, options, CharsetToEncoding) {');
 
   if (options.rowsAsArray) {
     result.push('  var result = new Array(' + fields.length + ');');
@@ -73,7 +73,7 @@ function compile (fields, options, config) {
     result.push('  if (nullBitmaskByte' + nullByteIndex + ' & ' + currentFieldNullBit + ')');
     result.push('  ' + lvalue + ' = null;');
     result.push('  else');
-    result.push('  ' + lvalue + ' = ' + readCodeFor(fields[i], config, options));
+    result.push('  ' + lvalue + ' = ' + readCodeFor(fields[i], config, options, i));
     // }
     currentFieldNullBit *= 2;
     if (currentFieldNullBit == 0x100) {
@@ -96,7 +96,7 @@ function compile (fields, options, config) {
   return vm.runInThisContext(src);
 }
 
-function readCodeFor (field, config, options) {
+function readCodeFor (field, config, options, fieldNum) {
   var supportBigNumbers = options.supportBigNumbers || config.supportBigNumbers;
   var bigNumberStrings = options.bigNumberStrings || config.bigNumberStrings;
   var unsigned = field.flags & FieldFlags.UNSIGNED;
@@ -135,7 +135,7 @@ function readCodeFor (field, config, options) {
   case Types.GEOMETRY:
     return 'packet.parseGeometryValue();';
   case Types.JSON:
-    return 'JSON.parse(packet.readLengthCodedString("' + CharsetToEncoding[field.characterSet] + '"));';
+    return 'JSON.parse(packet.readLengthCodedString(CharsetToEncoding[fields[' + fieldNum + '].characterSet]));';
   case Types.LONGLONG:
     if (!supportBigNumbers) {
       return unsigned ? 'packet.readInt64JSNumber();' : 'packet.readSInt64JSNumber();';
@@ -150,7 +150,7 @@ function readCodeFor (field, config, options) {
     if (field.characterSet == Charsets.BINARY) {
       return 'packet.readLengthCodedBuffer();';
     } else {
-      return 'packet.readLengthCodedString("' + CharsetToEncoding[field.characterSet] + '")';
+      return 'packet.readLengthCodedString(CharsetToEncoding[fields[' + fieldNum + '].characterSet])';
     }
   }
 }

--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -31,7 +31,7 @@ function compile (fields, options, config) {
   var i = 0;
   var lvalue = '';
 
-  result.push('(function() { return function TextRow(packet, fields, options) {');
+  result.push('(function() { return function TextRow(packet, fields, options, CharsetToEncoding) {');
   if (options.rowsAsArray) {
     result.push('  var result = new Array(' + fields.length + ')');
   }
@@ -74,10 +74,10 @@ function compile (fields, options, config) {
     } else {
       lvalue = '  this[' + srcEscape(fields[i].name) + ']';
     }
-    var encoding = CharsetToEncoding[fields[i].characterSet];
-    var readCode = readCodeFor(fields[i].columnType, fields[i].characterSet, encoding, config, options);
+    var encodingExpr = 'CharsetToEncoding[fields[' + i + '].characterSet]';
+    var readCode = readCodeFor(fields[i].columnType, fields[i].characterSet, encodingExpr, config, options);
     if (typeof options.typeCast === 'function') {
-      result.push(lvalue + ' = options.typeCast(wrap(fields[' + i + '], ' + srcEscape(typeNames[fields[i].columnType]) + ', packet, "' + encoding + '"), function() { return ' + readCode + ';})');
+      result.push(lvalue + ' = options.typeCast(wrap(fields[' + i + '], ' + srcEscape(typeNames[fields[i].columnType]) + ', packet, ' + encodingExpr + '), function() { return ' + readCode + ';})');
     } else if (options.typeCast === false) {
       result.push(lvalue + ' = packet.readLengthCodedBuffer();');
     } else {
@@ -100,7 +100,7 @@ function compile (fields, options, config) {
   return vm.runInThisContext(src);
 }
 
-function readCodeFor (type, charset, encoding, config, options) {
+function readCodeFor (type, charset, encodingExpr, config, options) {
   var supportBigNumbers = options.supportBigNumbers || config.supportBigNumbers;
   var bigNumberStrings = options.bigNumberStrings || config.bigNumberStrings;
 
@@ -143,12 +143,12 @@ function readCodeFor (type, charset, encoding, config, options) {
   case Types.GEOMETRY:
     return 'packet.parseGeometryValue()';
   case Types.JSON:
-    return 'JSON.parse(packet.readLengthCodedString("' + encoding + '"))';
+    return 'JSON.parse(packet.readLengthCodedString(' + encodingExpr + '))';
   default:
     if (charset == Charsets.BINARY) {
       return 'packet.readLengthCodedBuffer()';
     } else {
-      return 'packet.readLengthCodedString("' + encoding + '")';
+      return 'packet.readLengthCodedString(' + encodingExpr + ')';
     }
   }
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -442,7 +442,7 @@ Connection.prototype.resume = function resume () {
 
 Connection.prototype.keyFromFields = function keyFromFields (fields, options) {
   var res = (typeof options.nestTables) + '/' + options.nestTables + '/' + options.rowsAsArray
-    + options.supportBigNumbers + '/' + options.bigNumberStrings;
+    + options.supportBigNumbers + '/' + options.bigNumberStrings + '/' + typeof options.typeCast;
   for (var i = 0; i < fields.length; ++i) {
     res += '/' + fields[i].name + ':' + fields[i].columnType + ':' + fields[i].flags;
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "iconv-lite": "^0.4.13",
     "long": "^3.2.0",
     "named-placeholders": "1.1.1",
+    "object-assign": "^4.1.0",
     "readable-stream": "2.1.5",
     "safe-buffer": "^5.0.1",
     "seq-queue": "0.0.5",

--- a/test/integration/connection/encoding/test-client-encodings.js
+++ b/test/integration/connection/encoding/test-client-encodings.js
@@ -3,20 +3,20 @@ var common = require('../../../common');
 var assert = require('assert');
 
 var connection = common.createConnection({charset: 'UTF8MB4_GENERAL_CI'});
-connection.query('drop table __test_client_encodings');
-connection.query('create table if not exists __test_client_encodings (name VARCHAR(200)) CHARACTER SET=utf8mb4', function(err) {
+connection.query('drop table if exists __test_client_encodings');
+connection.query('create table if not exists __test_client_encodings (name VARCHAR(200)) CHARACTER SET=utf8mb4', function (err) {
   assert.ifError(err);
-  connection.query('delete from __test_client_encodings', function(err) {
+  connection.query('delete from __test_client_encodings', function (err) {
     assert.ifError(err);
     connection.end();
 
     var connection1 = common.createConnection({charset: 'CP1251_GENERAL_CI'});
-    connection1.query('insert into __test_client_encodings values("привет, мир")', function(err) {
+    connection1.query('insert into __test_client_encodings values("привет, мир")', function (err) {
       assert.ifError(err);
       connection1.end();
 
       var connection2 = common.createConnection({charset: 'KOI8R_GENERAL_CI'});
-      connection2.query('select * from __test_client_encodings', function(err, rows) {
+      connection2.query('select * from __test_client_encodings', function (err, rows) {
         assert.ifError(err);
         assert.equal(rows[0].name, 'привет, мир');
         connection2.end();

--- a/test/integration/connection/encoding/test-client-encodings.js
+++ b/test/integration/connection/encoding/test-client-encodings.js
@@ -2,8 +2,9 @@ var mysql = require('../../../../index.js');
 var common = require('../../../common');
 var assert = require('assert');
 
-var connection = common.createConnection({charset: 'UTF8_GENERAL_CI'});
-connection.query('create table if not exists __test_client_encodings (name VARCHAR(200))', function(err) {
+var connection = common.createConnection({charset: 'UTF8MB4_GENERAL_CI'});
+connection.query('drop table __test_client_encodings');
+connection.query('create table if not exists __test_client_encodings (name VARCHAR(200)) CHARACTER SET=utf8mb4', function(err) {
   assert.ifError(err);
   connection.query('delete from __test_client_encodings', function(err) {
     assert.ifError(err);

--- a/test/integration/connection/test-typecast.js
+++ b/test/integration/connection/test-typecast.js
@@ -10,16 +10,16 @@ connection.query({
     }
     return next();
   }
-}, function(err, res) {
+}, function (err, res) {
   assert.ifError(err);
-  assert.equal(res[0].foo, 'FOO UPPERCASE')
+  assert.equal(res[0].foo, 'FOO UPPERCASE');
 });
 
 
 connection.query({
   sql: 'select "foobar" as foo',
   typeCast: false
-}, function(err, res) {
+}, function (err, res) {
   assert.ifError(err);
   assert(Buffer.isBuffer(res[0].foo));
   assert.equal(res[0].foo.toString('utf8'), 'foobar');


### PR DESCRIPTION
It looks like text protocol parser cache was not used at all: https://github.com/sidorares/node-mysql2/pull/396#issuecomment-246134184

After fix, few tests failed. The reason was over-optimization in parser: encoding was part of compiled parser and if encoding changed between parser invocation the result was incorrect. This is changed to dynamically use charset from field parameter. Another problem was in re-use parser with typeCast options, first time where it's a function and second time where it's `false`. Now typeCast added to parser cache key, when typeCast values differ new parser is generated

TODO: compare benchmarks before/after caching