### PR TITLE
fix(packet): remove `noAssert`

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -56,7 +56,7 @@ Packet.prototype.readInt8 = function() {
 
 Packet.prototype.readInt16 = function() {
   this.offset += 2;
-  return this.buffer.readUInt16LE(this.offset - 2, true);
+  return this.buffer.readUInt16LE(this.offset - 2);
 };
 
 Packet.prototype.readInt24 = function() {
@@ -65,21 +65,21 @@ Packet.prototype.readInt24 = function() {
 
 Packet.prototype.readInt32 = function() {
   this.offset += 4;
-  return this.buffer.readUInt32LE(this.offset - 4, true);
+  return this.buffer.readUInt32LE(this.offset - 4);
 };
 
 Packet.prototype.readSInt8 = function() {
-  return this.buffer.readInt8(this.offset++, true);
+  return this.buffer.readInt8(this.offset++);
 };
 
 Packet.prototype.readSInt16 = function() {
   this.offset += 2;
-  return this.buffer.readInt16LE(this.offset - 2, true);
+  return this.buffer.readInt16LE(this.offset - 2);
 };
 
 Packet.prototype.readSInt32 = function() {
   this.offset += 4;
-  return this.buffer.readInt32LE(this.offset - 4, true);
+  return this.buffer.readInt32LE(this.offset - 4);
 };
 
 Packet.prototype.readInt64JSNumber = function() {
@@ -117,7 +117,8 @@ Packet.prototype.readInt64 = function() {
   var word0 = this.readInt32();
   var word1 = this.readInt32();
   var res = new Long(word0, word1, true);
-  var resNumber = res.toNumber(), resString = res.toString();
+  var resNumber = res.toNumber(),
+    resString = res.toString();
 
   res = resNumber.toString() === resString ? resNumber : resString;
 
@@ -128,7 +129,8 @@ Packet.prototype.readSInt64 = function() {
   var word0 = this.readInt32();
   var word1 = this.readInt32();
   var res = new Long(word0, word1, false);
-  var resNumber = res.toNumber(), resString = res.toString();
+  var resNumber = res.toNumber(),
+    resString = res.toString();
 
   res = resNumber.toString() === resString ? resNumber : resString;
 
@@ -194,7 +196,8 @@ Packet.prototype.readLengthCodedNumberExt = function(
 
     res = new Long(word0, word1, !signed); // Long need unsigned
 
-    var resNumber = res.toNumber(), resString = res.toString();
+    var resNumber = res.toNumber(),
+      resString = res.toString();
 
     res = resNumber.toString() === resString ? resNumber : resString;
 
@@ -763,7 +766,7 @@ Packet.prototype.writeInt8 = function(n) {
 Packet.prototype.writeDouble = function(n) {
   this.buffer.writeDoubleLE(n, this.offset);
   this.offset += 8;
-}
+};
 
 Packet.prototype.writeBuffer = function(b) {
   b.copy(this.buffer, this.offset);
@@ -854,7 +857,7 @@ Packet.prototype.writeDate = function(d) {
   this.buffer.writeUInt8(d.getSeconds(), this.offset + 7);
   this.buffer.writeUInt32LE(d.getMilliseconds() * 1000, this.offset + 8);
   this.offset += 12;
-}
+};
 
 Packet.prototype.writeHeader = function(sequenceId) {
   var offset = this.offset;


### PR DESCRIPTION
The `noAssert` argument is no longer supported by Node.js and all
input will be validated even if it is passed through. This removes
the argument therefore.

Refs: https://github.com/nodejs/node/pull/18395

Off-topic: the git hooks in use seem to interfere a lot with the contributors will.
It is for example not possible to commit something with `git commit -p` because even if you only apply a few patches, all code is going to be commited anyway. That is not very user friendly :-/ 