### PR TITLE
fix for #433 - use client encoding for errors and metadata with encoding=='binary'

### DIFF
--- a/lib/commands/change_user.js
+++ b/lib/commands/change_user.js
@@ -36,6 +36,7 @@ ChangeUser.prototype.start = function (packet, connection) {
   this.currentConfig.password = this.password;
   this.currentConfig.database = this.database;
   this.currentConfig.charsetNumber = this.charsetNumber;
+  connection.clientEncoding = CharsetToEncoding[this.charsetNumber];
   // reset prepared statements cache as all statements become invalid after changeUser
   connection._statements.reset();
   connection.writePacket(packet.toPacket());

--- a/lib/commands/change_user.js
+++ b/lib/commands/change_user.js
@@ -4,6 +4,7 @@ var Command = require('./command.js');
 var Packets = require('../packets/index.js');
 var ClientConstants = require('../constants/client.js');
 var ClientHandshake = require('./client_handshake.js');
+var CharsetToEncoding = require('../constants/charset_encodings.js');
 
 function ChangeUser (options, callback)
 {

--- a/lib/commands/command.js
+++ b/lib/commands/command.js
@@ -25,7 +25,7 @@ Command.prototype.execute = function (packet, connection) {
   }
 
   if (packet && packet.isError()) {
-    var err = packet.asError(connection.serverEncoding);
+    var err = packet.asError(connection.clientEncoding);
     if (this.onResult) {
       this.onResult(err);
     } else {

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -69,7 +69,7 @@ Execute.prototype.readField = function (packet, connection) {
   // var field = this.statement.columns.length == this._fieldCount ?
   //  this.statement.columns[this._receivedFieldsCount] : new Packets.ColumnDefinition(packet);
 
-  var field = new Packets.ColumnDefinition(packet);
+  var field = new Packets.ColumnDefinition(packet, connection.clientEncoding);
 
   this._receivedFieldsCount++;
   this._fields[this._resultIndex].push(field);

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -72,8 +72,8 @@ Prepare.prototype.prepareHeader = function (packet, connection) {
   }
 };
 
-Prepare.prototype.readParameter = function (packet) {
-  var def = new Packets.ColumnDefinition(packet);
+Prepare.prototype.readParameter = function (packet, connection) {
+  var def = new Packets.ColumnDefinition(packet, connection.clientEncoding);
   this.parameterDefinitions.push(def);
   if (this.parameterDefinitions.length == this.parameterCount) {
     return Prepare.prototype.parametersEOF;
@@ -82,7 +82,7 @@ Prepare.prototype.readParameter = function (packet) {
 };
 
 Prepare.prototype.readField = function (packet, connection) {
-  var def = new Packets.ColumnDefinition(packet);
+  var def = new Packets.ColumnDefinition(packet, connection.clientEncoding);
   this.fields.push(def);
   if (this.fields.length == this.fieldCount) {
     return Prepare.prototype.fieldsEOF;

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -178,7 +178,7 @@ Query.prototype.readField = function (packet, connection) {
   // this is the reason _receivedFieldsCount exist (otherwise we could just use current length of fields array)
 
   if (this._fields[this._resultIndex].length != this._fieldCount) {
-    var field = new Packets.ColumnDefinition(packet);
+    var field = new Packets.ColumnDefinition(packet, connection.clientEncoding);
     this._fields[this._resultIndex].push(field);
     if (connection.config.debug) {
       console.log('        Column definition:');

--- a/lib/compressed_protocol.js
+++ b/lib/compressed_protocol.js
@@ -37,7 +37,7 @@ function handleCompressedPacket (packet) {
     connection.inflateQueue.push(function (task) {
       zlib.inflate(body, function (err, data) {
         if (err) {
-          connection.emit('error', err);
+          connection._handleNetworkError(err);
           return;
         }
         connection._inflatedPacketsParser.execute(data);
@@ -70,6 +70,10 @@ function writeCompressedPacket (packet) {
 
   connection.deflateQueue.push(function (task) {
     zlib.deflate(packet.buffer, function (err, compressed) {
+      if (err) {
+        connection._handleNetworkError(err);
+        return;
+      }
       var compressedLength = compressed.length;
       if (compressedLength > packetLen) {
         compressHeader.writeUInt8(compressedLength & 0xff, 0);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -140,7 +140,7 @@ Connection.prototype._addCommandClosedState = function (cmd) {
   if (cmd.onResult) {
     cmd.onResult(err);
   } else {
-    connection.emit('error', err);
+    this.emit('error', err);
   }
 };
 
@@ -209,9 +209,10 @@ Connection.prototype._notifyError = function (err) {
 };
 
 Connection.prototype.write = function (buffer) {
+  var conn = this;
   this.stream.write(buffer, function (err) {
     if (err) {
-      conn._handleNetworkError(err);
+      this._handleNetworkError(err);
     }
   });
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -81,6 +81,8 @@ function Connection (opts)
   this._protocolError = null;
   this._outOfOrderPackets = [];
 
+  this.clientEncoding = CharsetToEncoding[this.config.charsetNumber];
+
   this.stream.once('error', connection._handleNetworkError.bind(this));
 
   // see https://gist.github.com/khoomeister/4985691#use-that-instead-of-bind

--- a/lib/packets/column_definition.js
+++ b/lib/packets/column_definition.js
@@ -15,9 +15,10 @@ var CharsetToEncoding = require('../constants/charset_encodings.js');
 // at some point of time this optimisation might become unnecessary
 // see https://github.com/sidorares/node-mysql2/pull/137
 //
-function ColumnDefinition (packet)
+function ColumnDefinition (packet, clientEncoding)
 {
   this._buf = packet.buffer;
+  this._clientEncoding = clientEncoding;
 
   this._catalogLength = packet.readLengthCodedNumber();
   this._catalogStart = packet.offset;
@@ -48,7 +49,7 @@ function ColumnDefinition (packet)
   this.characterSet = packet.readInt16();
   this.encoding = CharsetToEncoding[this.characterSet];
 
-  this.name = StringParser.decode(this._buf.slice(_nameStart, _nameStart + _nameLength), this.encoding === 'binary' ? 'utf8' : this.encoding);
+  this.name = StringParser.decode(this._buf.slice(_nameStart, _nameStart + _nameLength), this.encoding === 'binary' ? this._clientEncoding : this.encoding);
 
   this.columnLength = packet.readInt32();
   this.columnType = packet.readInt8();
@@ -60,7 +61,7 @@ var addString = function (name) {
   Object.defineProperty(ColumnDefinition.prototype, name, {get: function () {
     var start = this['_' + name + 'Start'];
     var end = start + this['_' + name + 'Length'];
-    return StringParser.decode(this._buf.slice(start, end), this.encoding === 'binary' ? 'utf8' : this.encoding);
+    return StringParser.decode(this._buf.slice(start, end), this.encoding === 'binary' ? this._clientEncoding : this.encoding);
   }});
 };
 

--- a/test/integration/regressions/test-#433.js
+++ b/test/integration/regressions/test-#433.js
@@ -38,6 +38,7 @@ function executeTest (err) {
   });
 }
 
+/* eslint quotes: 0 */
 var expectedError = "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '`МояТаблица' at line 1";
 
 function executeErrorMessageTest () {

--- a/test/integration/regressions/test-#433.js
+++ b/test/integration/regressions/test-#433.js
@@ -1,0 +1,64 @@
+var common = require('../../common');
+var connection = common.createConnection({charset: 'KOI8R_GENERAL_CI'});
+var assert = require('assert');
+
+var tableName = 'МояТаблица';
+var testFields = ['поле1', 'поле2', 'поле3', 'поле4'];
+var testRows = [
+  ['привет', 'мир', 47, 7],
+  ['ура', 'тест', 11, 108]
+];
+
+var actualRows = null;
+var atualError = null;
+
+connection.query([
+  'CREATE TEMPORARY TABLE `' + tableName + '` (',
+  ' `' + testFields[0] + '` varchar(255) NOT NULL,',
+  ' `' + testFields[1] + '` varchar(255) NOT NULL,',
+  ' `' + testFields[2] + '` int(11) NOT NULL,',
+  ' `' + testFields[3] + '` int(11) NOT NULL,',
+  ' PRIMARY KEY (`' + testFields[0] + '`)',
+  ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+].join(' '), function (err) {
+  assert.ifError(err);
+  connection.query([
+    'INSERT INTO `' + tableName + '` VALUES',
+    '("' + testRows[0][0] + '","' + testRows[0][1] + '", ' + testRows[0][2] + ', ' + testRows[0][3] + '),',
+    '("' + testRows[1][0] + '","' + testRows[1][1] + '", ' + testRows[1][2] + ', ' + testRows[1][3] + ')'
+  ].join(' '), executeTest);
+});
+
+function executeTest (err) {
+  assert.ifError(err);
+  connection.query('SELECT * FROM `' + tableName + '`', function (err, rows, fields) {
+    assert.ifError(err);
+    actualRows = rows;
+    executeErrorMessageTest();
+  });
+}
+
+var expectedError = "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '`МояТаблица' at line 1";
+
+function executeErrorMessageTest () {
+  // tableName does not have closing "`", we do this to have tableName in error string
+  // it is sent back in original encoding (koi8r), we are testing that it's decoded correctly
+  connection.query('SELECT * FROM `' + tableName, function (err, rows, fields) {
+    actualError = err.message;
+    connection.end();
+  });
+}
+
+
+process.on('exit', function () {
+  testRows.map(function (tRow, index) {
+    var cols = testFields;
+    var aRow = actualRows[index];
+    assert.equal(aRow[cols[0]], tRow[0]);
+    assert.equal(aRow[cols[1]], tRow[1]);
+    assert.equal(aRow[cols[2]], tRow[2]);
+    assert.equal(aRow[cols[3]], tRow[3]);
+  });
+
+  assert.equal(actualError, expectedError);
+});


### PR DESCRIPTION
see #433 for more details

Actually I'm starting to think that client encoding should be always used for metadata but it's hard to test - in my tests response fields always have same encoding as client regardless of schema (with exception of 'binary' encoding for non-string fields). Will try to check mysql server source to confirm this