### PR TITLE
Fix a MaxListenersExceededWarning with stream local infile

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -138,6 +138,9 @@ class Query extends Command {
   }
 
   _streamLocalInfile(connection) {
+    const onConnectionError = () => {
+      this._unpipeStream();
+    };
     const onDrain = () => {
       this._localStream.resume();
     };
@@ -152,10 +155,12 @@ class Query extends Command {
       );
     };
     const onEnd = () => {
+      connection.removeListener('error', onConnectionError);
       connection.writePacket(EmptyPacket);
     };
     const onError = err => {
       this._localStreamError = err;
+      connection.removeListener('error', onConnectionError);
       connection.writePacket(EmptyPacket);
     };
     this._unpipeStream = () => {
@@ -170,9 +175,7 @@ class Query extends Command {
     this._localStream.on('data', onData);
     this._localStream.on('end', onEnd);
     this._localStream.on('error', onError);
-    connection.once('error', () => {
-      this._unpipeStream();
-    });
+    connection.once('error', onConnectionError);
   }
 
   readField(packet, connection) {


### PR DESCRIPTION
The error event on a connection is never removed with stream local infile, resulting in a MaxListenersExceededWarning from node at the 11th attempt to stream on this connection. This change fixes this problem.