### PR TITLE
add support of CLIENT_SESSION_TRACK in ok packet

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -90,7 +90,7 @@ Query.prototype.doneInsert = function (rs) {
 };
 
 Query.prototype.resultsetHeader = function (packet, connection) {
-  var rs = new Packets.ResultSetHeader(packet, connection.config.bigNumberStrings, connection.serverEncoding);
+  var rs = new Packets.ResultSetHeader(packet, connection);
   this._fieldCount = rs.fieldCount;
   if (connection.config.debug) {
     console.log('        Resultset header received, expecting ' + rs.fieldCount + ' column definition packets');
@@ -234,7 +234,7 @@ Query.prototype.row = function (packet)
 };
 
 Query.prototype.infileOk = function (packet, connection) {
-  var rs = new Packets.ResultSetHeader(packet, connection.config.bigNumberStrings);
+  var rs = new Packets.ResultSetHeader(packet, connection);
   return this.doneInsert(rs);
 };
 

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -107,7 +107,8 @@ ConnectionConfig.getDefaultFlags = function (options) {
                         'CONNECT_WITH_DB', 'ODBC', 'LOCAL_FILES',
                         'IGNORE_SPACE', 'PROTOCOL_41', 'IGNORE_SIGPIPE',
                         'TRANSACTIONS', 'RESERVED', 'SECURE_CONNECTION',
-                        'MULTI_RESULTS'];
+                        'MULTI_RESULTS', 'TRANSACTIONS', 'SESSION_TRACK'];
+
   if (options && options.multipleStatements) {
     defaultFlags.push('MULTI_STATEMENTS');
   }

--- a/lib/constants/server_status.js
+++ b/lib/constants/server_status.js
@@ -37,3 +37,6 @@ exports.SERVER_QUERY_WAS_SLOW = 2048;
   To mark ResultSet containing output parameter values.
 */
 exports.SERVER_PS_OUT_PARAMS = 4096;
+
+exports.SERVER_STATUS_IN_TRANS_READONLY = 0x2000; // in a read-only transaction
+exports.SERVER_SESSION_STATE_CHANGED = 0x4000;

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -40,13 +40,8 @@ function ResultSetHeader (packet, connection)
   } else if (isSet('TRANSACTIONS')) {
     this.serverStatus = packet.readInt16();
   }
-  this.stateChanges = {
-    systemVariables: {},
-    schema: null,
-    // gtids: {},
-    trackStateChange: null
-  };
 
+  var stateChanges = null;
   if (isSet('SESSION_TRACK') && packet.offset < packet.end) {
     this.info = packet.readLengthCodedString(encoding);
     if (this.serverStatus && ServerSatusFlags.SERVER_SESSION_STATE_CHANGED) {
@@ -58,6 +53,15 @@ function ResultSetHeader (packet, connection)
       var end = packet.offset + len;
       var type, len, key, stateEnd;
 
+      if (len > 0) {
+        stateChanges = {
+          systemVariables: {},
+          schema: null,
+          // gtids: {},
+          trackStateChange: null
+        };
+      }
+
       while (packet.offset < end) {
         type = packet.readInt8();
         len = packet.readLengthCodedNumber();
@@ -65,21 +69,24 @@ function ResultSetHeader (packet, connection)
         key = packet.readLengthCodedString(encoding);
         if (type === 0) {
           var val = packet.readLengthCodedString(encoding);
-          this.stateChanges.systemVariables[key] = val;
+          stateChanges.systemVariables[key] = val;
         } else if (type === 1) {
           // TODO double check it's supposed to be the only value, not a list.
-          this.stateChanges.schema = key;
+          stateChanges.schema = key;
         } else if (type === 2) {
-          this.stateChanges.trackStateChange = packet.readLengthCodedString(encoding);
+          stateChanges.trackStateChange = packet.readLengthCodedString(encoding);
         } else {
           // GTIDs (type == 3) or unknown type - just skip for now
         }
-        debugger;
         packet.offset = stateEnd;
       }
     }
   } else {
     this.info = packet.readString(undefined, encoding);
+  }
+
+  if (stateChanges) {
+    this.stateChanges = stateChanges;
   }
 
   var m = this.info.match(/\schanged:\s*(\d+)/i);

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -1,39 +1,91 @@
 // TODO: rename to OK packet
+// https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html
 
 var Buffer = require('safe-buffer').Buffer;
-var Packet = require('../packets/packet');
 
