### PR TITLE
Fix for `TypeError: Cannot read property 'toString' of undefined` when missing a named parameter

### DIFF
--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -32,7 +32,7 @@ Execute.prototype.toPacket = function ()
     length += 2 * this.parameters.length;  // type byte for each parameter if new-params-bound-flag is set
     for (i = 0; i < this.parameters.length; i++)
     {
-      if (this.parameters[i] !== null) {
+      if (this.parameters[i] !== null && this.parameters[i] !== undefined) {
         if (Object.prototype.toString.call(this.parameters[i]) == '[object Date]') {
           var d = this.parameters[i];
           // TODO: move to asMysqlDateTime()
@@ -95,7 +95,7 @@ Execute.prototype.toPacket = function ()
 
     for (i = 0; i < this.parameters.length; i++)
     {
-      if (this.parameters[i] !== null) {
+      if (this.parameters[i] !== null && this.parameters[i] !== undefined) {
         if (Buffer.isBuffer(this.parameters[i])) {
           packet.writeLengthCodedBuffer(this.parameters[i]);
         } else {


### PR DESCRIPTION
This addresses an exception that occurs when using namedParameters if the named param is missing from the values object. The code hits `this.parameters[i].toString()` and throws up because `this.parameters[i]` is undefined.

Sorry I don't have a test for it, I fixed it directly in my installed dependency. Prior to the change I couldn't even tell what query was causing the error. After the change I get a proper ER_WRONG_ARGUMENTS error out of the query and was able to trace it back to the offending code.