### PR TITLE
Fix #485, Connection not released when Pool.Execute called without values

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -579,7 +579,7 @@ Connection.prototype.execute = function execute (sql, values, cb) {
     if (typeof values === 'function') {
       cb = values;
     } else {
-      options.values = values;
+      options.values = options.values || values;
     }
   } else if (typeof values === 'function') {
     // execute(sql, cb)

--- a/promise.js
+++ b/promise.js
@@ -96,14 +96,9 @@ function createPool (opts) {
       });
     },
 
-    execute: function (sql, args) {
+    execute: function (sql, values) {
       return new Promise(function (resolve, reject) {
-        var done = makeDoneCb(resolve, reject);
-        if (args) {
-          corePool.execute(sql, args, done);
-        } else {
-          corePool.execute(sql, done);
-        }
+        corePool.execute(sql, values, makeDoneCb(resolve, reject));
       });
     },
 

--- a/test/integration/regressions/test-#485.js
+++ b/test/integration/regressions/test-#485.js
@@ -12,11 +12,10 @@ var createPool = require('../../../promise.js').createPool;
 var PoolConnection = require('../../../lib/pool_connection.js');
 
 // stub
-var release = PoolConnection.prototype.release.bind(PoolConnection.prototype);
+var release = PoolConnection.prototype.release;
 var releaseCalls = 0;
 PoolConnection.prototype.release = function () {
   releaseCalls++;
-  release.call(this);
 };
 
 function testPoolPromiseExecuteLeak () {
@@ -36,7 +35,7 @@ function testPoolPromiseExecuteLeak () {
 testPoolPromiseExecuteLeak();
 
 process.on('exit', function () {
+  PoolConnection.prototype.release = release;
   if (skipTest) { return; }
-
   assert.equal(releaseCalls, 1, 'PoolConnection.release was not called');
 });

--- a/test/integration/regressions/test-#485.js
+++ b/test/integration/regressions/test-#485.js
@@ -1,0 +1,42 @@
+var config = require('../../common.js').config;
+
+var skipTest = false;
+if (typeof Promise == 'undefined') {
+  console.log('no Promise support, skipping test');
+  skipTest = true;
+  return;
+}
+
+var assert = require('assert');
+var createPool = require('../../../promise.js').createPool;
+var PoolConnection = require('../../../lib/pool_connection.js');
+
+// stub
+var release = PoolConnection.prototype.release.bind(PoolConnection.prototype);
+var releaseCalls = 0;
+PoolConnection.prototype.release = function () {
+  releaseCalls++;
+  release.call(this);
+};
+
+function testPoolPromiseExecuteLeak () {
+  var pool = createPool(config);
+  var conn = null;
+  pool
+    .execute('select 1+2 as ttt')
+    .then(function (result) {
+      assert.equal(result[0][0].ttt, 3);
+      return pool.end();
+    })
+    .catch(function (err) {
+      assert.ifError(err);
+    });
+}
+
+testPoolPromiseExecuteLeak();
+
+process.on('exit', function () {
+  if (skipTest) { return; }
+
+  assert.equal(releaseCalls, 1, 'PoolConnection.release was not called');
+});


### PR DESCRIPTION
Fix #485  (Main discussion)
Closes #475 (Past attempt solving this same issue)

**Changes** 
- Directly pass arguments to `execute`
- Added a test which will fail if execute dont release connection properly.
- Fixed options parser which could have failed for `execute(object, undefined, func)`