### PR TITLE
Fix .ping(), error checking for Query.then(), const correctness

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -33,7 +33,7 @@ function Query(options, callback) {
 util.inherits(Query, Command);
 
 Query.prototype.then = Query.prototype.catch = function() {
- var err = "Error: you have tried to call .then(), .catch(), or invoked await on the result of query that is not a promise, which is a programming error. Throwing an error.";
+ var err = "Error: you have tried to call .then(), .catch(), or invoked await on the result of query that is not a promise, which is a programming error. Try calling con.promise().query(), or require('mysql2/promise') instead of 'mysql2' for a promise-compatible version of the query interface. To learn how to use async/await or Promises check out documentation at https://www.npmjs.com/package/mysql2#using-promise-wrapper, or the mysql2 documentation at https://github.com/sidorares/node-mysql2/tree/master/documentation/Promise-Wrapper.md";
  console.log(err);
  throw err;
 };

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -32,6 +32,12 @@ function Query(options, callback) {
 }
 util.inherits(Query, Command);
 
+Query.prototype.then = Query.prototype.catch = function() {
+ var err = "Error: you have tried to call .then(), .catch(), or invoked await on the result of query that is not a promise, which is a programming error. Throwing an error.";
+ console.log(err);
+ throw err;
+};
+
 Query.prototype.start = function(packet, connection) {
   if (connection.config.debug) {
     console.log('        Sending query command: %s', this.sql);

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -33,9 +33,9 @@ function Query(options, callback) {
 util.inherits(Query, Command);
 
 Query.prototype.then = Query.prototype.catch = function() {
- var err = "Error: you have tried to call .then(), .catch(), or invoked await on the result of query that is not a promise, which is a programming error. Try calling con.promise().query(), or require('mysql2/promise') instead of 'mysql2' for a promise-compatible version of the query interface. To learn how to use async/await or Promises check out documentation at https://www.npmjs.com/package/mysql2#using-promise-wrapper, or the mysql2 documentation at https://github.com/sidorares/node-mysql2/tree/master/documentation/Promise-Wrapper.md";
+ var err = "You have tried to call .then(), .catch(), or invoked await on the result of query that is not a promise, which is a programming error. Try calling con.promise().query(), or require('mysql2/promise') instead of 'mysql2' for a promise-compatible version of the query interface. To learn how to use async/await or Promises check out documentation at https://www.npmjs.com/package/mysql2#using-promise-wrapper, or the mysql2 documentation at https://github.com/sidorares/node-mysql2/tree/master/documentation/Promise-Wrapper.md";
  console.log(err);
- throw err;
+ throw new Error(err);
 };
 
 Query.prototype.start = function(packet, connection) {

--- a/promise.js
+++ b/promise.js
@@ -284,7 +284,7 @@ PromisePreparedStatementInfo.prototype.close = function() {
 ]);
 
 (function(functionsToWrap) {
-  for (const i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
+  for (var i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
     const func = functionsToWrap[i];
 
     if (

--- a/promise.js
+++ b/promise.js
@@ -98,10 +98,10 @@ PromiseConnection.prototype.query = function(query, params) {
 };
 
 PromiseConnection.prototype.execute = function(query, params) {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     if (params) {
       c.execute(query, params, done);
     } else {
@@ -111,7 +111,7 @@ PromiseConnection.prototype.execute = function(query, params) {
 };
 
 PromiseConnection.prototype.end = function() {
-  var c = this.connection;
+  const c = this.connection;
   return new this.Promise(function(resolve, reject) {
     c.end(function() {
       resolve();
@@ -120,41 +120,43 @@ PromiseConnection.prototype.end = function() {
 };
 
 PromiseConnection.prototype.beginTransaction = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     c.beginTransaction(done);
   });
 };
 
 PromiseConnection.prototype.commit = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     c.commit(done);
   });
 };
 
 PromiseConnection.prototype.rollback = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     c.rollback(done);
   });
 };
 
 PromiseConnection.prototype.ping = function() {
-  var c = this.connection;
+  const c = this.connection;
+  const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    c.ping(resolve);
+    const done = makeDoneCb(resolve, reject, localErr);
+    c.ping(done);
   });
 };
 
 PromiseConnection.prototype.connect = function() {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     c.connect(function(err, param) {
@@ -173,8 +175,8 @@ PromiseConnection.prototype.connect = function() {
 };
 
 PromiseConnection.prototype.prepare = function(options) {
-  var c = this.connection;
-  var promiseImpl = this.Promise;
+  const c = this.connection;
+  const promiseImpl = this.Promise;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     c.prepare(options, function(err, statement) {
@@ -186,7 +188,7 @@ PromiseConnection.prototype.prepare = function(options) {
         localErr.sqlMessage = err.sqlMessage;
         reject(localErr);
       } else {
-        var wrappedStatement = new PromisePreparedStatementInfo(
+        const wrappedStatement = new PromisePreparedStatementInfo(
           statement,
           promiseImpl
         );
@@ -197,7 +199,7 @@ PromiseConnection.prototype.prepare = function(options) {
 };
 
 PromiseConnection.prototype.changeUser = function(options) {
-  var c = this.connection;
+  const c = this.connection;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     c.changeUser(options, function(err) {
@@ -221,10 +223,10 @@ function PromisePreparedStatementInfo(statement, promiseImpl) {
 }
 
 PromisePreparedStatementInfo.prototype.execute = function(parameters) {
-  var s = this.statement;
-  var localErr = new Error();
+  const s = this.statement;
+  const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     if (parameters) {
       s.execute(parameters, done);
     } else {
@@ -234,7 +236,7 @@ PromisePreparedStatementInfo.prototype.execute = function(parameters) {
 };
 
 PromisePreparedStatementInfo.prototype.close = function() {
-  var s = this.statement;
+  const s = this.statement;
   return new this.Promise(function(resolve, reject) {
     s.close();
     resolve();
@@ -251,7 +253,7 @@ PromisePreparedStatementInfo.prototype.close = function() {
 // proxy synchronous functions only
 (function(functionsToWrap) {
   for (var i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
-    var func = functionsToWrap[i];
+    const func = functionsToWrap[i];
 
     if (
       typeof core.Connection.prototype[func] === 'function' &&
@@ -282,8 +284,8 @@ PromisePreparedStatementInfo.prototype.close = function() {
 ]);
 
 (function(functionsToWrap) {
-  for (var i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
-    var func = functionsToWrap[i];
+  for (const i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
+    const func = functionsToWrap[i];
 
     if (
       typeof core.Pool.prototype[func] === 'function' &&
@@ -325,8 +327,8 @@ function PromisePool(pool, Promise) {
 util.inherits(PromisePool, EventEmitter);
 
 PromisePool.prototype.getConnection = function() {
-  var self = this;
-  var corePool = this.pool;
+  const self = this;
+  const corePool = this.pool;
 
   return new this.Promise(function(resolve, reject) {
     corePool.getConnection(function(err, coreConnection) {
@@ -343,7 +345,7 @@ PromisePool.prototype.query = function(sql, args) {
   const corePool = this.pool;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
-    var done = makeDoneCb(resolve, reject, localErr);
+    const done = makeDoneCb(resolve, reject, localErr);
     if (args) {
       corePool.query(sql, args, done);
     } else {
@@ -353,7 +355,7 @@ PromisePool.prototype.query = function(sql, args) {
 };
 
 PromisePool.prototype.execute = function(sql, values) {
-  var corePool = this.pool;
+  const corePool = this.pool;
   const localErr = new Error();
 
   return new this.Promise(function(resolve, reject) {
@@ -362,7 +364,7 @@ PromisePool.prototype.execute = function(sql, values) {
 };
 
 PromisePool.prototype.end = function() {
-  var corePool = this.pool;
+  const corePool = this.pool;
   const localErr = new Error();
   return new this.Promise(function(resolve, reject) {
     corePool.end(function(err) {
@@ -381,8 +383,8 @@ PromisePool.prototype.end = function() {
 };
 
 function createPool(opts) {
-  var corePool = core.createPool(opts);
-  var Promise = opts.Promise || global.Promise;
+  const corePool = core.createPool(opts);
+  const Promise = opts.Promise || global.Promise;
   if (!Promise) {
     throw new Error(
       'no Promise implementation available.' +

--- a/test/integration/connection/test-then-on-query.js
+++ b/test/integration/connection/test-then-on-query.js
@@ -10,6 +10,9 @@ try {
 } catch (err) {
  error = false;
 }
+q.on('end', function() {
+ connection.destroy();
+});
 
 process.on('exit', function() {
   assert.equal(error, false);

--- a/test/integration/connection/test-then-on-query.js
+++ b/test/integration/connection/test-then-on-query.js
@@ -1,0 +1,17 @@
+var common = require('../../common');
+var connection = common.createConnection();
+var assert = require('assert');
+
+var error = true;
+
+var q = connection.query('SELECT 1')
+try {
+ if (q.then) q.then();
+} catch (err) {
+ error = false;
+}
+
+process.on('exit', function() {
+  assert.equal(error, false);
+});
+ 


### PR DESCRIPTION
This PR includes 3 changes:
- A fix for PromiseConnection.ping(), as it was not failing on errors
- An error is now thrown if .then() or .catch() is called on a non-promise Query
- promise.js was updated to consistently use const instead of var