### PR TITLE
Pool and Connection closed error codes.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -134,6 +134,7 @@ class Connection extends EventEmitter {
     const err = new Error(
       "Can't add new command when connection is in closed state"
     );
+    err.code = 'CONNECTION_CLOSED';
     err.fatal = true;
     if (cmd.onResult) {
       cmd.onResult(err);
@@ -148,7 +149,9 @@ class Connection extends EventEmitter {
     this.stream.removeAllListeners('data');
     this.addCommand = this._addCommandClosedState;
     this.write = () => {
-      this.emit('error', new Error("Can't write in closed state"));
+      const err = new Error("Can't write in closed state");
+      err.code = 'CONNECTION_CLOSED';
+      this.emit('error', err);
     };
     this._notifyError(err);
     this._fatalError = err;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -35,7 +35,7 @@ class Pool extends EventEmitter {
 
   getConnection(cb) {
     if (this._closed) {
-      return process.nextTick(() => cb(new Error('Pool is closed.')));
+      return process.nextTick(() => cb(Pool._generatePoolIsClosedError()));
     }
     let connection;
     if (this._freeConnections.length > 0) {
@@ -53,7 +53,7 @@ class Pool extends EventEmitter {
       this._allConnections.push(connection);
       return connection.connect(err => {
         if (this._closed) {
-          return cb(new Error('Pool is closed.'));
+          return process.nextTick(() => cb(Pool._generatePoolIsClosedError()));
         }
         if (err) {
           return cb(err);
@@ -194,6 +194,12 @@ class Pool extends EventEmitter {
 
   escapeId(value) {
     return mysql.escapeId(value, false);
+  }
+
+  static _generatePoolIsClosedError() {
+    const err = new Error('Pool is closed.');
+    err.code = 'POOL_CLOSED';
+    return err;
   }
 }
 

--- a/test/unit/test-Pool.js
+++ b/test/unit/test-Pool.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const mysql = require('../..');
+const Pool = require('../../lib/pool');
 const test = require('utest');
 const assert = require('assert');
 
@@ -22,6 +23,20 @@ test('Pool', {
       pool.format('SELECT a FROM ?? WHERE b = ?', params),
       "SELECT a FROM `table name` WHERE b = 'thing'"
     );
+  },
+  'pool is closed error message': () => {
+    const poolIsClosedError = Pool._generatePoolIsClosedError();
+    assert.equal(
+      poolIsClosedError.message,
+      'Pool is closed.'
+    )
+  },
+  'pool is closed error code': () => {
+    const poolIsClosedError = Pool._generatePoolIsClosedError();
+    assert.equal(
+      poolIsClosedError.code,
+      'POOL_CLOSED'
+    )
   }
 });
 


### PR DESCRIPTION
The POOL_CLOSED err.code is in the original MySQL node module and exists every time the 'Pool is closed.' error message appears.

The CONNECTION_CLOSED does NOT exist in the original MySQL node module but I would like to add it for consistency.

I would definitely like to get POOL_CLOSED code in but I understand if you don't want to do CONNECTION_CLOSED. I can change any code style to your liking.

Thanks! 