### PR TITLE
Fixed a bug when ssl config is a boolean and a property is added to it

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -113,6 +113,11 @@ class ConnectionConfig {
       this.timezone = '+' + this.timezone.substr(1);
     }
     if (this.ssl) {
+      if (typeof this.ssl !== 'object') {
+        throw new TypeError(
+          "SSL profile must be an object, instead it's a " + typeof this.ssl
+        );
+      }
       // Default rejectUnauthorized to true
       this.ssl.rejectUnauthorized = this.ssl.rejectUnauthorized !== false;
     }

--- a/test/unit/connection/test-connection_config.js
+++ b/test/unit/connection/test-connection_config.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const ConnectionConfig = require('../../../lib/connection_config');
+
+const assert = require('assert');
+
+const expectedMessage = "SSL profile must be an object, instead it's a boolean";
+
+assert.throws(
+  () =>
+    new ConnectionConfig({
+      ssl: true
+    }),
+  err => err instanceof TypeError && err.message === expectedMessage,
+  'Error, the constructor accepts a boolean without throwing the right exception'
+);
+
+assert.doesNotThrow(
+  () =>
+    new ConnectionConfig({
+      ssl: {}
+    }),
+  'Error, the constructor accepts an object but throws an exception'
+);
+
+assert.doesNotThrow(() => {
+  const SSLProfiles = require('../../../lib/constants/ssl_profiles.js');
+  const sslProfile = Object.keys(SSLProfiles)[0];
+  new ConnectionConfig({
+    ssl: sslProfile
+  });
+}, 'Error, the constructor accepts a string but throws an exception');


### PR DESCRIPTION
Sequelizejs passes ssl configuration as a boolean.
This will assign `true` to this.ssl at line 99
```js
    this.ssl =
      typeof options.ssl === 'string'
        ? ConnectionConfig.getSSLProfile(options.ssl)
        : options.ssl || false;
```
and eventually pass the check at line 115 and assign a property to a boolean that will throw a TypeError in strict mode.
This doesn't attempt to fix the bug, but it gives a better error message.