### PR TITLE
Connection.execute() must honor callback

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -600,29 +600,41 @@ class Connection extends EventEmitter {
     // check for values containing undefined
     if (options.values) {
       //If namedPlaceholder is not enabled and object is passed as bind parameters
+      let err = null;
       if (!Array.isArray(options.values)) {
-        throw new TypeError(
+        err = new TypeError(
           'Bind parameters must be array if namedPlaceholders parameter is not enabled'
         );
       }
-      options.values.forEach(val => {
+      err || options.values.every(val => {
         //If namedPlaceholder is not enabled and object is passed as bind parameters
         if (!Array.isArray(options.values)) {
-          throw new TypeError(
+          err = new TypeError(
             'Bind parameters must be array if namedPlaceholders parameter is not enabled'
           );
+          return false;
         }
         if (val === undefined) {
-          throw new TypeError(
+          err = new TypeError(
             'Bind parameters must not contain undefined. To pass SQL NULL specify JS null'
           );
+          return false;
         }
         if (typeof val === 'function') {
-          throw new TypeError(
+          err = new TypeError(
             'Bind parameters must not contain function(s). To pass the body of a function as a string call .toString() first'
           );
+          return false;
         }
+        return true;
       });
+
+      if (err && cb) {
+        cb(err);
+        return null;
+      } else if (err) {
+        throw err;
+      }
     }
     const executeCommand = new Commands.Execute(options, cb);
     const prepareCommand = new Commands.Prepare(options, (err, stmt) => {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -161,9 +161,11 @@ class Pool extends EventEmitter {
         return cb(err);
       }
       const executeCmd = conn.execute(sql, values, cb);
-      executeCmd.once('end', () => {
-        conn.release();
-      });
+      if (executeCmd) {
+        executeCmd.once('end', () => {
+          conn.release();
+        });
+      }
     });
   }
 


### PR DESCRIPTION
If there is a callback provided to Connection.execute(), do not throw any exceptions.