### PR TITLE
Added a uri: parameter to the connection config

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -3,6 +3,49 @@ var ClientConstants = require('./constants/client');
 var Charsets = require('./constants/charsets');
 var SSLProfiles = null;
 
+const validOptions = {
+ authSwitchHandler: 1,
+ bigNumberStrings: 1,
+ charset: 1,
+ charsetNumber: 1,
+ compress: 1,
+ connectAttributes: 1,
+ connectTimeout: 1,
+ database: 1,
+ dateStrings: 1,
+ debug: 1,
+ decimalNumbers: 1,
+ flags: 1,
+ host: 1,
+ insecureAuth: 1,
+ isServer: 1,
+ localAddress: 1,
+ maxPreparedStatements: 1,
+ multipleStatements: 1,
+ namedPlaceholders: 1,
+ nestTables: 1,
+ password: 1,
+ passwordSha1: 1,
+ pool: 1,
+ port: 1,
+ queryFormat: 1,
+ rowsAsArray: 1,
+ socketPath: 1,
+ ssl: 1,
+ stream: 1,
+ stringifyObjects: 1,
+ supportBigNumbers: 1,
+ timezone: 1,
+ trace: 1,
+ typeCast: 1,
+ uri: 1,
+ user: 1,
+ // These options are used for Pool
+ connectionLimit: 1,
+ queueLimit: 1,
+ waitForConnections: 1,
+};
+
 module.exports = ConnectionConfig;
 function ConnectionConfig(options) {
   if (typeof options === 'string') {
@@ -14,6 +57,12 @@ function ConnectionConfig(options) {
       if (options[key]) continue;
       options[key] = uriOptions[key];
     }
+  }
+  for (var key in options) {
+   if (! options.hasOwnProperty(key)) continue;
+   if (validOptions[key] !== 1) {
+    console.error('Ignoring invalid configuration option passed to Connection: ' + key + '. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration options to a Connection');
+   }
   }
         
   this.isServer = options.isServer;

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -7,8 +7,15 @@ module.exports = ConnectionConfig;
 function ConnectionConfig(options) {
   if (typeof options === 'string') {
     options = ConnectionConfig.parseUrl(options);
+  } else if (options && options.uri) {
+    var uriOptions = ConnectionConfig.parseUrl(options.uri);
+    for (var key in uriOptions) {
+      if (! uriOptions.hasOwnProperty(key)) continue;
+      if (options[key]) continue;
+      options[key] = uriOptions[key];
+    }
   }
-
+        
   this.isServer = options.isServer;
   this.stream = options.stream;
 

--- a/test/common.js
+++ b/test/common.js
@@ -7,7 +7,9 @@ var config = {
   port: process.env.MYSQL_PORT || 3306
 };
 
+console.log(config);
 var configURI = "mysql://" + config.user + ":" + config.password + "@" + config.host + ":" + config.port + "/" + config.database;
+console.log(configURI);
 
 module.exports.SqlString = require('sqlstring');
 module.exports.config = config;

--- a/test/common.js
+++ b/test/common.js
@@ -154,7 +154,7 @@ module.exports.createPool = function(callback) {
 module.exports.createConnectionWithURI = function(callback) {
   var driver = require('../index.js');
   
-  return driver.createConnection(configURI);
+  return driver.createConnection({ uri: configURI });
 };
 
 module.exports.createTemplate = function() {

--- a/test/common.js
+++ b/test/common.js
@@ -1,15 +1,13 @@
 var config = {
   host: process.env.MYSQL_HOST || 'localhost',
   user: process.env.MYSQL_USER || 'root',
-  password: process.env.CI ? process.env.MYSQL_PASSWORD : '',
+  password: (process.env.CI ? process.env.MYSQL_PASSWORD : '') || '',
   database: process.env.MYSQL_DATABASE || 'test',
   compress: process.env.MYSQL_USE_COMPRESSION,
   port: process.env.MYSQL_PORT || 3306
 };
 
-console.log(config);
 var configURI = "mysql://" + config.user + ":" + config.password + "@" + config.host + ":" + config.port + "/" + config.database;
-console.log(configURI);
 
 module.exports.SqlString = require('sqlstring');
 module.exports.config = config;

--- a/test/common.js
+++ b/test/common.js
@@ -7,6 +7,8 @@ var config = {
   port: process.env.MYSQL_PORT || 3306
 };
 
+var configURI = "mysql://" + config.user + ":" + config.password + "@" + config.host + ":" + config.port + "/" + config.database;
+
 module.exports.SqlString = require('sqlstring');
 module.exports.config = config;
 
@@ -147,6 +149,12 @@ module.exports.createPool = function(callback) {
   }
 
   return driver.createPool(config);
+};
+
+module.exports.createConnectionWithURI = function(callback) {
+  var driver = require('../index.js');
+  
+  return driver.createConnection(configURI);
 };
 
 module.exports.createTemplate = function() {

--- a/test/integration/connection/test-connect-with-uri.js
+++ b/test/integration/connection/test-connect-with-uri.js
@@ -1,0 +1,20 @@
+var common = require('../../common');
+var connection = common.createConnectionWithURI();
+var assert = require('assert');
+
+var rows = undefined;
+var fields = undefined;
+connection.query('SELECT 1', function(err, _rows, _fields) {
+  if (err) {
+    throw err;
+  }
+
+  rows = _rows;
+  fields = _fields;
+  connection.end();
+});
+
+process.on('exit', function() {
+  assert.deepEqual(rows, [{ 1: 1 }]);
+  assert.equal(fields[0].name, '1');
+});

--- a/test/unit/test-Pool.js
+++ b/test/unit/test-Pool.js
@@ -2,7 +2,7 @@ const mysql = require('../..');
 const test = require('utest');
 const assert = require('assert');
 
-const poolConfig = { config: { connectionConfig: {} } };
+const poolConfig = {}; // config: { connectionConfig: {} } };
 
 const pool = new mysql.createPool(poolConfig);
 test('Pool', {


### PR DESCRIPTION
Frequently, I find myself using the following code:

```js
mysql.createPool(process.env.MYSQL_URI);
```

Unfortunately, when passing in a URI from an environment variable, it means that my application is unable to override any of the URI parameters, as createPool and createConnection only accept either URI String or Object parameters, not both at once.

This PR allows you to use both formats, by passing a uri: key into the options:
```js
mysql.createPool({
  uri: process.env.MYSQL_URI,
  multipleStatements: true
});
```

In the case of overlapping parameters, the Object parameters are currently given preference over the URI String parameters. I'm not sure if that is the correct preference. 