### PR TITLE
fix #495 : PromiseConnection missing interface functions from Connection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+1.2.0 ( 17/02/2017 )
+ - add new MySQL 5.6/8.0 charsets                        #494
+ - build: drop support for node 0.10 and 0.12
+ - fix: Connection not released when Pool.Execute 
+   called without values                                 #509, #485, #488, #475
+
 1.1.2 ( 15/11/2016 )
  - (fix) memory leak introduced with iconv
    encoder/decoder cache                                 #459, #458

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ If you find any incompatibility with [Node MySQL][node-mysql], Please report via
 
 ## Documentation
 
-You can find more detailed documentation [here](https://github.com/sidorares/node-mysql2/tree/master/documentation). You should also check various code [examples](https://github.com/sidorares/node-mysql2/tree/master/examples) to understand advance concepts.
+You can find more detailed documentation [here](https://github.com/sidorares/node-mysql2/tree/master/documentation). You should also check various code [examples](https://github.com/sidorares/node-mysql2/tree/master/examples) to understand advanced concepts.
 
 ## Acknowledgements
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sqlstring": "^2.2.0"
   },
   "devDependencies": {
-    "assert-diff": "^1.0.1",
+    "assert-diff": "^1.1.1",
     "eslint": "3.17.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "cardinal": "1.0.0",
-    "denque": "^1.1.0",
+    "denque": "^1.1.1",
     "generate-function": "^2.0.0",
     "iconv-lite": "^0.4.13",
     "long": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lru-cache": "^4.0.1",
     "named-placeholders": "1.1.1",
     "object-assign": "^4.1.1",
-    "readable-stream": "2.2.5",
+    "readable-stream": "2.2.6",
     "safe-buffer": "^5.0.1",
     "seq-queue": "0.0.5",
     "sqlstring": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",
-    "eslint": "3.14.1",
+    "eslint": "3.15.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",
     "portfinder": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "assert-diff": "^1.0.1",
     "eslint": "3.13.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
-    "husky": "^0.12.0",
+    "husky": "^0.13.0",
     "portfinder": "^1.0.10",
     "progress": "1.1.8",
     "urun": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lru-cache": "^4.0.1",
     "named-placeholders": "1.1.1",
     "object-assign": "^4.1.1",
-    "readable-stream": "2.2.3",
+    "readable-stream": "2.2.4",
     "safe-buffer": "^5.0.1",
     "seq-queue": "0.0.5",
     "sqlstring": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",
-    "eslint": "3.16.0",
+    "eslint": "3.16.1",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",
     "portfinder": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "sqlstring": "^2.2.0"
   },
   "devDependencies": {
-    "assert-diff": "^1.1.1",
+    "assert-diff": "^1.2.0",
     "eslint": "3.17.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",
-    "eslint": "3.13.0",
+    "eslint": "3.14.1",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",
     "portfinder": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "assert-diff": "^1.2.0",
-    "eslint": "3.17.0",
+    "eslint": "3.18.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",
     "portfinder": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lru-cache": "^4.0.1",
     "named-placeholders": "1.1.1",
     "object-assign": "^4.1.1",
-    "readable-stream": "2.2.2",
+    "readable-stream": "2.2.3",
     "safe-buffer": "^5.0.1",
     "seq-queue": "0.0.5",
     "sqlstring": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql2",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "fast mysql driver. Implements core protocol, prepared statements, ssl and compression in native JS",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lru-cache": "^4.0.1",
     "named-placeholders": "1.1.1",
     "object-assign": "^4.1.1",
-    "readable-stream": "2.2.4",
+    "readable-stream": "2.2.5",
     "safe-buffer": "^5.0.1",
     "seq-queue": "0.0.5",
     "sqlstring": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",
-    "eslint": "3.16.1",
+    "eslint": "3.17.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",
     "portfinder": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "assert-diff": "^1.2.0",
     "eslint": "3.18.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
-    "husky": "^0.13.0",
+    "husky": "^0.13.3",
     "portfinder": "^1.0.10",
     "progress": "1.1.8",
     "urun": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "assert-diff": "^1.0.1",
-    "eslint": "3.15.0",
+    "eslint": "3.16.0",
     "eslint-plugin-markdown": "^1.0.0-beta.2",
     "husky": "^0.13.0",
     "portfinder": "^1.0.10",

--- a/promise.js
+++ b/promise.js
@@ -153,22 +153,16 @@ PromiseConnection.prototype.prepare = function () {
 
 })([
 // synchronous functions
-  'addCommand',
   'close',
   'createBinlogStream',
   'destroy',
   'escape',
   'escapeId',
   'format',
-  'handlePacket',
-  'keyFromFields',
   'pause',
   'pipe',
-  'protocolError',
   'resume',
-  'serverHandshake',
-  'unprepare',
-  'write'
+  'unprepare'
 ]);
 
 

--- a/promise.js
+++ b/promise.js
@@ -68,6 +68,27 @@ PromiseConnection.prototype.end = function () {
   });
 };
 
+// patching PromiseConnection
+// create facade functions for prototype functions on "Connection" that are not yet
+// implemented with PromiseConnection
+for (var func in core.Connection.prototype) {
+
+  // omit private functions starting with "_"
+  if (
+    func[0] !== '_'
+    && typeof core.Connection.prototype[func] === 'function'
+    && PromiseConnection.prototype[func] === undefined
+  ) {
+    PromiseConnection.prototype[func] = (function factory (funcName, connection) {
+      return function () {
+        return core.Connection
+          .prototype[funcName].apply(this.connection, arguments);
+      };
+    }(func));
+  }
+}
+
+
 function createPool (opts) {
   var corePool = core.createPool(opts);
   var Promise = opts.Promise || global.Promise || require('es6-promise');


### PR DESCRIPTION
`PromiseConnection` was missing some functions `Connection` implements.
Hence it was unable to use the `Promise` wrapped connection like
the "real" connection.

This commit patches `PromiseConnection` and creates a facade
function for all functions that are missing from `PromiseConnection`
prototype.

fixes #495 