### PR TITLE
Correct await calls documentation to use Promise based versions

### DIFF
--- a/documentation/Promise-Wrapper.md
+++ b/documentation/Promise-Wrapper.md
@@ -29,13 +29,13 @@ In addition to errback interface there is thin wrapper to expose Promise-based a
 ```js
 async function example1 () {
   const mysql = require('mysql2/promise');
-  const conn = await mysql.createConnection({ database: test });
+  const conn = await mysql.createConnectionPromise({ database: test });
   let [rows, fields] = await conn.execute('select ?+? as sum', [2, 2]);
 }
 
 async function example2 () {
    let mysql = require('mysql2/promise');
-   let pool = mysql.createPool({database: test});
+   let pool = mysql.createPoolPromise({database: test});
    // execute in parallel, next console.log in 3 seconds
    await Promise.all([pool.query('select sleep(2)'), pool.query('select sleep(3)')]);
    console.log('3 seconds after');


### PR DESCRIPTION
Without the *Promise postfix added Node will throw the following error:

```
(node:23673) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): TypeError: (intermediate value) is not iterable
(node:23673) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```