### PR TITLE
Wrap executePacket.toPacket(1) call with try/catch

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -50,6 +50,12 @@ Execute.prototype.start = function(packet, connection) {
     this.parameters,
     connection.config.charsetNumber
   );
+  //For reasons why this try-catch is here, please see 
+  // https://github.com/sidorares/node-mysql2/pull/689 
+  //For additional discussion, see 
+  // 1. https://github.com/sidorares/node-mysql2/issues/493
+  // 2. https://github.com/sidorares/node-mysql2/issues/187
+  // 3. https://github.com/sidorares/node-mysql2/issues/480
   try {
     connection.writePacket(executePacket.toPacket(1));
   } catch (error) {

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -50,7 +50,11 @@ Execute.prototype.start = function(packet, connection) {
     this.parameters,
     connection.config.charsetNumber
   );
-  connection.writePacket(executePacket.toPacket(1));
+  try {
+    connection.writePacket(executePacket.toPacket(1));
+  } catch (error) {
+    this.onResult(error)
+  }
   return Execute.prototype.resultsetHeader;
 };
 


### PR DESCRIPTION
This is to provide more context to error messages when a parameter is undefined.