### PR TITLE
Make Promise Pool wrapper extend EventEmitter

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -33,7 +33,10 @@ function createConnection (opts) {
 function PromiseConnection (connection, promiseImpl) {
   this.connection = connection;
   this.Promise = promiseImpl;
+
+  inheritEvents(connection, this, ['error', 'drain', 'connect', 'end', 'enqueue']);
 }
+util.inherits(PromiseConnection, EventEmitter);
 
 PromiseConnection.prototype.release = function () {
   this.connection.release();

--- a/test/common.js
+++ b/test/common.js
@@ -56,25 +56,22 @@ module.exports.createConnection = function(args, callback) {
     // c.on('connect', function() {
     //
     // });
-    setTimeout(
-      function() {
-        console.log('altering client...');
-        c.oldQuery = c.query;
-        c.query = function(sql, callback) {
-          var rows = [];
-          var q = c.oldQuery(sql);
-          q.on('result', function(res) {
-            res.on('row', function(row) {
-              rows.push(row);
-            });
-            res.on('end', function() {
-              callback(null, rows);
-            });
+    setTimeout(function() {
+      console.log('altering client...');
+      c.oldQuery = c.query;
+      c.query = function(sql, callback) {
+        var rows = [];
+        var q = c.oldQuery(sql);
+        q.on('result', function(res) {
+          res.on('row', function(row) {
+            rows.push(row);
           });
-        };
-      },
-      1000
-    );
+          res.on('end', function() {
+            callback(null, rows);
+          });
+        });
+      };
+    }, 1000);
     return c;
   }
 

--- a/test/integration/test-promise-wrappers.js
+++ b/test/integration/test-promise-wrappers.js
@@ -21,7 +21,6 @@ var exceptionCaught = false;
 
 var doneCalledPool = false;
 var exceptionCaughtPool = false;
-
 var doneEventsPool = false;
 
 function testBasic() {


### PR DESCRIPTION
Fix #468

Introduce a new PromisePool constructor into promise.js. PromisePool
inherits from EventEmitter, and the following events are re-emitted
from the underlying Pool instance to it:
 - acquire
 - connection
 - enqueue
 - release

Methods like `on` can't just be bound to the Pool and added to the object as `this` would be
wrong in the callback: e.g. `this.query` wouldn't return a Promise.