### PR TITLE
`packet.skip(23);` means 23 unsafe bytes leak over wire

### DIFF
--- a/lib/packets/handshake_response.js
+++ b/lib/packets/handshake_response.js
@@ -132,7 +132,7 @@ HandshakeResponse.prototype.toPacket = function ()
   }
   // dry run: calculate resulting packet length
   var p = this.serializeResponse(Packet.MockBuffer());
-  return this.serializeResponse(Buffer.allocUnsafe(p.offset));
+  return this.serializeResponse(Buffer.alloc(p.offset));
 };
 
 module.exports = HandshakeResponse;


### PR DESCRIPTION
you may discard if not that important :)