### PR TITLE
Allow to set minVersion ssl option

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -301,7 +301,8 @@ class Connection extends EventEmitter {
       cert: this.config.ssl.cert,
       ciphers: this.config.ssl.ciphers,
       key: this.config.ssl.key,
-      passphrase: this.config.ssl.passphrase
+      passphrase: this.config.ssl.passphrase,
+      minVersion: this.config.ssl.minVersion
     });
     const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
     let secureEstablished = false;


### PR DESCRIPTION
This option allows Node v12.1.0 to connect to a server using 'TLSv1.1' because Node v12.1.0 minVersion default is 'TLSv1.2'.

Otherwise Node v12.1.0 has to be run with --tls-min-v1.1 CLI option.