### PR TITLE
document query() method with at least a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The pool does not create all connections upfront but creates them on demand unti
 You can use the pool in the same way as connections (using `pool.query()` and `pool.execute()`):
 ```js
 // For pool initialization, see above
-pool.query(function(err, rows, fields) {
+pool.query("SELECT field FROM atable", function(err, rows, fields) {
    // Connection is automatically released when query resolves
 })
 ```


### PR DESCRIPTION
pool.query() method need requires a string first parameter, optional array as second, and callback (and execute() also)
examples/pool-test.js has to be fixed as well (TODO)