### PR TITLE
Fix/pool release on error

### DIFF
--- a/lib/commands/command.js
+++ b/lib/commands/command.js
@@ -28,8 +28,10 @@ Command.prototype.execute = function(packet, connection) {
     var err = packet.asError(connection.clientEncoding);
     if (this.onResult) {
       this.onResult(err);
+      this.emit('end');
     } else {
       this.emit('error', err);
+      this.emit('end');
     }
     return true;
   }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -714,6 +714,7 @@ Connection.prototype.execute = function execute(sql, values, cb) {
       } else {
         executeCommand.emit('error', err);
       }
+      executeCommand.emit('end');
       return;
     }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -170,10 +170,9 @@ Pool.prototype.execute = function(sql, values, cb) {
       return cb(err);
     }
 
-    conn.config.namedPlaceholders = useNamedPlaceholders;
-    return conn.execute(sql, values, function() {
+    const executeCmd = conn.execute(sql, values, cb);
+    executeCmd.once('end', function() {
       conn.release();
-      cb.apply(this, arguments);
     });
   });
 };

--- a/test/integration/test-pool-release.js
+++ b/test/integration/test-pool-release.js
@@ -1,0 +1,35 @@
+var createPool = require('../common.js').createPool;
+var assert = require('assert');
+
+var pool = createPool();
+
+pool.query('test sql', function(err, res, rows) {
+  pool.query('test sql', [], function(err, res, rows) {
+    pool.query('test sql', [], function(err, res, rows) {
+      pool.query('test sql', [], function(err, res, rows) {
+        pool.query('test sql', function(err, res, rows) {
+          pool.query('test sql').on('error', function(err) {
+            pool.query('test sql', function(err, res, rows) {
+              pool.execute('test sql', function(err, res, rows) {
+                pool.execute('test sql', function(err, res, rows) {
+                  pool.execute('test sql', [], function(err, res, rows) {
+                    pool.execute('test sql', function(err) {
+                      pool.execute('test sql', function(err, res, rows) {
+                        // TODO change order events are fires so that connection is released before callback
+                        // that way this number will be more deterministic
+                        assert(pool._allConnections.length < 3);
+                        assert(pool._freeConnections.length === 1);
+                        assert(pool._connectionQueue.length === 0);
+                        pool.end();
+                      });
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
there was couple of issues preventing `pool.query` and `pool.execute` from releasing connection properly back to the pool

1) in case of error 'end' event was not fired
2) `execute(sql, cb)` treated as `execute(sql, params, undefined)`

this pr fixes that + adds simple integration test