### PR TITLE
redo event delegation in promise wrappers to be lazy, self-cleaning

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -3,13 +3,21 @@ var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
 function inheritEvents(source, target, events) {
-  events.forEach(function(eventName) {
-    source.on(eventName, function() {
-      var args = [].slice.call(arguments);
-      args.unshift(eventName);
+  var listeners = {};
+  target.on('newListener', function(eventName) {
+    if (events.indexOf(eventName) >= 0 && !target.listenerCount(eventName)) {
+      source.on(eventName, listeners[eventName] = function() {
+        var args = [].slice.call(arguments);
+        args.unshift(eventName);
 
-      target.emit.apply(target, args);
-    });
+        target.emit.apply(target, args);
+      });
+    }
+  }).on('removeListener', function(eventName) {
+    if (events.indexOf(eventName) >= 0 && !target.listenerCount(eventName)) {
+      source.removeListener(eventName, listeners[eventName]);
+      delete listeners[eventName];
+    }
   });
 }
 


### PR DESCRIPTION
fix sidorares/node-mysql2#577

---

I saw that #577 already had a fix in #578, but you seemed to have some concerns about that solution that I think I share, and I'm eager to see a fix for this issue actually land. So here's what I think the fix should be: it's fully lazy, so no event listeners get added to the wrapped object until one is added to the wrapper, and it removes those listeners as early as possible.