### PR TITLE
Fixes typo in handshake_response.js

### DIFF
--- a/lib/packets/handshake_response.js
+++ b/lib/packets/handshake_response.js
@@ -137,10 +137,10 @@ HandshakeResponse.prototype.serializeResponse = function(buffer) {
 
 HandshakeResponse.prototype.toPacket = function() {
   if (typeof this.user != 'string') {
-    throw new Error('"user" connection config prperty must be a string');
+    throw new Error('"user" connection config property must be a string');
   }
   if (typeof this.database != 'string') {
-    throw new Error('"database" connection config prperty must be a string');
+    throw new Error('"database" connection config property must be a string');
   }
   // dry run: calculate resulting packet length
   var p = this.serializeResponse(Packet.MockBuffer());


### PR DESCRIPTION
The `handshake_response.js` `toPacket` function had two typos.