### PR TITLE
Add support for minimum connections and auto close idle connections

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -50,6 +50,12 @@ Execute.prototype.start = function(packet, connection) {
     this.parameters,
     connection.config.charsetNumber
   );
+  //For reasons why this try-catch is here, please see 
+  // https://github.com/sidorares/node-mysql2/pull/689 
+  //For additional discussion, see 
+  // 1. https://github.com/sidorares/node-mysql2/issues/493
+  // 2. https://github.com/sidorares/node-mysql2/issues/187
+  // 3. https://github.com/sidorares/node-mysql2/issues/480
   try {
     connection.writePacket(executePacket.toPacket(1));
   } catch (error) {

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -50,7 +50,11 @@ Execute.prototype.start = function(packet, connection) {
     this.parameters,
     connection.config.charsetNumber
   );
-  connection.writePacket(executePacket.toPacket(1));
+  try {
+    connection.writePacket(executePacket.toPacket(1));
+  } catch (error) {
+    this.onResult(error)
+  }
   return Execute.prototype.resultsetHeader;
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -103,6 +103,7 @@ function Connection(opts) {
   });
 
   this.stream.on('end', function() {
+    this._closed = true;
     // we need to set this flag everywhere where we want connection to close
     if (connection._closing) {
       return;
@@ -946,8 +947,8 @@ Connection.prototype.serverHandshake = function serverHandshake(args) {
 Connection.prototype.end = function(callback) {
   var connection = this;
 
+  connection._closing = true;
   if (this.config.isServer) {
-    connection._closing = true;
     var quitCmd = new EventEmitter();
     setImmediate(function() {
       connection.stream.end();

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,6 +1,7 @@
 var mysql = require('../index.js');
 
 var EventEmitter = require('events').EventEmitter;
+var Timers = require('timers');
 var Util = require('util');
 var PoolConnection = require('./pool_connection.js');
 var Queue = require('denque');
@@ -18,6 +19,22 @@ function Pool(options) {
   this._freeConnections = new Queue();
   this._connectionQueue = new Queue();
   this._closed = false;
+  if (this.config.autoOpenConnections) {
+    this._openingConnections = true;
+    var self = this;
+    var opened = 0;
+    for (var i = 0; i < this.config.minConnections; i++) {
+      this.getConnection(function (conn) {
+        process.nextTick(function() {
+          self.releaseConnection(conn);
+          if (++opened === self.config.minConnections) {
+            self._openingConnections = false;
+          }
+        });
+      });
+    }
+
+  }
 }
 
 Pool.prototype.getConnection = function(cb) {
@@ -25,6 +42,10 @@ Pool.prototype.getConnection = function(cb) {
     return process.nextTick(function() {
       return cb(new Error('Pool is closed.'));
     });
+  }
+  if (this._openingConnections) {
+    // We are opening a connect, use it when ready
+    return this._connectionQueue.push(cb);
   }
 
   var connection;
@@ -82,6 +103,7 @@ Pool.prototype.getConnection = function(cb) {
 Pool.prototype.releaseConnection = function(connection) {
   var cb;
 
+  connection._lastReleased = Date.now();
   if (!connection._pool) {
     // The connection has been removed from the pool and is no longer good.
     if (this._connectionQueue.length) {
@@ -95,6 +117,7 @@ Pool.prototype.releaseConnection = function(connection) {
     process.nextTick(cb.bind(null, null, connection));
   } else {
     this._freeConnections.push(connection);
+    this._manageExpiredTimer();
   }
 };
 
@@ -111,14 +134,14 @@ Pool.prototype.end = function(cb) {
 
   var calledBack = false;
   var closedConnections = 0;
-  var connection;
+  var numConnections = this._allConnections.length;
 
   var endCB = function(err) {
     if (calledBack) {
       return;
     }
 
-    if (err || ++closedConnections >= this._allConnections.length) {
+    if (err || ++closedConnections >= numConnections) {
       calledBack = true;
       cb(err);
       return;
@@ -130,9 +153,9 @@ Pool.prototype.end = function(cb) {
     return;
   }
 
-  for (var i = 0; i < this._allConnections.length; i++) {
-    connection = this._allConnections.get(i);
-    connection._realEnd(endCB);
+  var connection;
+  while ((connection = this._allConnections.shift())) {
+    this._closeConnection(connection, endCB);
   }
 };
 
@@ -184,6 +207,39 @@ Pool.prototype.execute = function(sql, values, cb) {
   });
 };
 
+Pool.prototype._manageExpiredTimer = function() {
+  var hasExtra = this._allConnections.length > this.config.minConnections;
+  if (hasExtra && !this._expiredTimer) {
+    this._expiredTimer = Timers.setInterval(
+      Pool.prototype._closeIdleConnections.bind(this),
+      Math.min(15, this.config.idleTimeout) * 1000
+    );
+  } else if (!hasExtra && this._expiredTimer) {
+    Timers.clearInterval(this._expiredTimer);
+    this._expiredTimer = null;
+  }
+};
+
+Pool.prototype._closeIdleConnections = function() {
+  var now = Date.now();
+  var timeout = this.config.idleTimeout * 1000;
+  var length = this._freeConnections.length;
+  var numExtra = this._allConnections.length - this.config.minConnections;
+  for (var i = 0; numExtra > 0 && i < length; i++) {
+    var conn = this._freeConnections.get(i);
+
+    if (now > conn._lastReleased + timeout) {
+      // This connection has been unused for longer than the timeout
+      this._closeConnection(conn);
+      // decrement i and length as the length will be reduced by 1 by closeConnection
+      i--;
+      length--;
+      numExtra--;
+    }
+  }
+  this._manageExpiredTimer();
+};
+
 Pool.prototype._removeConnection = function(connection) {
   // Remove connection from all connections
   spliceConnection(this._allConnections, connection);
@@ -191,7 +247,16 @@ Pool.prototype._removeConnection = function(connection) {
   // Remove connection from free connections
   spliceConnection(this._freeConnections, connection);
 
-  this.releaseConnection(connection);
+  if (!connection._closing && !connection._closed) {
+    this.releaseConnection(connection);
+  }
+
+  this._manageExpiredTimer();
+};
+
+Pool.prototype._closeConnection = function (connection, cb) {
+  connection._realEnd(cb);
+  this._removeConnection(connection);
 };
 
 Pool.prototype.format = function(sql, values) {

--- a/lib/pool_config.js
+++ b/lib/pool_config.js
@@ -6,13 +6,23 @@ function PoolConfig(options) {
     options = ConnectionConfig.parseUrl(options);
   }
   this.connectionConfig = new ConnectionConfig(options);
-  this.waitForConnections = options.waitForConnections === undefined
+  this.waitForConnections = options.waitForConnections == null
     ? true
     : Boolean(options.waitForConnections);
-  this.connectionLimit = options.connectionLimit === undefined
+  this.connectionLimit = options.connectionLimit == null
     ? 10
-    : Number(options.connectionLimit);
-  this.queueLimit = options.queueLimit === undefined
+    : Number(options.connectionLimit) || 10;
+  this.queueLimit = options.queueLimit == null
     ? 0
-    : Number(options.queueLimit);
+    : Number(options.queueLimit) || 0;
+  this.minConnections = Math.min(
+    this.connectionLimit,
+    Number(options.minConnections) || 0
+  );
+  this.autoOpenConnections = options.autoOpenConnections == null
+    ? true
+    : Boolean(options.autoOpenConnections);
+  this.idleTimeout = options.idleTimeout == null
+    ? 300
+    : Number(options.idleTimeout) || 300;
 }


### PR DESCRIPTION
This is very similar to #321 but not the same. 321 is targeting cycling connections.

The goal if this PR is to allow users to set an upwards bounds on number of connections to a pool, but not keep every one of those connections open should it ever be hit.

This PR will let you specify a minimum number of desired connections to keep open, and any beyond that will automatically be closed after a period of inactivity.

Default configuration keeps existing behavior, by defaulting min = max, so no behavior change will apply to those who upgrade (semver minor)

This brings the pool inline with standard connection pool features, so you can set the min to a value that your application for the most part needs to keep open to avoid constantly opening new connections, but on the other hand allow temporary increases for out of the normal spikes in activity, but let them close out when no longer needed.

I know discussion of API was a concern with mysqljs, but I hope we can get this pulled and encourage mysqljs to also add support for this too.