### PR TITLE
allow use streaming query rows from promise-connection

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -97,6 +97,11 @@ PromiseConnection.prototype.query = function(query, params) {
   });
 };
 
+PromiseConnection.prototype.streamingQuery = function(query, params) {
+  const c = this.connection;
+  return c.query(query, params);
+};
+
 PromiseConnection.prototype.execute = function(query, params) {
   const c = this.connection;
   const localErr = new Error();


### PR DESCRIPTION
https://github.com/mysqljs/mysql#streaming-query-rows
sometime, streaming results interface is useful
add `streamingQuery` to PromiseConnection
directly export original `connection.query` to access streaming interface

