### PR TITLE
Use stream close event instead of end

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -79,7 +79,7 @@ class Connection extends EventEmitter {
       }
       connection.packetParser.execute(data);
     });
-    this.stream.on('end', function() {
+    this.stream.on('close', function() {
       // we need to set this flag everywhere where we want connection to close
       if (connection._closing) {
         return;


### PR DESCRIPTION
The "Socket ended by other party error" seems to be caused by the `end` event not being fired in certain cases (TLS connections?). Using the `close` event instead makes sure that timed out connections are removed from the pool.

Related node issue(?): https://github.com/nodejs/node/issues/10871

Fixes #447 