### PR TITLE
(fix/query): Row parsing could lead to uncaught errors

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -226,12 +226,18 @@ class Query extends Command {
       }
       return this.done();
     }
-    const row = new this._rowParser(
-      packet,
-      this._fields[this._resultIndex],
-      this.options,
-      CharsetToEncoding
-    );
+    let row;
+    try {
+      row = new this._rowParser(
+        packet,
+        this._fields[this._resultIndex],
+        this.options,
+        CharsetToEncoding
+      );
+    } catch (err) {
+      this._localStreamError = err;
+      return this.doneInsert(null);
+    }
     if (this.onResult) {
       this._rows[this._resultIndex].push(row);
     } else {

--- a/test/unit/commands/test-query.js
+++ b/test/unit/commands/test-query.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('assert');
+const Query = require('../../../lib/commands/query');
+
+const testError = new Error('something happened');
+const testQuery = new Query({}, (err, res) => {
+  assert.equal(err, testError);
+  assert.equal(res, null);
+});
+
+testQuery._rowParser = class FailingRowParser {
+  constructor() {
+    throw testError;
+  }
+};
+
+testQuery.row({
+  isEOF: () => false
+});


### PR DESCRIPTION
Data type parsers could throw an exception, e.g. `JSON.parse` for the JSON type. Currently, this exception is unhandled and crashes the application that receives it.

This change does the catching and passes it to either the callback, or the error event subscribers in order to support graceful recover if needed.