### PR TITLE
Don't write to stream when socket is closed

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -27,6 +27,7 @@ function Execute (options, callback)
   this._executeOptions = options;
   this._resultIndex = 0;
   this._localStream = null;
+  this._unpipeStream = function () {};
   this._streamFactory = options.infileStreamFactory;
 }
 util.inherits(Execute, Command);

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -21,6 +21,17 @@ function Prepare (options, callback)
 util.inherits(Prepare, Command);
 
 Prepare.prototype.start = function (packet, connection) {
+  var Connection = connection.constructor;
+  this.key = Connection.statementKey(this.options);
+
+  var statement = connection._statements.get(this.key);
+  if (statement) {
+    if (this.onResult) {
+      this.onResult(null, statement);
+    }
+    return null;
+  }
+
   var cmdPacket = new Packets.PrepareStatement(this.query, connection.config.charsetNumber);
   connection.writePacket(cmdPacket.toPacket(1));
   return Prepare.prototype.prepareHeader;
@@ -101,19 +112,18 @@ Prepare.prototype.fieldsEOF = function (packet, connection) {
 Prepare.prototype.prepareDone = function (connection)
 {
   var self = this;
+  var statement = new PreparedStatementInfo(
+    self.query,
+    self.id,
+    self.fields,
+    self.parameterDefinitions,
+    connection
+  );
+
+  connection._statements.set(this.key, statement);
+
   if (this.onResult) {
-    process.nextTick(function () {
-      self.onResult(
-        null,
-        new PreparedStatementInfo(
-          self.query,
-          self.id,
-          self.fields,
-          self.parameterDefinitions,
-          connection
-        )
-      );
-    });
+    self.onResult(null, statement);
   }
   return null;
 };

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -146,6 +146,7 @@ Query.prototype._streamLocalInfile = function (connection) {
 
   var onError = function (err) {
     command._localStreamError = err;
+    connection.writePacket(EmptyPacket);
   };
 
   command._unpipeStream = function () {

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -27,6 +27,7 @@ function Query (options, callback)
   this._receivedFieldsCount = 0;
   this._resultIndex = 0;
   this._localStream = null;
+  this._unpipeStream = function () {};
   this._streamFactory = options.infileStreamFactory;
   this._connection = null;
 }
@@ -45,6 +46,7 @@ Query.prototype.start = function (packet, connection) {
 
 Query.prototype.done = function () {
   var self = this;
+  this._unpipeStream();
   if (this.onResult) {
     var rows, fields;
     if (this._resultIndex === 0) {
@@ -123,23 +125,45 @@ Query.prototype._findOrCreateReadStream = function (path) {
 
 Query.prototype._streamLocalInfile = function (connection) {
   var command = this;
-  connection.stream.on('pause', function () {
-    command._localStream.pause();
-  });
-  connection.stream.on('drain', function () {
+
+  var onDrain = function () {
     command._localStream.resume();
-  });
-  this._localStream.on('data', function (data) {
+  };
+
+  var onPause = function () {
+    command._localStream.pause();
+  };
+
+  var onData = function (data) {
     var dataWithHeader = Buffer.allocUnsafe(data.length + 4);
     data.copy(dataWithHeader, 4);
     connection.writePacket(new Packets.Packet(0, dataWithHeader, 0, dataWithHeader.length));
-  });
-  this._localStream.on('end', function (data) {
+  };
+
+  var onEnd = function () {
     connection.writePacket(EmptyPacket);
-  });
-  this._localStream.on('error', function (err) {
+  };
+
+  var onError = function (err) {
     command._localStreamError = err;
-    command._localStream.emit('end');
+  };
+
+  command._unpipeStream = function () {
+    connection.stream.removeListener('pause', onPause);
+    connection.stream.removeListener('drain', onDrain);
+    command._localStream.removeListener('data', onData);
+    command._localStream.removeListener('end', onEnd);
+    command._localStream.removeListener('error', onError);
+  };
+
+  connection.stream.on('pause', onPause);
+  connection.stream.on('drain', onDrain);
+  command._localStream.on('data', onData);
+  command._localStream.on('end', onEnd);
+  command._localStream.on('error', onError);
+
+  connection.once('error', function (err) {
+    command._unpipeStream();
   });
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -134,18 +134,24 @@ function Connection (opts)
 }
 util.inherits(Connection, EventEmitter);
 
+Connection.prototype._addCommandClosedState = function (cmd) {
+  var err = new Error('Can\t add new command when connection is in closed state');
+  err.fatal = true;
+  if (cmd.onResult) {
+    cmd.onResult(err);
+  } else {
+    connection.emit('error', err);
+  }
+};
+
 Connection.prototype._handleNetworkError = function (err) {
   var connection = this;
   err.fatal = true;
   // stop receiving packets
   connection.stream.removeAllListeners('data');
-  connection.addCommand = function (cmd) {
-    if (cmd.onResult) {
-      cmd.onResult(err);
-    } else {
-      connection.emit('error', err);
-    }
-    return;
+  connection.addCommand = connection._addCommandClosedState;
+  connection.write = function () {
+    connection.emit('error', new Error('Can\'t write in closed state'));
   };
   connection._notifyError(err);
   connection._fatalError = err;
@@ -202,7 +208,11 @@ Connection.prototype._notifyError = function (err) {
 };
 
 Connection.prototype.write = function (buffer) {
-  this.stream.write(buffer);
+  this.stream.write(buffer, function (err) {
+    if (err) {
+      conn._handleNetworkError(err);
+    }
+  });
 };
 
 Connection.prototype.writePacket = function (packet) {
@@ -620,16 +630,7 @@ Connection.prototype.close = function () {
   this._closing = true;
   this.stream.end();
   var connection = this;
-  connection.addCommand = function (cmd) {
-    var err = new Error('Trying to add new command when connection in closed state');
-    err.fatal = true;
-    if (cmd.onResult) {
-      cmd.onResult(err);
-    } else {
-      connection.emit('error', err);
-    }
-    return;
-  };
+  connection.addCommand = connection._addCommandClosedState;
 };
 
 Connection.prototype.createBinlogStream = function (opts) {
@@ -757,11 +758,7 @@ Connection.prototype.end = function (callback) {
 
   // trigger error if more commands enqueued after end command
   var quitCmd = this.addCommand(new Commands.Quit(callback));
-  connection.addCommand = function () {
-    if (connection._closing) {
-      this.emit(new Error('addCommand() called on closing connection'));
-    }
-  };
+  connection.addCommand = connection._addCommandClosedState;
   return quitCmd;
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -135,7 +135,7 @@ function Connection (opts)
 util.inherits(Connection, EventEmitter);
 
 Connection.prototype._addCommandClosedState = function (cmd) {
-  var err = new Error('Can\t add new command when connection is in closed state');
+  var err = new Error('Can\'t add new command when connection is in closed state');
   err.fatal = true;
   if (cmd.onResult) {
     cmd.onResult(err);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -490,10 +490,10 @@ Connection.prototype.keyFromFields = function keyFromFields (fields, options) {
   return res;
 };
 
-function statementKey (options) {
+Connection.statementKey = function (options) {
   return (typeof options.nestTables) +
     '/' + options.nestTables + '/' + options.rowsAsArray + options.sql;
-}
+};
 
 // TODO: named placeholders support
 Connection.prototype.prepare = function prepare (options, cb) {
@@ -510,7 +510,7 @@ Connection.prototype.unprepare = function unprepare (sql) {
   } else {
     options.sql = sql;
   }
-  var key = statementKey(options);
+  var key = Connection.statementKey(options);
   var stmt = this._statements.get(key);
   if (stmt) {
     this._statements.del(key);
@@ -542,30 +542,26 @@ Connection.prototype.execute = function execute (sql, values, cb) {
   cb = _domainify(cb);
   this._resolveNamedPlaceholders(options);
 
-  var connection = this;
-  var key = statementKey(options);
-  var statement = connection._statements.get(key);
-
-  options.statement = statement;
   var executeCommand = new Commands.Execute(options, cb);
+  var prepareCommand = new Commands.Prepare(options, function (err, stmt) {
+    if (err) {
+      // skip execute command if prepare failed, we have main
+      // combined callback here
+      executeCommand.start = function () { return null; };
 
-  if (!statement) {
-    connection.prepare(options, function executeStatement (err, stmt) {
-      if (err) {
-        if (cb) {
-          cb(err);
-        } else {
-          executeCommand.emit('error', err);
-        }
-        return;
+      if (cb) {
+        cb(err);
+      } else {
+        executeCommand.emit('error', err);
       }
-      executeCommand.statement = stmt;
-      connection._statements.set(key, stmt);
-      connection.addCommand(executeCommand);
-    });
-  } else {
-    connection.addCommand(executeCommand);
-  }
+      return;
+    }
+
+    executeCommand.statement = stmt;
+  });
+
+  this.addCommand(prepareCommand);
+  this.addCommand(executeCommand);
   return executeCommand;
 };
 

--- a/test/integration/connection/test-execute-order.js
+++ b/test/integration/connection/test-execute-order.js
@@ -1,0 +1,22 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var order = [];
+connection.execute('select 1+2', function (err, _rows, _fields) {
+  assert.ifError(err);
+  order.push(0);
+});
+connection.execute('select 2+2', function (err, _rows, _fields) {
+  assert.ifError(err);
+  order.push(1);
+});
+connection.query('select 1+1', function (err, _rows, _fields) {
+  assert.ifError(err);
+  order.push(2);
+  connection.end();
+});
+
+process.on('exit', function () {
+  assert.deepEqual(order, [0, 1, 2]);
+});

--- a/test/integration/connection/test-load-infile.js
+++ b/test/integration/connection/test-load-infile.js
@@ -43,10 +43,18 @@ connection.query(sql, [badPath, ','], function (err, result) {
 });
 
 // test path mapping
-var Stream = require('readable-stream').PassThrough;
-var myStream = new Stream();
+var createMyStream = function (path) {
+  var Stream = require('readable-stream').PassThrough;
+  var myStream = new Stream();
+  setTimeout(function () {
+    myStream.write('11,Hello World\n');
+    myStream.write('21,One ');
+    myStream.write('more row\n');
+    myStream.end();
+  }, 1000);
+  return myStream;
+};
 
-var createMyStream = function (path) { return myStream; };
 var streamResult;
 connection.query({
   sql: sql,
@@ -57,14 +65,8 @@ connection.query({
     throw err;
   }
   streamResult = result;
-}
-);
-myStream.write('11,Hello World\n');
-myStream.write('21,One ');
-myStream.write('more row\n');
-myStream.end();
-
-connection.end();
+  connection.end();
+});
 
 process.on('exit', function () {
   assert.equal(ok.affectedRows, 4);

--- a/test/integration/connection/test-named-paceholders.js
+++ b/test/integration/connection/test-named-paceholders.js
@@ -48,12 +48,12 @@ connection.query('SELECT :a + :a as sum', {a: 2}, function (err, rows, fields) {
     throw err;
   }
   assert.deepEqual(rows, [{'sum':4}]);
+  connection.end();
 });
 
 var sql = connection.format('SELECT * from test_table where num1 < :numParam and num2 > :lParam', {lParam: 100, numParam: 2});
 assert.equal(sql, 'SELECT * from test_table where num1 < 2 and num2 > 100');
 
-connection.end();
 
 var pool = common.createPool();
 pool.config.connectionConfig.namedPlaceholders = true;

--- a/test/integration/connection/test-stream-errors.js
+++ b/test/integration/connection/test-stream-errors.js
@@ -47,5 +47,5 @@ process.on('exit', function () {
   assert.equal(receivedError2.fatal, true);
   assert.equal(receivedError2.code, err.code);
   assert.equal(receivedError3.fatal, true);
-  assert.equal(receivedError3.code, err.code);
+  assert.equal(receivedError3.message, 'Can\'t add new command when connection is in closed state');
 });

--- a/test/integration/test-rows-as-array.js
+++ b/test/integration/test-rows-as-array.js
@@ -21,6 +21,7 @@ c.execute('select 1+1 as a', function (err, rows, fields) {
 c.execute({sql: 'select 1+2 as a', rowsAsArray: false}, function (err, rows, fields) {
   assert.ifError(err);
   assert.equal(rows[0].a, 3);
+  c.end();
 });
 
 // disabled in initial config, enable in some tets
@@ -42,9 +43,8 @@ c1.execute('select 1+1 as a', function (err, rows, fields) {
 
 c1.execute({sql: 'select 1+2 as a', rowsAsArray: true}, function (err, rows, fields) {
   assert.ifError(err);
-  assert.equal(rows[0][1], 3);
+  assert.equal(rows[0][0], 3);
+  c1.end();
 });
 
 
-c.end();
-c1.end();


### PR DESCRIPTION
network error handler already closes commands in the queue on network error, hovewer there still seems to be possibility to when code is writing to socket after it was already closed:
 - connection closed in the middle of wrtiting command
 - there was long running multi packet command such as `LOAD INFILE` packets from client to server

Just listening `error` events on socket is not enough, in the scenarios above error is thrown from event loop and it's not possible to handle it

hopefully fixes #289 #57 and #38

solution: 
 - add callback to `socket.write` and treat callback error as network error
 - stop listening `LOAD INFILE` stream in case of network error
 - guard from adding new commands and writing packets if client is in the closed state