### PR TITLE
Using Denque

### DIFF
--- a/benchmarks/unit/packets/column_definition.js
+++ b/benchmarks/unit/packets/column_definition.js
@@ -6,10 +6,10 @@ var fixtureFile = __dirname + '/../fixtures/column_definition';
 function prepareFixture() {
   var Packets = require('../../../lib/packets/index.js');
   var packetInd = 0;
-  Packets.ColumnDefinition = function(packet) {
+  Packets.ColumnDefinition = function(packet, clientEncoding) {
     fs.writeFileSync(fixtureFile + packetInd, packet.buffer.slice(packet.start, packet.end));
     packetInd++;
-    var c = new ColumnDefinition(packet);
+    var c = new ColumnDefinition(packet, clientEncoding);
     //console.log('packet', c);
     return c;
   };
@@ -38,7 +38,7 @@ function bench(done) {
   for (var i=0; i < repeats; ++i) {
     for (var j=0; j < npackets; ++j) {
       packets[j].offset = 0;
-      c =new ColumnDefinition(packets[j]);
+      c =new ColumnDefinition(packets[j], 'utf8');
     }
   }
   done();

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -3,7 +3,7 @@ var util = require('util');
 var Tls = require('tls');
 var Timers = require('timers');
 var EventEmitter = require('events').EventEmitter;
-var Queue = require('double-ended-queue');
+var Queue = require('denque');
 var SqlString = require('sqlstring');
 var LRU = require('lru-cache');
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -3,7 +3,7 @@ var mysql = require('../index.js');
 var EventEmitter = require('events').EventEmitter;
 var Util = require('util');
 var PoolConnection = require('./pool_connection.js');
-var Queue = require('double-ended-queue');
+var Queue = require('denque');
 var Connection = require('./connection.js');
 
 module.exports = Pool;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "dependencies": {
     "cardinal": "1.0.0",
-    "double-ended-queue": "2.1.0-0",
+    "denque": "^1.1.0",
     "generate-function": "^2.0.0",
     "iconv-lite": "^0.4.13",
     "long": "^3.2.0",


### PR DESCRIPTION
There is good performance increase as per the benchmarks

**With Denque**

```
packet_parser.execute() toSpeed() 17463.53125 24954.22432172604
           = 44900000000 ±64200000000 packets/second
read 43 column definitions (select * from mysql.user) x 10000: 342000000  ±15000000
           = 1260000 ±60000 columns/second
read 5 chars strings from 10000 bytes buffer x 10000: 1664000000  ±8300000
           = 300500000 ±1500000 chars/second
```

**Master**

```
packet_parser.execute() toSpeed() 23182.71875 25260.35895211405
           = 33900000000 ±36900000000 packets/second
read 43 column definitions (select * from mysql.user) x 10000: 374600000  ±4300000
           = 1150000 ±10000 columns/second
Slower then prev result: 1258983.2138447813 ±columns/second %s
read 5 chars strings from 10000 bytes buffer x 10000: 1989000000  ±44000000
           = 251400000 ±5500000 chars/second
Slower then prev result: 300484564.14630795 ±chars/second %s
```