### PR TITLE
test(typecast): first null value, corrupts next field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     env: LINT=0
   - node_js: "6.11"
     env: LINT=0
-  - node_js: "8.7"
+  - node_js: "8.0"
     env: LINT=1
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ matrix:
   include:
   - node_js: "4.8"
     env: LINT=0
-  - node_js: "6.10"
+  - node_js: "6.11"
     env: LINT=0
-  - node_js: "7.10"
-    env: LINT=0
-  - node_js: "8.4"
+  - node_js: "8.7"
     env: LINT=1
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,8 @@ environment:
   LINT: 0
 
   matrix:
-    - nodejs_version: "6.10"
-    - nodejs_version: "7.10"
-    - nodejs_version: "8.1"
+    - nodejs_version: "6.11"
+    - nodejs_version: "8.7"
       LINT: 1
 
 services:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
   matrix:
     - nodejs_version: "6.11"
-    - nodejs_version: "8.7"
+    - nodejs_version: "8.6"
       LINT: 1
 
 services:

--- a/lib/compile_text_parser.js
+++ b/lib/compile_text_parser.js
@@ -153,7 +153,7 @@ function readCodeFor(type, charset, encodingExpr, config, options) {
     case Types.DOUBLE:
       return 'packet.parseLengthCodedFloat()';
     case Types.NULL:
-      return 'null; packet.skip(1)';
+      return 'packet.readLengthCodedNumber()';
     case Types.DECIMAL:
     case Types.NEWDECIMAL:
       if (config.decimalNumbers) {

--- a/test/integration/connection/test-typecast.js
+++ b/test/integration/connection/test-typecast.js
@@ -30,4 +30,18 @@ connection.query(
   }
 );
 
+connection.query(
+  {
+    sql: 'SELECT NULL as test, 6 as value;',
+    typeCast: function(field, next) {
+      return next();
+    }
+  },
+  function(err, _rows) {
+    assert.ifError(err);
+    assert.equal(_rows[0].test, null);
+    assert.equal(_rows[0].value, 6);
+  }
+);
+
 connection.end();


### PR DESCRIPTION
If first field  is null then it will corrupt next field value to become null as well.

I dont know reason behind this but this only happens with `typeCast`, even when only `next()` is called. I guess somehow depend upon access order to packet buffer.

https://github.com/sequelize/sequelize/issues/8475