### PR TITLE
Fix issue #711: close emitted before end

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -245,8 +245,8 @@ class Query extends Command {
       stream.emit('error', err); // Pass on any errors
     });
     this.on('end', function () {
-      stream.emit('close'); // notify readers that query has completed
       stream.push(null); // pushing null, indicating EOF
+      stream.emit('close'); // notify readers that query has completed
     });
     this.on('fields', function (fields) {
       stream.emit('fields', fields); // replicate old emitter


### PR DESCRIPTION
The 'end' event (emitted by `stream.push(null)`) should always be emitted before the close event.
This fixes issue https://github.com/sidorares/node-mysql2/issues/711