### PR TITLE
sqlState normalized (error object) && minor version bump && Changelog update

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 1.4.3 (03/11/2017)
  - Added sqlMessage to Error callback object           #665
- - Normalized sqlState to a string of 5 chars
+ - Normalized sqlState to a string of 5 chars          #667
    as Mysql specifies it
 1.4.2 ( 27/08/2017 )
  - fix null value incorrectly returned as empty

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+1.4.3 (03/11/2017)
+ - Added sqlMessage to Error callback object           #665
+ - Normalized sqlState to a string of 5 chars
+   as Mysql specifies it
 1.4.2 ( 27/08/2017 )
  - fix null value incorrectly returned as empty
    string fro int values in text protocol              #637

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -706,7 +706,8 @@ Packet.prototype.asError = function(encoding) {
   var errorCode = this.readInt16();
   var sqlState = '';
   if (this.buffer[this.offset] == 0x23) {
-    sqlState = this.readBuffer(6).toString();
+    this.skip(1);
+    sqlState = this.readBuffer(5).toString();
   }
   var message = this.readString(undefined, encoding);
   var err = new Error(message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql2",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "fast mysql driver. Implements core protocol, prepared statements, ssl and compression in native JS",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Changed ```sqlState``` of an error to a string of 5 chars as mysql specifies it [here]
(https://dev.mysql.com/doc/refman/5.5/en/mysql-sqlstate.html) and to  align with [mysqljs/mysql](https://github.com/mysqljs/mysql).

I updated the Changelog and did a minor version bump as asked in #665 
I did not find any tests related to ```sqlState```

Test : 
```js
var mysql = require('mysql2');
var connection = mysql.createConnection({user: 'xx', password: 'xx', database: 'xx', host: 'xx'});
connection.query("SIGNAL SQLSTATE '02000' SET MESSAGE_TEXT = 'My message', MYSQL_ERRNO = '1999';", function (err, rows) {
  console.log(JSON.stringify(err));
});
```
Before : 
```json
{"errno":1999,"sqlState":"#02000","sqlMessage":"My message"}
```
After : 
```json
{"errno":1999,"sqlState":"02000","sqlMessage":"My message"}
```