### PR TITLE
Remove destroyed promise pool connections from pool

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ module.exports.createServer = function(handler) {
   return s;
 };
 
+exports.PoolConnection = require('./lib/pool_connection');
 exports.escape = SqlString.escape;
 exports.escapeId = SqlString.escapeId;
 exports.format = SqlString.format;

--- a/promise.js
+++ b/promise.js
@@ -299,6 +299,19 @@ PromisePreparedStatementInfo.prototype.close = function() {
   'format'
 ]);
 
+function PromisePoolConnection() {
+  PromiseConnection.apply(this, arguments);
+}
+
+util.inherits(PromisePoolConnection, PromiseConnection);
+
+PromisePoolConnection.prototype.destroy = function() {
+  return core.PoolConnection.prototype.destroy.apply(
+    this.connection,
+    arguments
+  );
+};
+
 function PromisePool(pool, Promise) {
   this.pool = pool;
   this.Promise = Promise;
@@ -316,7 +329,7 @@ PromisePool.prototype.getConnection = function() {
       if (err) {
         reject(err);
       } else {
-        resolve(new PromiseConnection(coreConnection, self.Promise));
+        resolve(new PromisePoolConnection(coreConnection, self.Promise));
       }
     });
   });


### PR DESCRIPTION
Make promise pool connection calls to `destroy` proxy pool connection `destroy` method, rather than non-pool connection `destroy` method.

(The prettify commit hook has reformatted a lot of unchanged code once again!)

Relates to #672