### PR TITLE
parseLengthCodedIntString to return null instead of empty string for null columns

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -669,7 +669,7 @@ Packet.prototype.parseLengthCodedInt = function(supportBigNumbers) {
 };
 
 Packet.prototype.parseLengthCodedIntString = function() {
-  return this.readString(this.readLengthCodedNumber(), 'binary');
+  return this.readLengthCodedString('binary');
 };
 
 Packet.prototype.parseLengthCodedFloat = function() {

--- a/test/integration/connection/test-binary-longlong.js
+++ b/test/integration/connection/test-binary-longlong.js
@@ -18,7 +18,7 @@ var values = [
   ['-11', '11'],
   ['965432100123456789', '1965432100123456789'],
   ['-965432100123456789', '2965432100123456789'],
-  [null, null],
+  [null, null]
 ];
 
 conn.connect(function(err) {
@@ -51,15 +51,7 @@ conn.connect(function(err) {
     { id: 5, ls: null, lu: null }
   ];
 
-  var bigNums_query_bnStringsTrueTrue = [
-    { id: 1, ls: 10, lu: 10 },
-    { id: 2, ls: -11, lu: 11 },
-    { id: 3, ls: '965432100123456789', lu: '1965432100123456789' },
-    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' },
-    { id: 5, ls: '', lu: '' }
-  ];
-
-  var bigNums_execute_bnStringsTrueTrue = [
+  var bigNums_bnStringsTrueTrue = [
     { id: 1, ls: 10, lu: 10 },
     { id: 2, ls: -11, lu: 11 },
     { id: 3, ls: '965432100123456789', lu: '1965432100123456789' },
@@ -117,9 +109,9 @@ conn.connect(function(err) {
 
   testQuery(false, false, bigNums_bnStringsFalse);
   testQuery(true, false, bigNums_bnStringsTrueFalse);
-  testQuery(true, true, bigNums_query_bnStringsTrueTrue);
+  testQuery(true, true, bigNums_bnStringsTrueTrue);
 
   testExecute(false, false, bigNums_bnStringsFalse);
   testExecute(true, false, bigNums_bnStringsTrueFalse);
-  testExecute(true, true, bigNums_execute_bnStringsTrueTrue);
+  testExecute(true, true, bigNums_bnStringsTrueTrue);
 });

--- a/test/integration/connection/test-binary-longlong.js
+++ b/test/integration/connection/test-binary-longlong.js
@@ -7,8 +7,8 @@ var conn = common.createConnection();
 conn.query(
   'CREATE TEMPORARY TABLE `tmp_longlong` ( ' +
     ' `id` int(11) NOT NULL AUTO_INCREMENT, ' +
-    ' `ls` BIGINT SIGNED NOT NULL, ' +
-    ' `lu` BIGINT UNSIGNED NOT NULL, ' +
+    ' `ls` BIGINT SIGNED, ' +
+    ' `lu` BIGINT UNSIGNED, ' +
     ' PRIMARY KEY (`id`) ' +
     ' ) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8'
 );
@@ -17,7 +17,8 @@ var values = [
   ['10', '10'],
   ['-11', '11'],
   ['965432100123456789', '1965432100123456789'],
-  ['-965432100123456789', '2965432100123456789']
+  ['-965432100123456789', '2965432100123456789'],
+  [null, null],
 ];
 
 conn.connect(function(err) {
@@ -38,21 +39,32 @@ conn.connect(function(err) {
     { id: 1, ls: 10, lu: 10 },
     { id: 2, ls: -11, lu: 11 },
     { id: 3, ls: 965432100123456800, lu: 1965432100123456800 },
-    { id: 4, ls: -965432100123456800, lu: 2965432100123457000 }
+    { id: 4, ls: -965432100123456800, lu: 2965432100123457000 },
+    { id: 5, ls: null, lu: null }
   ];
 
   var bigNums_bnStringsTrueFalse = [
     { id: 1, ls: 10, lu: 10 },
     { id: 2, ls: -11, lu: 11 },
     { id: 3, ls: '965432100123456789', lu: '1965432100123456789' },
-    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' }
+    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' },
+    { id: 5, ls: null, lu: null }
   ];
 
-  var bigNums_bnStringsTrueTrue = [
+  var bigNums_query_bnStringsTrueTrue = [
     { id: 1, ls: 10, lu: 10 },
     { id: 2, ls: -11, lu: 11 },
     { id: 3, ls: '965432100123456789', lu: '1965432100123456789' },
-    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' }
+    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' },
+    { id: 5, ls: '', lu: '' }
+  ];
+
+  var bigNums_execute_bnStringsTrueTrue = [
+    { id: 1, ls: 10, lu: 10 },
+    { id: 2, ls: -11, lu: 11 },
+    { id: 3, ls: '965432100123456789', lu: '1965432100123456789' },
+    { id: 4, ls: '-965432100123456789', lu: '2965432100123456789' },
+    { id: 5, ls: null, lu: null }
   ];
 
   function check() {
@@ -105,9 +117,9 @@ conn.connect(function(err) {
 
   testQuery(false, false, bigNums_bnStringsFalse);
   testQuery(true, false, bigNums_bnStringsTrueFalse);
-  testQuery(true, true, bigNums_bnStringsTrueTrue);
+  testQuery(true, true, bigNums_query_bnStringsTrueTrue);
 
   testExecute(false, false, bigNums_bnStringsFalse);
   testExecute(true, false, bigNums_bnStringsTrueFalse);
-  testExecute(true, true, bigNums_bnStringsTrueTrue);
+  testExecute(true, true, bigNums_execute_bnStringsTrueTrue);
 });


### PR DESCRIPTION
pulling commits described in #637