### PR TITLE
fix Query.stream exception on prepared statements

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -29,6 +29,7 @@ function Execute (options, callback)
   this._localStream = null;
   this._unpipeStream = function () {};
   this._streamFactory = options.infileStreamFactory;
+  this._connection = null;
 }
 util.inherits(Execute, Command);
 
@@ -43,6 +44,7 @@ Execute.prototype.buildParserFromFields = function (fields, connection) {
 };
 
 Execute.prototype.start = function (packet, connection) {
+  this._connection = connection;
   this.options = objectAssign({}, connection.config, this._executeOptions);
   var executePacket = new Packets.Execute(this.statement.id, this.parameters, connection.config.charsetNumber);
   connection.writePacket(executePacket.toPacket(1));


### PR DESCRIPTION
Related to #174 but for prepared statements