### PR TITLE
Fix - release the connection if there is and error in the query

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -137,6 +137,8 @@ Pool.prototype.query = function (sql, values, cb) {
       } else {
         cmdQuery.emit('error', err);
       }
+      cmdQuery.emit('end', err);
+
       return;
     }
 


### PR DESCRIPTION
Currently when we use `pool.query` and the query returns an error, the connection is not released from the pool.

This fix will release the connection from the pool even if there was an error in the query.