### PR TITLE
Safe buffer fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     env: LINT=0
   - node_js: "7.10"
     env: LINT=0
-  - node_js: "8.10"
+  - node_js: "8.0"
     env: LINT=1
 
 cache:
@@ -26,7 +26,8 @@ notifications:
   email: false
 
 script:
-  - docker run -d --name mysql -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=test -p 33306:3306 mysql:5.7
+  - nvm ls-remote
+  - docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=test -p 33306:3306 mysql:5.7
   - MYSQL_PORT=33306 node tools/wait-up.js
   - node --version
   - yarn --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
   - node_js: "6.10"
     env: LINT=0
   - node_js: "7.10"
-    env: LINT=0
-  - node_js: "8.0"
     env: LINT=1
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   - node_js: "6.10"
     env: LINT=0
   - node_js: "7.10"
+    env: LINT=0
+  - node_js: "8.10"
     env: LINT=1
 
 cache:

--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -1,21 +1,8 @@
+var Buffer = require('safe-buffer').Buffer;
 var Iconv = require('iconv-lite');
 
-var NODE_ENCODING = [
-  'ascii',
-  'utf8',
-  'utf16le',
-  'ucs2',
-  'base64',
-  'latin1',
-  'binary',
-  'hex'
-].reduce(function (map, item) {
-  map[item] = Buffer.isEncoding(item);
-  return map;
-}, {});
-
 exports.decode = function(buffer, encoding, options) {
-  if (NODE_ENCODING[encoding]) {
+  if (Buffer.isEncoding(encoding)) {
     return buffer.toString(encoding);
   }
 
@@ -28,7 +15,7 @@ exports.decode = function(buffer, encoding, options) {
 };
 
 exports.encode = function(string, encoding, options) {
-  if (NODE_ENCODING[encoding]) {
+  if (Buffer.isEncoding(encoding)) {
     return Buffer.from(string, encoding);
   }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -165,6 +165,13 @@ Pool.prototype.query = function(sql, values, cb) {
 Pool.prototype.execute = function(sql, values, cb) {
   var useNamedPlaceholders = this.config.connectionConfig.namedPlaceholders;
 
+  // TODO construct execute command first here and pass it to connection.execute
+  // so that polymorphic arguments logic is there in one place
+  if (typeof values == 'function') {
+    cb = values;
+    values = [];
+  }
+
   this.getConnection(function(err, conn) {
     if (err) {
       return cb(err);

--- a/test/common.js
+++ b/test/common.js
@@ -11,7 +11,7 @@ module.exports.SqlString = require('sqlstring');
 module.exports.config = config;
 
 module.exports.waitDatabaseReady = function(callback) {
-  const tryConnect = () => {
+  const tryConnect = function() {
     const conn = module.exports.createConnection();
     conn.on('error', function(err) {
       console.log(err);

--- a/test/integration/connection/encoding/test-non-bmp-chars.js
+++ b/test/integration/connection/encoding/test-non-bmp-chars.js
@@ -7,6 +7,7 @@ var pileOfPoo = '💩';
 
 var connection = common.createConnection({ charset: 'UTF8_GENERAL_CI' });
 connection.query('select "💩"', function(err, rows, fields) {
+  assert.ifError(err);
   assert.equal(fields[0].name, pileOfPoo);
   assert.equal(rows[0][fields[0].name], pileOfPoo);
   connection.end();
@@ -14,6 +15,7 @@ connection.query('select "💩"', function(err, rows, fields) {
 
 var connection2 = common.createConnection({ charset: 'UTF8MB4_GENERAL_CI' });
 connection2.query('select "💩"', function(err, rows, fields) {
+  assert.ifError(err);
   assert.equal(fields[0].name, '?');
   assert.equal(rows[0]['?'], pileOfPoo);
   connection2.end();

--- a/test/integration/test-pool-release.js
+++ b/test/integration/test-pool-release.js
@@ -15,6 +15,7 @@ pool.query('test sql', function(err, res, rows) {
                   pool.execute('test sql', [], function(err, res, rows) {
                     pool.execute('test sql', function(err) {
                       pool.execute('test sql', function(err, res, rows) {
+                        assert.ifError(err);
                         // TODO change order events are fires so that connection is released before callback
                         // that way this number will be more deterministic
                         assert(pool._allConnections.length < 3);

--- a/test/integration/test-pool-release.js
+++ b/test/integration/test-pool-release.js
@@ -15,7 +15,6 @@ pool.query('test sql', function(err, res, rows) {
                   pool.execute('test sql', [], function(err, res, rows) {
                     pool.execute('test sql', function(err) {
                       pool.execute('test sql', function(err, res, rows) {
-                        assert.ifError(err);
                         // TODO change order events are fires so that connection is released before callback
                         // that way this number will be more deterministic
                         assert(pool._allConnections.length < 3);

--- a/test/run.js
+++ b/test/run.js
@@ -13,15 +13,14 @@ process.env.TZ = 'UTC';
 
 require('urun')(__dirname, options);
 
-
-process.on('exit', (code) => {
-  console.log(`About to exit with code: ${code}`);
+process.on('exit', function(code) {
+  console.log('About to exit with code: ' + code);
 });
 
-process.on('unhandledRejection', (reason) => {
+process.on('unhandledRejection', function(reason) {
   console.log('unhandledRejection', reason);
 });
 
-process.on('uncaughtException', (err) => {
+process.on('uncaughtException', function(err) {
   console.log('uncaughtException', err);
 });


### PR DESCRIPTION
- use safe-buffer in string decoder #585 
- make tests run in node 0.10
- make pool.execute() work without parameters 