### PR TITLE
Don't try to write undefined parameters.

### DIFF
--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -32,7 +32,7 @@ Execute.prototype.toPacket = function ()
     length += 2 * this.parameters.length;  // type byte for each parameter if new-params-bound-flag is set
     for (i = 0; i < this.parameters.length; i++)
     {
-      if (this.parameters[i] !== null) {
+      if (this.parameters[i] !== null && this.parameters[i] !== undefined) {
         if (Object.prototype.toString.call(this.parameters[i]) == '[object Date]') {
           var d = this.parameters[i];
           // TODO: move to asMysqlDateTime()
@@ -95,7 +95,7 @@ Execute.prototype.toPacket = function ()
 
     for (i = 0; i < this.parameters.length; i++)
     {
-      if (this.parameters[i] !== null) {
+      if (this.parameters[i] !== null && this.parameters[i] !== undefined) {
         if (Buffer.isBuffer(this.parameters[i])) {
           packet.writeLengthCodedBuffer(this.parameters[i]);
         } else {


### PR DESCRIPTION
This is a re-submission of @ChiperSoft's fix, as [requested](https://github.com/sidorares/node-mysql2/pull/480#issuecomment-277293179) by @sushantdhiman: 

> This addresses an exception that occurs when using namedParameters if the named param is missing from the values object. The code hits `this.parameters[i].toString()` and throws up because `this.parameters[i]` is undefined.