### PR TITLE
fix(debug): remove usage of callee

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -467,9 +467,10 @@ class Connection extends EventEmitter {
     // this.compressedSequenceId = 0;
     // this.sequenceId = 0;
     if (this.config.debug) {
+      const commandName = cmd.constructor.name;
       // eslint-disable-next-line no-console
-      console.log('Add command: ' + arguments.callee.caller.name);
-      cmd._commandName = arguments.callee.caller.name;
+      console.log('Add command: ' + commandName);
+      cmd._commandName = commandName;
     }
     if (!this._command) {
       this._command = cmd;


### PR DESCRIPTION
Fixes #881
I kinda want to add a test but maybe it would be a good idea to run one of the test instances with `DEBUG=1` instead, that would instantly ensure that they at least don't cause errors :)

In any case it's 3am and I really don't want to deep dive into this right now.