### PR TITLE
fix: PromiseConnection missing interface functions from Connection

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -68,6 +68,104 @@ PromiseConnection.prototype.end = function () {
   });
 };
 
+PromiseConnection.prototype.beginTransaction = function () {
+  var c = this.connection;
+  return new this.Promise(function (resolve, reject) {
+    var done = makeDoneCb(resolve, reject);
+    c.beginTransaction(done);
+  });
+};
+
+PromiseConnection.prototype.commit = function () {
+  var c = this.connection;
+  return new this.Promise(function (resolve, reject) {
+    var done = makeDoneCb(resolve, reject);
+    c.commit(done);
+  });
+};
+
+PromiseConnection.prototype.rollback = function () {
+  var c = this.connection;
+  return new this.Promise(function (resolve, reject) {
+    var done = makeDoneCb(resolve, reject);
+    c.rollback(done);
+  });
+};
+
+PromiseConnection.prototype.ping = function () {
+  var c = this.connection;
+  return new this.Promise(function (resolve, reject) {
+    c.ping(resolve);
+  });
+};
+
+PromiseConnection.prototype.connect = function () {
+  var c = this.connection;
+  return new this.Promise(function (resolve, reject) {
+    c.connect(function (error, param) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(param);
+      }
+    });
+  });
+};
+
+PromiseConnection.prototype.prepare = function () {
+  var c = this.connection;
+  return new this.Promise(function (resolve, reject) {
+    c.prepare(function (error, statement) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(statement);
+      }
+    });
+  });
+};
+
+// note: the callback of "changeUser" is not called on success
+// hence there is no possibility to call "resolve"
+
+// patching PromiseConnection
+// create facade functions for prototype functions on "Connection" that are not yet
+// implemented with PromiseConnection
+
+// proxy synchronous functions only
+(function (functionsToWrap) {
+
+  for (var i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
+    var func = functionsToWrap[i];
+
+    if (
+      typeof core.Connection.prototype[func] === 'function'
+      && PromiseConnection.prototype[func] === undefined
+    ) {
+      PromiseConnection.prototype[func] = (function factory (funcName) {
+        return function () {
+          return core.Connection
+            .prototype[funcName].apply(this.connection, arguments);
+        };
+      })(func);
+    }
+  }
+
+})([
+// synchronous functions
+  'close',
+  'createBinlogStream',
+  'destroy',
+  'escape',
+  'escapeId',
+  'format',
+  'pause',
+  'pipe',
+  'resume',
+  'unprepare'
+]);
+
+
 function createPool (opts) {
   var corePool = core.createPool(opts);
   var Promise = opts.Promise || global.Promise || require('es6-promise');


### PR DESCRIPTION
`PromiseConnection` was missing some functions `Connection` implements.
Hence it was unable to use the `Promise` wrapped connection like
the "real" connection.

This commit adds implementation for all missing asynchronous functions.
Additionally a whitelist is used to determine, which synchronous
functions are implementd by a facade function, passing the call to
the internally used connection instance.

fixes #495 , see pull request #496 