### PR TITLE
Do not throw an error when a connection ends with a RST,ACK packet

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -167,6 +167,11 @@ Connection.prototype._handleFatalError = function(err) {
 };
 
 Connection.prototype._handleNetworkError = function(err) {
+  // Do not throw an error when a connection ends with a RST,ACK packet
+  if (err.errno === 'ECONNRESET' && this._closing) {
+    return;
+  }
+
   this._handleFatalError(err);
 };
 


### PR DESCRIPTION
Refer to issue #766  