### PR TITLE
Added changelog for next release

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,17 @@
+1.6.0 (01/08/2018)
+ - Fixed `PromiseConnection.ping()` ignoring errors   #813
+ - Added a uri parameter to the connection config     #815
+ - Added a `.promise()` method shortcut on Pool,
+   Connection and PoolConnection                      #810 
+ - Added more functions from node-mysql:
+   `createQuery`, `raw`, `escape`, `escapeId`,
+   `format`                                           #799
+ - Added `acquire` and `release` and release events
+   on Connection                                      #783
+ - Added support for a Japanese charset `ujis`        #772
+ - Improved error handling on `ECONNRESET`            #768
+ - Drop support for Node 4                            #791
+
 1.5.3 (19/03/2018)
  - fix incorrect denque dependency                     #740
  - build: bump to node 8.10 and 6.16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mysql2",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "fast mysql driver. Implements core protocol, prepared statements, ssl and compression in native JS",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
As per title and following issue https://github.com/sidorares/node-mysql2/issues/820.

Regarding the version number:
The new features in this release are backward compatible, therefore I bumped the minor only (following semver).

Given we're also dropping support for node 4, we may want to bump the major.