### PR TITLE
Added access to the "sqlMessage" of an error

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -713,6 +713,7 @@ Packet.prototype.asError = function(encoding) {
   err.code = ErrorCodeToName[errorCode];
   err.errno = errorCode;
   err.sqlState = sqlState;
+  err.sqlMessage = message;
   return err;
 };
 


### PR DESCRIPTION
I was using [github:mysqljs/mysql](https://github.com/mysqljs/mysql) and I changed to node-mysql2.

We dont have access to sqlMessage with node-mysql2 so I added it :)

**My tests**
With node-mysql2 :
```javascript
var mysql = require('mysql2');
var connection = mysql.createConnection({user: 'xx', password: 'xxx', database: 'xx', host: 'xxx'});

connection.query("SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'MY_ERR';", function (err, rows) {
  console.log(JSON.stringify(err));
/*
Before : {"code":"ER_SIGNAL_EXCEPTION","errno":1644,"sqlState":"#45000"}
After : {"code":"ER_SIGNAL_EXCEPTION","errno":1644,"sqlState":"#45000","sqlMessage":"MY_ERR"}
*/
});
```
With mysql from [github:mysqljs/mysql](https://github.com/mysqljs/mysql)
```javascript
var mysql = require('mysql');
var connection = mysql.createConnection({user: 'xx', password: 'xxx', database: 'xx', host: 'xxx'});

connection.query("SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'MY_ERR';", function (err, rows) {
  console.log(JSON.stringify(err));
/*
{"code":"ER_SIGNAL_EXCEPTION","errno":1644,"sqlMessage":"MY_ERR","sqlState":"45000","index":0,"sql":"SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'MY_ERR';"}
*/
});
```
