### PR TITLE
Fix and tests for garbled column names

### DIFF
--- a/lib/packets/column_definition.js
+++ b/lib/packets/column_definition.js
@@ -60,7 +60,7 @@ var addString = function (name) {
   Object.defineProperty(ColumnDefinition.prototype, name, {get: function () {
     var start = this['_' + name + 'Start'];
     var end = start + this['_' + name + 'Length'];
-    return StringParser.decode(this._buf.slice(start, end), this.encoding);
+    return StringParser.decode(this._buf.slice(start, end), this.encoding === 'binary' ? 'utf8' : this.encoding);
   }});
 };
 

--- a/lib/packets/column_definition.js
+++ b/lib/packets/column_definition.js
@@ -48,10 +48,7 @@ function ColumnDefinition (packet)
   this.characterSet = packet.readInt16();
   this.encoding = CharsetToEncoding[this.characterSet];
 
-  // TODO: use this.characterSet to get proper encoding
-  // May be keep it cesu8 since MySQL meta data is actually cesu8
-  // https://github.com/sidorares/node-mysql2/pull/374
-  this.name = StringParser.decode(this._buf.slice(_nameStart, _nameStart + _nameLength), this.encoding);
+  this.name = StringParser.decode(this._buf.slice(_nameStart, _nameStart + _nameLength), this.encoding === 'binary' ? 'utf8' : this.encoding);
 
   this.columnLength = packet.readInt32();
   this.columnType = packet.readInt8();

--- a/test/integration/regressions/test-#442.js
+++ b/test/integration/regressions/test-#442.js
@@ -17,7 +17,7 @@ connection.query([
   ' `' + testFields[1] + '` varchar(255) NOT NULL,',
   ' `' + testFields[2] + '` int(11) NOT NULL,',
   ' `' + testFields[3] + '` int(11) NOT NULL,',
-  ' PRIMARY KEY (`商品类型`)',
+  ' PRIMARY KEY (`' + testFields[0] + '`)',
   ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
 ].join(' '), function (err) {
   assert.ifError(err);

--- a/test/integration/regressions/test-#442.js
+++ b/test/integration/regressions/test-#442.js
@@ -1,0 +1,49 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var tableName = '商城';
+var testFields = ['商品类型', '商品说明', '价格', '剩余'];
+var testRows = [
+  ['商类型', '商品型', 47, 7],
+  ['类商型', '商型品', 11, 108]
+];
+
+var actualRows = null;
+
+connection.query([
+  'CREATE TEMPORARY TABLE `' + tableName + '` (',
+  ' `' + testFields[0] + '` varchar(255) NOT NULL,',
+  ' `' + testFields[1] + '` varchar(255) NOT NULL,',
+  ' `' + testFields[2] + '` int(11) NOT NULL,',
+  ' `' + testFields[3] + '` int(11) NOT NULL,',
+  ' PRIMARY KEY (`商品类型`)',
+  ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+].join(' '), function (err) {
+  assert.ifError(err);
+  connection.query([
+    'INSERT INTO `' + tableName + '` VALUES',
+    '("' + testRows[0][0] + '","' + testRows[0][1] + '", ' + testRows[0][2] + ', ' + testRows[0][3] + '),',
+    '("' + testRows[1][0] + '","' + testRows[1][1] + '", ' + testRows[1][2] + ', ' + testRows[1][3] + ')'
+  ].join(' '), executeTest);
+});
+
+function executeTest (err) {
+  assert.ifError(err);
+  connection.query('SELECT * FROM `' + tableName + '`', function (err, rows) {
+    assert.ifError(err);
+    actualRows = rows;
+    connection.end();
+  });
+}
+
+process.on('exit', function () {
+  testRows.map(function (tRow, index) {
+    var cols = testFields;
+    var aRow = actualRows[index];
+    assert.equal(aRow[cols[0]], tRow[0]);
+    assert.equal(aRow[cols[1]], tRow[1]);
+    assert.equal(aRow[cols[2]], tRow[2]);
+    assert.equal(aRow[cols[3]], tRow[3]);
+  });
+});


### PR DESCRIPTION
Closes #422

When encoding is unknown we try to parse name as `binary`. I have added check which will force name parsing to `utf8` in such case. I don't know if its a proper fix. Test case included