### PR TITLE
Fix #967 - Return a string for '00:00:00' time

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -319,7 +319,7 @@ class Packet {
   readTimeString(convertTtoMs) {
     const length = this.readInt8();
     if (length === 0) {
-      return 0;
+      return '00:00:00';
     }
     const sign = this.readInt8() ? -1 : 1; // 'isNegative' flag byte
     let d = 0;


### PR DESCRIPTION
The method `readTimeString` returns a string in all other cases, so it should return `00:00:00`

Fixes: #967 