### PR TITLE
Fix when ssl is boolean value, it can not be set rejectUnauthorized issue

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -112,7 +112,7 @@ class ConnectionConfig {
       // connection string..
       this.timezone = '+' + this.timezone.substr(1);
     }
-    if (this.ssl) {
+    if (this.ssl && typeof this.ssl === 'object') {
       // Default rejectUnauthorized to true
       this.ssl.rejectUnauthorized = this.ssl.rejectUnauthorized !== false;
     }


### PR DESCRIPTION
If `ssl` is a boolean value, and it is `true`.
the code will set a property for a boolean value and will throw error : Cannot create property 'rejectUnauthorized' on boolean 'true'