### PR TITLE
Fix handling of errors in promise prepared statement execute

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -213,8 +213,9 @@ function PromisePreparedStatementInfo(statement, promiseImpl) {
 
 PromisePreparedStatementInfo.prototype.execute = function(parameters) {
   var s = this.statement;
+  var localErr = new Error()
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject);
+    var done = makeDoneCb(resolve, reject, localErr);
     if (parameters) {
       s.execute(parameters, done);
     } else {


### PR DESCRIPTION
If an error occurs during execution of a promisifed prepared statement, instead of receiving the real error you are presented with:
```
  TypeError: Cannot set property 'message' of undefined
      at Execute.onResult (/Users/tom/dev/src/github.com/tsholmes/node-mysql2/promise.js:72:24)
      at Execute.Command.execute (/Users/tom/dev/src/github.com/tsholmes/node-mysql2/lib/commands/command.js:30:12)
      at Connection.handlePacket (/Users/tom/dev/src/github.com/tsholmes/node-mysql2/lib/connection.js:515:28)
      at PacketParser.onPacket (/Users/tom/dev/src/github.com/tsholmes/node-mysql2/lib/connection.js:94:16)
      at PacketParser.executeStart (/Users/tom/dev/src/github.com/tsholmes/node-mysql2/lib/packet_parser.js:77:14)
      at Socket.<anonymous> (/Users/tom/dev/src/github.com/tsholmes/node-mysql2/lib/connection.js:102:29)
      at emitOne (events.js:115:13)
      at Socket.emit (events.js:210:7)
      at addChunk (_stream_readable.js:250:12)
      at readableAddChunk (_stream_readable.js:237:11)
```

This properly passes a local error to `makeDoneCb` so errors are properly passed as part of the promise rejection.