### PR TITLE
Added a .promise() function to Pool, Connection, PoolConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ MySQL2 also support Promise API. Which works very well with ES7 async await.
 ```js
 async function main() {
   // get the client
-  const  mysql = require('mysql2/promise');
+  const mysql = require('mysql2/promise');
   // create the connection
   const connection = await mysql.createConnection({host:'localhost', user: 'root', database: 'test'});
   // query database
@@ -186,6 +186,38 @@ const connection = await mysql.createConnection({host:'localhost', user: 'root',
 
 // query database
 const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
+```
+
+MySQL2 also exposes a .promise() function on Pools, so you can create a promise/non-promise connections from the same pool
+```js
+async function main() {
+  // get the client
+  const mysql = require('mysql2');
+  // create the pool
+  const pool = await mysql.createPool({host:'localhost', user: 'root', database: 'test'});
+  // now get a Promise wrapped instance of that pool
+  const promisePool = pool.promise();
+  // query database
+  const [rows,fields] = await promisePool.query("SELECT 1");
+```
+
+MySQL2 exposes a .promise() function on Connections, to "upgrade" an existing non-promise connection to use promise
+```js
+async function main() {
+  // get the client
+  const mysql = require('mysql2');
+  // create the connection
+  mysql.createConnection(
+   {host:'localhost', user: 'root', database: 'test'},
+   (err,con) => {
+    con.promise().query("SELECT 1")
+    .then( ([rows,fields]) => {
+     console.log(rows);
+    })
+    .catch(console.log)
+    .then( () => con.end());
+   }
+  );
 ```
 
 ## API and Configuration

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ async function main() {
   // get the client
   const mysql = require('mysql2');
   // create the pool
-  const pool = await mysql.createPool({host:'localhost', user: 'root', database: 'test'});
+  const pool = mysql.createPool({host:'localhost', user: 'root', database: 'test'});
   // now get a Promise wrapped instance of that pool
   const promisePool = pool.promise();
-  // query database
+  // query database using promises
   const [rows,fields] = await promisePool.query("SELECT 1");
 ```
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -141,6 +141,12 @@ function Connection(opts) {
 }
 util.inherits(Connection, EventEmitter);
 
+Connection.prototype.promise = function() {
+  const PromiseConnection = require('../promise').PromiseConnection;
+  return new PromiseConnection(this);
+}
+
+
 Connection.prototype._addCommandClosedState = function(cmd) {
   var err = new Error(
     "Can't add new command when connection is in closed state"

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -141,9 +141,9 @@ function Connection(opts) {
 }
 util.inherits(Connection, EventEmitter);
 
-Connection.prototype.promise = function() {
+Connection.prototype.promise = function(promiseImpl) {
   const PromiseConnection = require('../promise').PromiseConnection;
-  return new PromiseConnection(this);
+  return new PromiseConnection(this,promiseImpl);
 }
 
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -20,9 +20,9 @@ function Pool(options) {
   this._closed = false;
 }
 
-Pool.prototype.promise = function() {
+Pool.prototype.promise = function(promiseImpl) {
   const PromisePool = require('../promise').PromisePool;
-  return new PromisePool(this);
+  return new PromisePool(this,promiseImpl);
 }
 
 Pool.prototype.getConnection = function(cb) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -20,6 +20,11 @@ function Pool(options) {
   this._closed = false;
 }
 
+Pool.prototype.promise = function() {
+  const PromisePool = require('../promise').PromisePool;
+  return new PromisePool(this);
+}
+
 Pool.prototype.getConnection = function(cb) {
   if (this._closed) {
     return process.nextTick(function() {

--- a/lib/pool_connection.js
+++ b/lib/pool_connection.js
@@ -33,9 +33,9 @@ PoolConnection.prototype.release = function() {
 // TODO: Remove this when we are removing PoolConnection#end
 PoolConnection.prototype._realEnd = Connection.prototype.end;
 
-PoolConnection.prototype.promise = function() {
+PoolConnection.prototype.promise = function(promiseImpl) {
   const PromisePoolConnection = require('../promise').PromisePoolConnection;
-  return new PromisePoolConnection(this);
+  return new PromisePoolConnection(this,promiseImpl);
 }
 
 PoolConnection.prototype.end = function() {

--- a/lib/pool_connection.js
+++ b/lib/pool_connection.js
@@ -33,6 +33,11 @@ PoolConnection.prototype.release = function() {
 // TODO: Remove this when we are removing PoolConnection#end
 PoolConnection.prototype._realEnd = Connection.prototype.end;
 
+PoolConnection.prototype.promise = function() {
+  const PromisePoolConnection = require('../promise').PromisePoolConnection;
+  return new PromisePoolConnection(this);
+}
+
 PoolConnection.prototype.end = function() {
   console.warn(
     'Calling conn.end() to release a pooled connection is ' +

--- a/package-lock.json
+++ b/package-lock.json
@@ -721,9 +721,9 @@
       "dev": true
     },
     "denque": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.2.4.tgz",
-      "integrity": "sha512-/VU7mVDHTVsLt2WbCwKJjz1EElceWJ9nyfnLpe/dWb3oIiRqJsd/Ae14m0dl17YdSOxSFGeyPpLBxMWFs7rc9g=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.3.0.tgz",
+      "integrity": "sha512-4SRaSj+PqmrS1soW5/Avd7eJIM2JJIqLLmwhRqIGleZM/8KwZq80njbSS2Iqas+6oARkSkLDHEk4mm78q3JlIg=="
     },
     "diff": {
       "version": "3.5.0",

--- a/promise.js
+++ b/promise.js
@@ -400,3 +400,6 @@ module.exports.escape = core.escape;
 module.exports.escapeId = core.escapeId;
 module.exports.format = core.format;
 module.exports.raw = core.raw;
+module.exports.PromisePool = PromisePool;
+module.exports.PromiseConnection = PromiseConnection;
+module.exports.PromisePoolConnection = PromisePoolConnection;

--- a/promise.js
+++ b/promise.js
@@ -53,7 +53,7 @@ function createConnection(opts) {
 
 function PromiseConnection(connection, promiseImpl) {
   this.connection = connection;
-  this.Promise = promiseImpl;
+  this.Promise = promiseImpl || global.Promise;
 
   inheritEvents(connection, this, [
     'error',
@@ -318,7 +318,7 @@ PromisePoolConnection.prototype.destroy = function() {
 
 function PromisePool(pool, Promise) {
   this.pool = pool;
-  this.Promise = Promise;
+  this.Promise = Promise || global.Promise;
 
   inheritEvents(pool, this, ['acquire', 'connection', 'enqueue', 'release']);
 }

--- a/test/unit/test-Pool.js
+++ b/test/unit/test-Pool.js
@@ -21,6 +21,26 @@ test('Pool', {
       "SELECT a FROM `table name` WHERE b = 'thing'"
     );
   }
+  
+});
+
+const poolDotPromise = pool.promise();
+test('Pool.promise()', {
+  'exposes escape': () => {
+    assert.equal(poolDotPromise.escape(123), '123');
+  },
+
+  'exposes escapeId': () => {
+    assert.equal(poolDotPromise.escapeId('table name'), '`table name`');
+  },
+
+  'exposes format': () => {
+    const params = ['table name', 'thing'];
+    assert.equal(
+      poolDotPromise.format('SELECT a FROM ?? WHERE b = ?', params),
+      "SELECT a FROM `table name` WHERE b = 'thing'"
+    );
+  }
 });
 
 const promisePool = new mysql.createPoolPromise(poolConfig);
@@ -41,3 +61,4 @@ test('PromisePool', {
     );
   }
 });
+


### PR DESCRIPTION
This adds a .promise() function to Pool, Connection, and PoolConnection, which allows you to wrap an existing non-promise instance of any of these objects with a promise wrapper.

See issue https://github.com/sidorares/node-mysql2/issues/809

Code is not well tested yet. I wrote a unit test for Pool which passes but not sure how to test a Connection.