### PR TITLE
Expose escape & format methods on connection pool

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,25 +3,28 @@ var SqlString = require('sqlstring');
 var Connection = require('./lib/connection.js');
 var ConnectionConfig = require('./lib/connection_config.js');
 
-module.exports.createConnection = function (opts) {
-  return new Connection({config: new ConnectionConfig(opts)});
+module.exports.createConnection = function(opts) {
+  return new Connection({ config: new ConnectionConfig(opts) });
 };
 
 module.exports.connect = module.exports.createConnection;
 module.exports.Connection = Connection;
 
-module.exports.createPool = function (config) {
+var Pool = require('./lib/pool.js');
+
+module.exports.createPool = function(config) {
   var PoolConfig = require('./lib/pool_config.js');
-  var Pool = require('./lib/pool.js');
-  return new Pool({config: new PoolConfig(config)});
+  return new Pool({ config: new PoolConfig(config) });
 };
 
-exports.createPoolCluster = function (config) {
+exports.createPoolCluster = function(config) {
   var PoolCluster = require('./lib/pool_cluster.js');
   return new PoolCluster(config);
 };
 
-module.exports.createServer = function (handler) {
+module.exports.Pool = Pool;
+
+module.exports.createServer = function(handler) {
   var Server = require('./lib/server.js');
   var s = new Server();
   if (handler) {
@@ -34,26 +37,26 @@ exports.escape = SqlString.escape;
 exports.escapeId = SqlString.escapeId;
 exports.format = SqlString.format;
 
-exports.__defineGetter__('createConnectionPromise', function () {
+exports.__defineGetter__('createConnectionPromise', function() {
   return require('./promise.js').createConnection;
 });
 
-exports.__defineGetter__('createPoolPromise', function () {
+exports.__defineGetter__('createPoolPromise', function() {
   return require('./promise.js').createPool;
 });
 
-exports.__defineGetter__('createPoolClusterPromise', function () {
+exports.__defineGetter__('createPoolClusterPromise', function() {
   return require('./promise.js').createPoolCluster;
 });
 
-exports.__defineGetter__('Types', function () {
+exports.__defineGetter__('Types', function() {
   return require('./lib/constants/types.js');
 });
 
-exports.__defineGetter__('Charsets', function () {
+exports.__defineGetter__('Charsets', function() {
   return require('./lib/constants/charsets.js');
 });
 
-exports.__defineGetter__('CharsetToEncoding', function () {
+exports.__defineGetter__('CharsetToEncoding', function() {
   return require('./lib/constants/charset_encodings.js');
 });

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -194,6 +194,15 @@ Pool.prototype._removeConnection = function(connection) {
   this.releaseConnection(connection);
 };
 
+Pool.prototype.format = function(sql, values) {
+  return mysql.format(
+    sql,
+    values,
+    this.config.connectionConfig.stringifyObjects,
+    this.config.connectionConfig.timezone
+  );
+};
+
 Pool.prototype.escape = function(value) {
   return mysql.escape(
     value,

--- a/test/unit/test-Pool.js
+++ b/test/unit/test-Pool.js
@@ -1,0 +1,43 @@
+const mysql = require('../..');
+const test = require('utest');
+const assert = require('assert');
+
+const poolConfig = { config: { connectionConfig: {} } };
+
+const pool = new mysql.createPool(poolConfig);
+test('Pool', {
+  'exposes escape': () => {
+    assert.equal(pool.escape(123), '123');
+  },
+
+  'exposes escapeId': () => {
+    assert.equal(pool.escapeId('table name'), '`table name`');
+  },
+
+  'exposes format': () => {
+    const params = ['table name', 'thing'];
+    assert.equal(
+      pool.format('SELECT a FROM ?? WHERE b = ?', params),
+      "SELECT a FROM `table name` WHERE b = 'thing'"
+    );
+  }
+});
+
+const promisePool = new mysql.createPoolPromise(poolConfig);
+test('PromisePool', {
+  'exposes escape': () => {
+    assert.equal(pool.escape(123), '123');
+  },
+
+  'exposes escapeId': () => {
+    assert.equal(pool.escapeId('table name'), '`table name`');
+  },
+
+  'exposes format': () => {
+    const params = ['table name', 'thing'];
+    assert.equal(
+      pool.format('SELECT a FROM ?? WHERE b = ?', params),
+      "SELECT a FROM `table name` WHERE b = 'thing'"
+    );
+  }
+});


### PR DESCRIPTION
Escape methods already exist on `Pool`, so are only new to `PromisePool`.

(The pre-commit hook went to town prettifying the code.)

Fixes #663.