### PR TITLE
Use source parameter types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     env: LINT=0
   - node_js: "6.11"
     env: LINT=0
-  - node_js: "8.0"
+  - node_js: "8.9"
     env: LINT=1
 
 cache:

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -21,7 +21,73 @@ function leftPad(num, value) {
     return (pad + s).slice(-num);
 }
 
+function toMysqlDateTime(date) {
+  return [date.getFullYear(), date.getMonth() + 1, date.getDate()].join('-') +  ' ' +
+    [date.getHours(), date.getMinutes(), date.getSeconds()].join(':') + '.' +
+    leftPad(3, date.getMilliseconds());
+}
+
+function isJSON(value) {
+  return Array.isArray(value) ||
+    value.constructor === Object ||
+    (typeof value.toJSON === 'function' && !Buffer.isBuffer(value));
+}
+
+/**
+ * Converts a value to an object describing type, String/Buffer representation and length
+ * @param {*} value
+ */
+function toParameter(value, encoding) {
+  var type = Types.VAR_STRING;
+  var length;
+  var fixed = false;
+  if (value !== null) {
+    switch (typeof value) {
+      case 'number':
+        type = Types.DOUBLE;
+        fixed = true;
+        var bufferValue = Buffer.allocUnsafe(8);
+        bufferValue.writeDoubleLE(value, 0);
+        value = bufferValue;
+        break;
+
+      case 'boolean':
+        type = Types.TINY;
+        fixed = true;
+        var bufferValue = Buffer.allocUnsafe(1);
+        bufferValue.writeInt8(value | 0, 0);
+        value = bufferValue;
+        break;
+
+      case 'object':
+        if (Object.prototype.toString.call(value) == '[object Date]') {
+          value = toMysqlDateTime(value);
+        } else if (isJSON(value)) {
+          type = Types.JSON;
+          value = JSON.stringify(value);
+        }
+        break;
+    }
+  } else {
+    type = Types.NULL;
+    value = '';
+  }
+  if (fixed) {
+    length = value.length;
+  } else {
+    if (Buffer.isBuffer(value)) {
+      length = Packet.lengthCodedNumberLength(value.length) + value.length;
+    } else {
+      value = value.toString();
+      length = Packet.lengthCodedStringLength(value, encoding);
+    }
+  }
+  return { type, value, length, fixed };
+}
+
 Execute.prototype.toPacket = function() {
+  var self = this;
+
   // TODO: don't try to calculate packet length in advance, allocate some big buffer in advance (header + 256 bytes?)
   // and copy + reallocate if not enough
 
@@ -32,33 +98,17 @@ Execute.prototype.toPacket = function() {
   // 9 + 1 - flags
   // 10 + 4 - iteration-count (always 1)
   var length = 14;
+  var parameters;
   if (this.parameters && this.parameters.length > 0) {
     length += Math.floor((this.parameters.length + 7) / 8);
     length += 1; // new-params-bound-flag
     length += 2 * this.parameters.length; // type byte for each parameter if new-params-bound-flag is set
-    for (i = 0; i < this.parameters.length; i++) {
-      if (this.parameters[i] !== null) {
-        if (
-          Object.prototype.toString.call(this.parameters[i]) == '[object Date]'
-        ) {
-          var d = this.parameters[i];
-          // TODO: move to asMysqlDateTime()
-          this.parameters[i] =
-            [d.getFullYear(), d.getMonth() + 1, d.getDate()].join('-') +
-            ' ' +
-            [d.getHours(), d.getMinutes(), d.getSeconds()].join(':') +
-            '.' + leftPad(3, d.getMilliseconds())
-          ;
-        }
-        if (Buffer.isBuffer(this.parameters[i])) {
-          length += Packet.lengthCodedNumberLength(this.parameters[i].length);
-          length += this.parameters[i].length;
-        } else {
-          var str = this.parameters[i].toString();
-          length += Packet.lengthCodedStringLength(str, this.encoding);
-        }
-      }
-    }
+    parameters = this.parameters.map(function (value) {
+      return toParameter(value, self.encoding);
+    });
+    length += parameters.reduce(function (accumulator, parameter) {
+      return accumulator + parameter.length;
+    }, 0);
   }
 
   var buffer = Buffer.allocUnsafe(length);
@@ -68,11 +118,11 @@ Execute.prototype.toPacket = function() {
   packet.writeInt32(this.id);
   packet.writeInt8(CursorType.NO_CURSOR); // flags
   packet.writeInt32(1); // iteration-count, always 1
-  if (this.parameters && this.parameters.length > 0) {
+  if (parameters) {
     var bitmap = 0;
     var bitValue = 1;
-    for (i = 0; i < this.parameters.length; i++) {
-      if (this.parameters[i] === null) {
+    parameters.forEach(function (parameter) {
+      if (parameter.type === Types.NULL) {
         bitmap += bitValue;
       }
       bitValue *= 2;
@@ -81,7 +131,7 @@ Execute.prototype.toPacket = function() {
         bitmap = 0;
         bitValue = 1;
       }
-    }
+    });
     if (bitValue != 1) {
       packet.writeInt8(bitmap);
     }
@@ -91,27 +141,24 @@ Execute.prototype.toPacket = function() {
     // if not, previous execution types are used (TODO prooflink)
     packet.writeInt8(1); // new-params-bound-flag
 
-    // TODO: don't typecast always to sting, use parameters type
-    for (i = 0; i < this.parameters.length; i++) {
-      if (this.parameters[i] !== null) {
-        packet.writeInt16(Types.VAR_STRING);
-      } else {
-        packet.writeInt16(Types.NULL);
-      }
-    }
+    // Write parameter types
+    parameters.forEach(function (parameter) {
+      packet.writeInt8(parameter.type); // field type
+      packet.writeInt8(0); // parameter flag
+    });
 
-    for (i = 0; i < this.parameters.length; i++) {
-      if (this.parameters[i] !== null) {
-        if (Buffer.isBuffer(this.parameters[i])) {
-          packet.writeLengthCodedBuffer(this.parameters[i]);
+    // Write parameter values
+    parameters.forEach(function (parameter) {
+      if (parameter.type !== Types.NULL) {
+        if (parameter.fixed) {
+          packet.writeBuffer(parameter.value);
+        } else if (Buffer.isBuffer(parameter.value)) {
+          packet.writeLengthCodedBuffer(parameter.value);
         } else {
-          packet.writeLengthCodedString(
-            this.parameters[i].toString(),
-            this.encoding
-          );
+          packet.writeLengthCodedString(parameter.value, self.encoding);
         }
       }
-    }
+    });
   }
   return packet;
 };

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -11,26 +11,23 @@ function Execute(id, parameters, charsetNumber) {
   this.encoding = CharsetToEncoding[charsetNumber];
 }
 
-var pad = '000000000000';
-function leftPad(num, value) {
-    var s = value.toString();
-    // if we don't need to pad
-    if (s.length >= num) {
-        return s;
-    }
-    return (pad + s).slice(-num);
-}
-
-function toMysqlDateTime(date) {
-  return [date.getFullYear(), date.getMonth() + 1, date.getDate()].join('-') +  ' ' +
-    [date.getHours(), date.getMinutes(), date.getSeconds()].join(':') + '.' +
-    leftPad(3, date.getMilliseconds());
-}
-
 function isJSON(value) {
   return Array.isArray(value) ||
     value.constructor === Object ||
     (typeof value.toJSON === 'function' && !Buffer.isBuffer(value));
+}
+
+function toMysqlDateBuffer(value) {
+  var bufferValue = Buffer.allocUnsafe(12);
+  bufferValue.writeUInt8(11, 0);
+  bufferValue.writeUInt16LE(value.getFullYear(), 1);
+  bufferValue.writeUInt8(value.getMonth() + 1, 3);
+  bufferValue.writeUInt8(value.getDate(), 4);
+  bufferValue.writeUInt8(value.getHours(), 5);
+  bufferValue.writeUInt8(value.getMinutes(), 6);
+  bufferValue.writeUInt8(value.getSeconds(), 7);
+  bufferValue.writeUInt32LE(value.getMilliseconds() * 1000, 8);
+  return bufferValue;
 }
 
 /**
@@ -43,6 +40,9 @@ function toParameter(value, encoding) {
   var fixed = false;
   if (value !== null) {
     switch (typeof value) {
+      case 'undefined':
+        throw new TypeError('Bind parameters must not contain undefined');
+
       case 'number':
         type = Types.DOUBLE;
         fixed = true;
@@ -61,7 +61,9 @@ function toParameter(value, encoding) {
 
       case 'object':
         if (Object.prototype.toString.call(value) == '[object Date]') {
-          value = toMysqlDateTime(value);
+          type = Types.DATETIME;
+          fixed = true;
+          value = toMysqlDateBuffer(value);
         } else if (isJSON(value)) {
           type = Types.JSON;
           value = JSON.stringify(value);

--- a/test/integration/connection/test-execute-bind-boolean.js
+++ b/test/integration/connection/test-execute-bind-boolean.js
@@ -1,0 +1,17 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var rows, fields;
+connection.execute('SELECT ? AS trueValue, ? AS falseValue', [true, false], function(err, _rows, _fields) {
+  if (err) {
+    throw err;
+  }
+  rows = _rows;
+  fields = _fields;
+  connection.end();
+});
+
+process.on('exit', function() {
+  assert.deepEqual(rows, [{ trueValue: 1, falseValue: 0 }]);
+});

--- a/test/integration/connection/test-execute-bind-date.js
+++ b/test/integration/connection/test-execute-bind-date.js
@@ -1,0 +1,19 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var date = new Date(2018, 02, 10, 15, 12, 34, 1234)
+
+var rows, fields;
+connection.execute('SELECT ? AS result', [date], function(err, _rows, _fields) {
+  if (err) {
+    throw err;
+  }
+  rows = _rows;
+  fields = _fields;
+  connection.end();
+});
+
+process.on('exit', function() {
+  assert.deepEqual(rows, [{ result: date }]);
+});

--- a/test/integration/connection/test-execute-bind-json.js
+++ b/test/integration/connection/test-execute-bind-json.js
@@ -1,0 +1,17 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var rows, fields;
+connection.execute('SELECT ? AS result', [{ a: 1, b: true, c: ["foo"] }], function(err, _rows, _fields) {
+  if (err) {
+    throw err;
+  }
+  rows = _rows;
+  fields = _fields;
+  connection.end();
+});
+
+process.on('exit', function() {
+  assert.deepEqual(rows, [{ result: { a: 1, b: true, c: ["foo"] } }]);
+});

--- a/test/integration/connection/test-execute-bind-null.js
+++ b/test/integration/connection/test-execute-bind-null.js
@@ -1,0 +1,17 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var rows, fields;
+connection.execute('SELECT ? AS firstValue, ? AS nullValue, ? AS lastValue', ['foo', null, 'bar'], function(err, _rows, _fields) {
+  if (err) {
+    throw err;
+  }
+  rows = _rows;
+  fields = _fields;
+  connection.end();
+});
+
+process.on('exit', function() {
+  assert.deepEqual(rows, [{ firstValue: 'foo', nullValue: null, lastValue: 'bar' }]);
+});

--- a/test/integration/connection/test-execute-bind-number.js
+++ b/test/integration/connection/test-execute-bind-number.js
@@ -1,0 +1,17 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var rows, fields;
+connection.execute('SELECT ? AS zeroValue, ? AS positiveValue, ? AS negativeValue, ? AS decimalValue', [0, 123, -123, 1.25], function(err, _rows, _fields) {
+  if (err) {
+    throw err;
+  }
+  rows = _rows;
+  fields = _fields;
+  connection.end();
+});
+
+process.on('exit', function() {
+  assert.deepEqual(rows, [{ zeroValue: 0, positiveValue: 123, negativeValue: -123, decimalValue: 1.25 }]);
+});

--- a/test/integration/connection/test-execute-bind-undefined.js
+++ b/test/integration/connection/test-execute-bind-undefined.js
@@ -1,0 +1,18 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var error = null;
+var foo = {};
+
+connection.execute('SELECT ? AS result', [foo.bar], function(err, _rows) { });
+
+// TODO: Needs to be a better way of catching this exception
+process.on('uncaughtException', (err) => {
+  error = err;
+  process.exit(0);
+});
+
+process.on('exit', function() {
+  assert.equal(error.name, 'TypeError');
+});


### PR DESCRIPTION
This PR is a follow on from https://github.com/sidorares/node-mysql2/pull/353 - it sets the type for bind parameters based on the source parameter type.

- Numbers are typed as `DOUBLE`
- JSON is typed as `JSON`
- Booleans are typed as `TINY`
- Dates are converted to string

There's a PR for sequelize that relies on these changes: https://github.com/sequelize/sequelize/pull/8861
  