### PR TITLE
writeString and readString default encoding

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -388,6 +388,7 @@ Packet.prototype.readString = function(len, encoding) {
     len = this.end - this.offset;
   }
   this.offset += len;
+  encoding = encoding || 'utf8'
   return StringParser.decode(
     this.buffer.slice(this.offset - len, this.offset),
     encoding
@@ -788,7 +789,8 @@ Packet.prototype.writeString = function(s, encoding) {
   if (s.length === 0) {
     return;
   }
-
+  
+  encoding = encoding || 'utf8'
   // var bytes = Buffer.byteLength(s, 'utf8');
   // this.buffer.write(s, this.offset, bytes, 'utf8');
   // this.offset += bytes;


### PR DESCRIPTION
There is a bug in connection.createBinlogStream() as there is a missing encoding.
we should set the default encoding, once the encoding is empty.