-function ResultSetHeader (packet, bigNumberStrings, encoding)
+var Packet = require('./packet.js');
+var ClientConstants = require('../constants/client.js');
+var ServerSatusFlags = require('../constants/server_status.js');
+
+var SessionChangeTypeToName = ['systemVariables', 'schema', 'status', 'gtids'];
+
+function ResultSetHeader (packet, connection)
 {
+  var bigNumberStrings = connection.config.bigNumberStrings;
+  var encoding = connection.serverEncoding;
+
+  var flags = connection._handshakePacket.capabilityFlags;
+
+  var isSet = function (flag) {
+    return flags & ClientConstants[flag];
+  };
+
   if (packet.buffer[packet.offset] !== 0) {
     this.fieldCount = packet.readLengthCodedNumber();
-  } else {
-    this.fieldCount = packet.readInt8(); // skip OK byte
-    this.affectedRows = packet.readLengthCodedNumber(bigNumberStrings);
-    this.insertId = packet.readLengthCodedNumberSigned(bigNumberStrings);
+    if (this.fieldCount === null) {
+      this.infileName = packet.readString(undefined, encoding);
+    }
+    return;
+  }
+
+  this.fieldCount = packet.readInt8(); // skip OK byte
+  this.affectedRows = packet.readLengthCodedNumber(bigNumberStrings);
+  this.insertId = packet.readLengthCodedNumberSigned(bigNumberStrings);
+  this.info = '';
+
+
+  if (isSet('PROTOCOL_41')) {
     this.serverStatus = packet.readInt16();
     this.warningStatus = packet.readInt16();
+  } else if (isSet('TRANSACTIONS')) {
+    this.serverStatus = packet.readInt16();
   }
-  if (this.fieldCount === null) {
-    this.infileName = packet.readString(undefined, encoding);
-  }
+  this.stateChanges = {
+    systemVariables: {},
+    schema: null,
+    // gtids: {},
+    trackStateChange: null
+  };
 
-  // issue#288: Add changedRow if exists, reference to https://github.com/sidorares/node-mysql2/issues/288
-  if (encoding) {
-    var message = packet.readString(undefined, encoding);
-    var m = message.match(/\schanged:\s*(\d+)/i);
-    if (m !== null) {
-      this.changedRows = parseInt(m[1], 10);
+  if (isSet('SESSION_TRACK') && packet.offset < packet.end) {
+    this.info = packet.readLengthCodedString(encoding);
+    if (this.serverStatus && ServerSatusFlags.SERVER_SESSION_STATE_CHANGED) {
+
+      // session change info record - see
+      // https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html#cs-sect-packet-ok-sessioninfo
+
+      var len = packet.offset < packet.end ? packet.readLengthCodedNumber() : 0;
+      var end = packet.offset + len;
+      var type, len, key, stateEnd;
+
+      while (packet.offset < end) {
+        type = packet.readInt8();
+        len = packet.readLengthCodedNumber();
+        stateEnd = packet.offset + len;
+        key = packet.readLengthCodedString(encoding);
+        if (type === 0) {
+          var val = packet.readLengthCodedString(encoding);
+          this.stateChanges.systemVariables[key] = val;
+        } else if (type === 1) {
+          // TODO double check it's supposed to be the only value, not a list.
+          this.stateChanges.schema = key;
+        } else if (type === 2) {
+          this.stateChanges.trackStateChange = packet.readLengthCodedString(encoding);
+        } else {
+          // GTIDs (type == 3) or unknown type - just skip for now
+        }
+        debugger;
+        packet.offset = stateEnd;
+      }
     }
+  } else {
+    this.info = packet.readString(undefined, encoding);
   }
 
-  // snippet from mysql-native:
-  // res.affected_rows = this.lcnum();
-  // res.insert_id = this.lcnum();
-  // res.server_status = this.num(2);
-  // res.warning_count = this.num(2);
-
-  // TODO: extra
+  var m = this.info.match(/\schanged:\s*(\d+)/i);
+  if (m !== null) {
+    this.changedRows = parseInt(m[1], 10);
+  }
 }
 
 // TODO: should be consistent instance member, but it's just easier here to have just function

--- a/test/integration/connection/test-binary-multiple-results.js
+++ b/test/integration/connection/test-binary-multiple-results.js
@@ -13,7 +13,8 @@ var rs1 = {
   fieldCount: 0,
   insertId: 0,
   serverStatus: 10,
-  warningStatus: 0
+  warningStatus: 0,
+  info: ''
 };
 var rs2 = clone(rs1);
 rs2.serverStatus = 2;

--- a/test/integration/connection/test-multiple-results.js
+++ b/test/integration/connection/test-multiple-results.js
@@ -13,7 +13,8 @@ var rs1 = {
   fieldCount: 0,
   insertId: 0,
   serverStatus: 10,
-  warningStatus: 0
+  warningStatus: 0,
+  info: ''
 };
 var rs2 = clone(rs1);
 rs2.serverStatus = 2;

--- a/test/integration/connection/test-track-state-change.js
+++ b/test/integration/connection/test-track-state-change.js
@@ -6,8 +6,8 @@ var result1, resul2;
 
 
 connection.query('SET NAMES koi8r', function (err, _ok) {
-   assert.ifError(err);
-   result1 = _ok;
+  assert.ifError(err);
+  result1 = _ok;
 });
 
 connection.query('USE mysql', function (err, _ok) {

--- a/test/integration/connection/test-track-state-change.js
+++ b/test/integration/connection/test-track-state-change.js
@@ -1,0 +1,26 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var result1, resul2;
+
+
+connection.query('SET NAMES koi8r', function (err, _ok) {
+   assert.ifError(err);
+   result1 = _ok;
+});
+
+connection.query('USE mysql', function (err, _ok) {
+  assert.ifError(err);
+  result2 = _ok;
+  connection.end();
+});
+
+process.on('exit', function () {
+  assert.deepEqual(result1.stateChanges.systemVariables, {
+    character_set_connection: 'koi8r',
+    character_set_client: 'koi8r',
+    character_set_results: 'koi8r'
+  });
+  assert.deepEqual(result2.stateChanges.schema, 'mysql');
+});


### PR DESCRIPTION
see #388

Going to be used to implement #389 

implemented deserealizing of 'session change info' structure in OK packet - https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html#cs-sect-packet-ok-sessioninfo

The structure returns list of updated system variables, name of new database (if changed) and list of GTIDs (not implemented yet)

The API is open for discussion, I suggest consider it internal initially and not document (so that this change might go into patch release)