### PR TITLE
correctly parse microsecond in datetime type

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -253,7 +253,7 @@ Packet.prototype.readDateTime = function() {
     S = this.readInt8();
   }
   if (length > 10) {
-    ms = this.readInt32();
+    ms = this.readInt32() / 1000;
   }
   if (y + m + d + H + M + S + ms === 0) {
     return INVALID_DATE;

--- a/test/integration/regressions/test-#629.js
+++ b/test/integration/regressions/test-#629.js
@@ -1,0 +1,90 @@
+var common = require('../../common');
+var connection = common.createConnection({ dateStrings: false });
+var assert = require('assert');
+
+var tableName = 'dates';
+var testFields = ['id', 'date1', 'date2', 'name'];
+var testRows = [
+  [1, '2017-07-26 09:36:42.000', '2017-07-29 09:22:24.000', 'John'],
+  [2, '2017-07-26 09:36:42.123', '2017-07-29 09:22:24.321', 'Jane']
+];
+var expected = [
+  {
+    id: 1,
+    date1: new Date('2017-07-26T09:36:42.000Z'),
+    date2: new Date('2017-07-29T09:22:24.000Z'),
+    name: 'John'
+  },
+  {
+    id: 2,
+    date1: new Date('2017-07-26T09:36:42.123Z'),
+    date2: new Date('2017-07-29T09:22:24.321Z'),
+    name: 'Jane'
+  }
+];
+
+var actualRows = null;
+
+connection.query(
+  [
+    'CREATE TEMPORARY TABLE `' + tableName + '` (',
+    ' `' + testFields[0] + '` int,',
+    ' `' + testFields[1] + '` TIMESTAMP(3),',
+    ' `' + testFields[2] + '` DATETIME(3),',
+    ' `' + testFields[3] + '` varchar(10)',
+    ') ENGINE=InnoDB DEFAULT CHARSET=utf8'
+  ].join(' '),
+  function(err) {
+    assert.ifError(err);
+    connection.query(
+      [
+        'INSERT INTO `' + tableName + '` VALUES',
+        '(' +
+          testRows[0][0] +
+          ',"' +
+          testRows[0][1] +
+          '", "' +
+          testRows[0][2] +
+          '", "' +
+          testRows[0][3] +
+          '"),',
+        '(' +
+          testRows[1][0] +
+          ',"' +
+          testRows[1][1] +
+          '", "' +
+          testRows[1][2] +
+          '", "' +
+          testRows[1][3] +
+          '")'
+      ].join(' '),
+      executeTest
+    );
+  }
+);
+
+function executeTest(err) {
+  assert.ifError(err);
+  connection.execute('SELECT * FROM `' + tableName + '`', function(
+    err,
+    rows,
+    fields
+  ) {
+    assert.ifError(err);
+    actualRows = rows;
+    connection.end();
+  });
+}
+
+process.on('exit', function() {
+  expected.map(function(exp, index) {
+    var row = actualRows[index];
+    Object.keys(exp).map(function(key) {
+      if (key.startsWith('date')) {
+        assert.equal(+exp[key], +row[key]);
+      } else {
+        assert.equal(exp[key], row[key]);
+      }
+    });
+  });
+});

--- a/test/unit/packets/test-datetime.js
+++ b/test/unit/packets/test-datetime.js
@@ -20,7 +20,7 @@ i = packet.readInt16();
 var s = packet.readLengthCodedString('cesu8');
 assert.equal(s, 'foo1');
 d = packet.readDateTime();
-assert.equal(+d, 1455030494821);
+assert.equal(+d, 1455030069425);
 
 var s1 = packet.readLengthCodedString('cesu8');
 assert.equal(s1, 'bar1');


### PR DESCRIPTION
For example, MySQL binary protocol data in little endian for
2017-08-14 23:55:29.327:

```
hex:    0b      e107   08   0e     17   37  1d   58fd0400
dec:    11      2017   8    14     23   55  29   327000
unit:   bytes   year   mon  day    hour min sec  microseconds
```