### PR TITLE
feat: make end resume command queue (partial #450)

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -803,6 +803,10 @@ Connection.prototype.serverHandshake = function serverHandshake (args) {
 Connection.prototype.end = function (callback) {
   var connection = this;
 
+  if (this._paused === true) {
+    this.resume();
+  }
+
   if (this.config.isServer) {
     connection._closing = true;
     var quitCmd = new EventEmitter();


### PR DESCRIPTION
Enable `end` method to finish the command queue.