### PR TITLE
Fix crash when first packet from server is error packet 

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -180,7 +180,6 @@ Connection.prototype._handleFatalError = function(err) {
 };
 
 Connection.prototype._handleNetworkError = function(err) {
-  console.log('_handleNetworkError AAAAA NETWORK ERROR');
   this._handleFatalError(err);
 };
 
@@ -807,6 +806,10 @@ Connection.prototype.destroy = function() {
 };
 
 Connection.prototype.close = function() {
+  if (this.connectTimeout) {
+    Timers.clearTimeout(this.connectTimeout);
+    this.connectTimeout = null;
+  }
   this._closing = true;
   this.stream.end();
   var connection = this;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -87,7 +87,7 @@ function Connection(opts) {
 
   this.clientEncoding = CharsetToEncoding[this.config.charsetNumber];
 
-  this.stream.once('error', connection._handleNetworkError.bind(this));
+  this.stream.on('error', connection._handleNetworkError.bind(this));
 
   // see https://gist.github.com/khoomeister/4985691#use-that-instead-of-bind
   this.packetParser = new PacketParser(function(p) {
@@ -123,11 +123,17 @@ function Connection(opts) {
   if (!this.config.isServer) {
     handshakeCommand = new Commands.ClientHandshake(this.config.clientFlags);
     handshakeCommand.on('end', function() {
+      // this happens when handshake finishes early and first packet is error
+      // and not server hello ( for example, 'Too many connactions' error)
+      if (!handshakeCommand.handshake) {
+        return;
+      }
       connection._handshakePacket = handshakeCommand.handshake;
       connection.threadId = handshakeCommand.handshake.connectionId;
       connection.emit('connect', handshakeCommand.handshake);
     });
     handshakeCommand.on('error', function(err) {
+      connection._closing = true;
       connection._notifyError(err);
     });
     this.addCommand(handshakeCommand);
@@ -174,6 +180,7 @@ Connection.prototype._handleFatalError = function(err) {
 };
 
 Connection.prototype._handleNetworkError = function(err) {
+  console.log('_handleNetworkError AAAAA NETWORK ERROR');
   this._handleFatalError(err);
 };
 
@@ -212,7 +219,16 @@ Connection.prototype._notifyError = function(err) {
     connection._command.onResult(err);
     connection._command = null;
   } else {
-    bubbleErrorToConnection = true;
+    // connection handshake is special because we allow it to be implicit
+    // if error happened during handshake, but there are others commands in queue
+    // then bubble error to other commands and not to connection
+    if (
+      !(connection._command &&
+        connection._command.constructor == Commands.ClientHandshake &&
+        connection._commands.length > 0)
+    ) {
+      bubbleErrorToConnection = true;
+    }
   }
   while ((command = connection._commands.shift())) {
     if (command.onResult) {
@@ -900,7 +916,7 @@ Connection.prototype.writeOk = function(args) {
 Connection.prototype.writeError = function(args) {
   // if we want to send error before initial hello was sent, use default encoding
   var encoding = this.serverConfig ? this.serverConfig.encoding : 'cesu8';
-  this.writePacket(Packets.Error.toPacket(args, this.serverConfig.encoding));
+  this.writePacket(Packets.Error.toPacket(args, encoding));
 };
 
 Connection.prototype.serverHandshake = function serverHandshake(args) {

--- a/test/integration/connection/test-connect-time-error.js
+++ b/test/integration/connection/test-connect-time-error.js
@@ -25,13 +25,10 @@ portfinder.getPort(function(err, port) {
   });
 
   connection.query('select 1+1', function(err) {
-    console.log('Here! 1');
-    console.log(err);
     assert.equal(err.message, ERROR_TEXT);
   });
 
   connection.query('select 1+2', function(err) {
-    console.log('Here! 2');
     assert.equal(err.message, ERROR_TEXT);
     connection.close();
     server._server.close();

--- a/test/integration/connection/test-connect-time-error.js
+++ b/test/integration/connection/test-connect-time-error.js
@@ -1,0 +1,39 @@
+var mysql = require('../../../index.js');
+var assert = require('assert');
+var Buffer = require('safe-buffer').Buffer;
+
+var server;
+
+const ERROR_TEXT = 'test error';
+
+var portfinder = require('portfinder');
+portfinder.getPort(function(err, port) {
+  var server = mysql.createServer();
+  server.listen(port);
+  server.on('connection', function(conn) {
+    console.log('Here!');
+    conn.writeError(new Error(ERROR_TEXT));
+    conn.close();
+  });
+
+  var connection = mysql.createConnection({
+    host: 'localhost',
+    port: port,
+    user: 'testuser',
+    database: 'testdatabase',
+    password: 'testpassword'
+  });
+
+  connection.query('select 1+1', function(err) {
+    console.log('Here! 1');
+    console.log(err);
+    assert.equal(err.message, ERROR_TEXT);
+  });
+
+  connection.query('select 1+2', function(err) {
+    console.log('Here! 2');
+    assert.equal(err.message, ERROR_TEXT);
+    connection.close();
+    server._server.close();
+  });
+});


### PR DESCRIPTION
this fixes a problem when client connection receives error packet as first packet instead of 'start handshake' packet. This can happen, for example, when number of opened connections is at max_connections. This is different from auth error response packet ( which arrives after 'handshake response' )

The problem itself is side effect of [todo: insert link here. pr where query object returned from pool.query gets 'end' event]

thanks @calebeaires for showing error in https://github.com/sidorares/node-mysql2/issues/606#issuecomment-314084053 