### PR TITLE
fix pool connection never be released with promised pool.execute

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -99,11 +99,7 @@ function createPool (opts) {
     execute: function (sql, args) {
       return new Promise(function (resolve, reject) {
         var done = makeDoneCb(resolve, reject);
-        if (args) {
-          corePool.execute(sql, args, done);
-        } else {
-          corePool.execute(sql, done);
-        }
+        corePool.execute(sql, args, done);
       });
     },
 


### PR DESCRIPTION
In `pool.js`:
```javascript
Pool.prototype.execute = function (sql, values, cb) {
  var useNamedPlaceholders = this.config.connectionConfig.namedPlaceholders;

  this.getConnection(function (err, conn) {
    if (err) {
      return cb(err);
    }

    conn.config.namedPlaceholders = useNamedPlaceholders;
    return conn.execute(sql, values, function () {
      conn.release();
      cb.apply(this, arguments);
    });
  });
};
```

`Pool.prototype.execute` expects that third argument must be callback function. 
but, In `promise.js` they can invoke `Pool.prototype.execute` with only two arguments. then the callback will be disappeared.
and `Pool.prototype.execute` will never release connection. and all pool connections will be hang.
so I make third parameter always be a callback function. and it seems it's fixed.
