### PR TITLE
Emit pool connection acquire and release events

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -31,6 +31,7 @@ Pool.prototype.getConnection = function(cb) {
 
   if (this._freeConnections.length > 0) {
     connection = this._freeConnections.shift();
+    this.emit('acquire', connection);
 
     return process.nextTick(function() {
       return cb(null, connection);
@@ -57,6 +58,7 @@ Pool.prototype.getConnection = function(cb) {
         }
 
         this.emit('connection', connection);
+        this.emit('acquire', connection);
         return cb(null, connection);
       }.bind(this)
     );
@@ -95,6 +97,7 @@ Pool.prototype.releaseConnection = function(connection) {
     process.nextTick(cb.bind(null, null, connection));
   } else {
     this._freeConnections.push(connection);
+    this.emit('release', connection);
   }
 };
 


### PR DESCRIPTION
At the moment mysql2 does not emit any events when a connection is acquired or released back into the pool, which is something mysql-node does support. Adding these helps instrument database usage patterns more comprehensively,  allowing users to better understand how their applications make use of the library, whether they're leaking connections or just using more than they need and help them diagnose connection limit errors and suchlike.