### PR TITLE
Improve performance of removing connections from pools

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -217,17 +217,10 @@ Pool.prototype.escapeId = function escapeId(value) {
 
 function spliceConnection(queue, connection) {
   var len = queue.length;
-  if (len) {
-    if (queue.get(len - 1) === connection) {
-      queue.pop();
-    } else {
-      for (; --len; ) {
-        if (queue.get(0) === connection) {
-          queue.shift();
-          break;
-        }
-        queue.push(queue.shift());
-      }
+  for (var i = 0; i < len; i++) {
+    if (queue.get(i) === connection) {
+      queue.removeOne(i);
+      break;
     }
   }
 }


### PR DESCRIPTION
Use the built in splice method to avoid reordering the queue and improve performance.

Originally was removed due to https://github.com/sidorares/node-mysql2/issues/226 - but that was when it used 'double-ended-queue', and we now use denque, which does include a splice method.