### PR TITLE
Using Denque and Connection Timeout Fix

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,9 +1,9 @@
 var Net = require('net');
 var util = require('util');
-var Tls = require('tls');
+var TLS = require('tls');
 var Timers = require('timers');
 var EventEmitter = require('events').EventEmitter;
-var Queue = require('double-ended-queue');
+var Queue = require('denque');
 var SqlString = require('sqlstring');
 var LRU = require('lru-cache');
 
@@ -227,7 +227,7 @@ Connection.prototype.writePacket = function (packet) {
   this.write(packet.buffer);
 };
 
-if (Tls.TLSSocket) {
+if (TLS.TLSSocket) {
   // 0.11+ environment
   Connection.prototype.startTLS = function _startTLS (onSecure) {
     if (this.config.debug) {
@@ -235,7 +235,7 @@ if (Tls.TLSSocket) {
     }
     var connection = this;
     var stream = this.stream;
-    var secureContext = Tls.createSecureContext({
+    var secureContext = TLS.createSecureContext({
       ca         : this.config.ssl.ca,
       cert       : this.config.ssl.cert,
       ciphers    : this.config.ssl.ciphers,
@@ -245,7 +245,7 @@ if (Tls.TLSSocket) {
 
     var rejectUnauthorized = this.config.ssl.rejectUnauthorized;
     var secureEstablished = false;
-    var secureSocket = new Tls.TLSSocket(connection.stream, {
+    var secureSocket = new TLS.TLSSocket(connection.stream, {
       rejectUnauthorized : rejectUnauthorized,
       requestCert        : true,
       secureContext      : secureContext,
@@ -291,7 +291,7 @@ if (Tls.TLSSocket) {
       ca         : config.ssl.ca,
       ciphers    : config.ssl.ciphers
     });
-    var securePair = Tls.createSecurePair(credentials, false, true, rejectUnauthorized);
+    var securePair = TLS.createSecurePair(credentials, false, true, rejectUnauthorized);
 
     if (stream.ondata) {
       stream.ondata = null;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,7 +1,6 @@
 var Net = require('net');
 var util = require('util');
 var TLS = require('tls');
-var Timers = require('timers');
 var EventEmitter = require('events').EventEmitter;
 var Queue = require('denque');
 var SqlString = require('sqlstring');
@@ -87,9 +86,8 @@ function Connection (opts)
   this.packetParser = new PacketParser(function (p) { connection.handlePacket(p); });
 
   this.stream.on('data', function (data) {
-    if (connection.connectTimeout) {
-      Timers.clearTimeout(connection.connectTimeout);
-      connection.connectTimeout = null;
+    if (connection.stream.setTimeout) {
+      connection.stream.setTimeout(0);
     }
     connection.packetParser.execute(data);
   });
@@ -127,9 +125,10 @@ function Connection (opts)
   // will be overwrittedn with actial encoding value as soon as server handshake packet is received
   this.serverEncoding = 'utf8';
 
-  if (this.config.connectTimeout) {
+  // add timeout if stream supports it
+  if (this.config.connectTimeout && this.stream.setTimeout) {
     var timeoutHandler = this._handleTimeoutError.bind(this);
-    this.connectTimeout = Timers.setTimeout(timeoutHandler, this.config.connectTimeout);
+    this.stream.setTimeout(this.config.connectTimeout, timeoutHandler);
   }
 }
 util.inherits(Connection, EventEmitter);
@@ -158,9 +157,9 @@ Connection.prototype._handleNetworkError = function (err) {
 };
 
 Connection.prototype._handleTimeoutError = function () {
-  if (this.connectTimeout) {
-    Timers.clearTimeout(this.connectTimeout);
-    this.connectTimeout = null;
+  if (this.stream.setTimeout) {
+    this.stream.setTimeout(0);
+    this.stream.destroy();
   }
 
   var err = new Error('connect ETIMEDOUT');

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -3,7 +3,7 @@ var mysql = require('../index.js');
 var EventEmitter = require('events').EventEmitter;
 var Util = require('util');
 var PoolConnection = require('./pool_connection.js');
-var Queue = require('double-ended-queue');
+var Queue = require('denque');
 var Connection = require('./connection.js');
 
 module.exports = Pool;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "cardinal": "1.0.0",
-    "double-ended-queue": "2.1.0-0",
+    "denque": "^1.0.4",
     "generate-function": "^2.0.0",
     "iconv-lite": "^0.4.13",
     "long": "^3.2.0",


### PR DESCRIPTION
- `denque` is [much faster](https://github.com/Salakar/denque#benchmarks) than `double-ended-queue` and both are API compatible
- Fixed the `connectTimeout` issue, we need to destroy stream, because its blocking the event reporting. Any error set before destroying are not reported to receiver. We don't need to use timers as well, because we are now implementing it only if stream supports `setTimeout`