### PR TITLE
Added .transaction(options ?,asyncFunction) to PromisePool & PromiseConnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,19 +220,22 @@ async function main() {
   );
 ```
 
-When using a promise pool, MySQL2 also exposes a .withConnection(asyncFunction) function for automatically disposing of the connection after you are finished working with it:
+### Using managed transaction
+
+When using a promise pool, MySQL2 offers a .transaction() function to allow you to execute code within a transaction, with pre-defined behavior to roll back the transaction on error, and which automatically releases the connection after you are finished working with it:
 ```js
 async function main() {
   // get the client
   const mysql = require('mysql2/promise');
   // create the pool
   const pool = mysql.createPool({host:'localhost', user: 'root', database: 'test'});
-  // using the pool, execute a query
-  pool.withConnection(async function(con) {
-   const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
-   console.log(rows);
+  // using the pool, execute a chain of queries within a transaction
+  pool.transaction({ autoCommit: false, readWrite: true, consistentSnapshot: false }, async function(con) {
+    const [rows, fields] = await con.query('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
+    await con.execute('INSERT INTO `table` (name,age) VALUES(?,?)', ['Bob',rows[0].age]); // Bob and Morty are the same age
   });
-  // No need to call con.release(), connection is automatically disposed of when using .withConnection()
+  // If the promise chain passed to .transaction() resolves, .transaction() commits the changes, and releases the connection.
+  // If the promise chain passed to .transaction() rejects, or if a connection or SQL error occures, .transaction() rolls back the changes, and releases the connection.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,22 @@ async function main() {
   );
 ```
 
+When using a promise pool, MySQL2 also exposes a .withConnection(asyncFunction) function for automatically disposing of the connection after you are finished working with it:
+```js
+async function main() {
+  // get the client
+  const mysql = require('mysql2/promise');
+  // create the pool
+  const pool = mysql.createPool({host:'localhost', user: 'root', database: 'test'});
+  // using the pool, execute a query
+  pool.withConnection(async function(con) {
+   const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
+   console.log(rows);
+  });
+  // No need to call con.release(), connection is automatically disposed of when using .withConnection()
+}
+```
+
 ## API and Configuration
 
 MySQL2 is mostly API compatible with [Node MySQL][node-mysql]. You should check their API documentation to see all available API options.

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -32,6 +32,12 @@ function Query(options, callback) {
 }
 util.inherits(Query, Command);
 
+Query.prototype.then = Query.prototype.catch = function() {
+ var err = "Error: you have tried to call .then(), .catch(), or invoked await on the result of query that is not a promise, which is a programming error. Throwing an error.";
+ console.log(err);
+ throw err;
+};
+
 Query.prototype.start = function(packet, connection) {
   if (connection.config.debug) {
     console.log('        Sending query command: %s', this.sql);

--- a/promise.js
+++ b/promise.js
@@ -342,7 +342,7 @@ PromisePool.prototype.getConnection = function() {
 PromisePool.prototype.withConnection = function(promise) {
   return this.getConnection()
   .then(function(con) {
-    return this.Promise.resolve(promise(con))
+    return this.Promise.resolve(con).then(promise)
     .catch(function(err) {
       con.release();
       throw err;

--- a/promise.js
+++ b/promise.js
@@ -339,6 +339,20 @@ PromisePool.prototype.getConnection = function() {
   });
 };
 
+PromisePool.prototype.withConnection = function(promise) {
+  return this.getConnection()
+  .then(function(con) {
+    return this.Promise.resolve(promise(con))
+    .catch(function(err) {
+      con.release();
+      throw err;
+    })
+    .then(function() {
+      con.release();
+    });
+  });
+};
+
 PromisePool.prototype.query = function(sql, args) {
   const corePool = this.pool;
   const localErr = new Error();

--- a/promise.js
+++ b/promise.js
@@ -98,10 +98,10 @@ PromiseConnection.prototype.query = function(query, params) {
 };
 
 PromiseConnection.prototype.execute = function(query, params) {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     if (params) {
       c.execute(query, params, done);
     } else {
@@ -111,7 +111,7 @@ PromiseConnection.prototype.execute = function(query, params) {
 };
 
 PromiseConnection.prototype.end = function() {
-  var c = this.connection;
+  const c = this.connection;
   return new this.Promise(function(resolve, reject) {
     c.end(function() {
       resolve();
@@ -120,41 +120,43 @@ PromiseConnection.prototype.end = function() {
 };
 
 PromiseConnection.prototype.beginTransaction = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     c.beginTransaction(done);
   });
 };
 
 PromiseConnection.prototype.commit = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     c.commit(done);
   });
 };
 
 PromiseConnection.prototype.rollback = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     c.rollback(done);
   });
 };
 
 PromiseConnection.prototype.ping = function() {
-  var c = this.connection;
+  const c = this.connection;
+  const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    c.ping(resolve);
+    const done = makeDoneCb(resolve, reject, localErr);
+    c.ping(done);
   });
 };
 
 PromiseConnection.prototype.connect = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     c.connect(function(err, param) {
@@ -173,8 +175,8 @@ PromiseConnection.prototype.connect = function() {
 };
 
 PromiseConnection.prototype.prepare = function(options) {
-  var c = this.connection;
-  var promiseImpl = this.Promise;
+  const c = this.connection;
+  const promiseImpl = this.Promise;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     c.prepare(options, function(err, statement) {
@@ -186,7 +188,7 @@ PromiseConnection.prototype.prepare = function(options) {
         localErr.sqlMessage = err.sqlMessage;
         reject(localErr);
       } else {
-        var wrappedStatement = new PromisePreparedStatementInfo(
+        const wrappedStatement = new PromisePreparedStatementInfo(
           statement,
           promiseImpl
         );
@@ -197,7 +199,7 @@ PromiseConnection.prototype.prepare = function(options) {
 };
 
 PromiseConnection.prototype.changeUser = function(options) {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     c.changeUser(options, function(err) {
@@ -262,10 +264,10 @@ function PromisePreparedStatementInfo(statement, promiseImpl) {
 }
 
 PromisePreparedStatementInfo.prototype.execute = function(parameters) {
-  var s = this.statement;
-  var localErr = new Error();
+  const s = this.statement;
+  const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     if (parameters) {
       s.execute(parameters, done);
     } else {
@@ -275,7 +277,7 @@ PromisePreparedStatementInfo.prototype.execute = function(parameters) {
 };
 
 PromisePreparedStatementInfo.prototype.close = function() {
-  var s = this.statement;
+  const s = this.statement;
   return new this.Promise(function(resolve, reject) {
     s.close();
     resolve();
@@ -292,7 +294,7 @@ PromisePreparedStatementInfo.prototype.close = function() {
 // proxy synchronous functions only
 (function(functionsToWrap) {
   for (var i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
-    var func = functionsToWrap[i];
+    const func = functionsToWrap[i];
 
     if (
       typeof core.Connection.prototype[func] === 'function' &&
@@ -323,8 +325,8 @@ PromisePreparedStatementInfo.prototype.close = function() {
 ]);
 
 (function(functionsToWrap) {
-  for (var i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
-    var func = functionsToWrap[i];
+  for (const i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
+    const func = functionsToWrap[i];
 
     if (
       typeof core.Pool.prototype[func] === 'function' &&
@@ -366,8 +368,8 @@ function PromisePool(pool, Promise) {
 util.inherits(PromisePool, EventEmitter);
 
 PromisePool.prototype.getConnection = function() {
-  var self = this;
-  var corePool = this.pool;
+  const self = this;
+  const corePool = this.pool;
 
   return new this.Promise(function(resolve, reject) {
     corePool.getConnection(function(err, coreConnection) {
@@ -399,7 +401,7 @@ PromisePool.prototype.query = function(sql, args) {
   const corePool = this.pool;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     if (args) {
       corePool.query(sql, args, done);
     } else {
@@ -409,7 +411,7 @@ PromisePool.prototype.query = function(sql, args) {
 };
 
 PromisePool.prototype.execute = function(sql, values) {
-  var corePool = this.pool;
+  const corePool = this.pool;
   const localErr = new Error();
 
   return new this.Promise(function(resolve, reject) {
@@ -418,7 +420,7 @@ PromisePool.prototype.execute = function(sql, values) {
 };
 
 PromisePool.prototype.end = function() {
-  var corePool = this.pool;
+  const corePool = this.pool;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     corePool.end(function(err) {
@@ -437,8 +439,8 @@ PromisePool.prototype.end = function() {
 };
 
 function createPool(opts) {
-  var corePool = core.createPool(opts);
-  var Promise = opts.Promise || global.Promise;
+  const corePool = core.createPool(opts);
+  const Promise = opts.Promise || global.Promise;
   if (!Promise) {
     throw new Error(
       'no Promise implementation available.' +

--- a/promise.js
+++ b/promise.js
@@ -325,7 +325,7 @@ PromisePreparedStatementInfo.prototype.close = function() {
 ]);
 
 (function(functionsToWrap) {
-  for (const i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
+  for (var i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
     const func = functionsToWrap[i];
 
     if (

--- a/promise.js
+++ b/promise.js
@@ -351,7 +351,7 @@ PromisePool.prototype.transaction = function(options,userPromise) {
  
   return this.getConnection()
   .then(function(con) {
-    const promiseChain = Promise.resolve();
+    var promiseChain = Promise.resolve();
 
     if (options.autoCommit === false) {
       promiseChain = promiseChain.then(function() {

--- a/test/integration/connection/test-then-on-query.js
+++ b/test/integration/connection/test-then-on-query.js
@@ -1,0 +1,17 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var error = true;
+
+var q = connection.query('SELECT 1')
+try {
+ if (q.then) q.then();
+} catch (err) {
+ error = false;
+}
+
+process.on('exit', function() {
+  assert.equal(error, false);
+});
+ 


### PR DESCRIPTION
This PR adds a .withConnection(asyncFunction) function to PromisePool, which allows the user to borrow a connection from the connection pool, run as many queries as they like, and then it will automatically release the connection back to the pool when the asyncFunction(con) they pass in either resolves or rejects.

Solves a garbage disposal problem when using promise pools.