### PR TITLE
Ping connection from the pool to check health

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -311,7 +311,17 @@ class PromisePool extends EventEmitter {
         if (err) {
           reject(err);
         } else {
-          resolve(new PromisePoolConnection(coreConnection, this.Promise));
+          function onPingOk() {
+            // Ping went through, connection good to be handed to client
+            resolve(new PromisePoolConnection(coreConnection, self.Promise));
+          }
+          function onPingError(err) {
+            // Ping went dead, release the connection for it is dead
+            corePool.releaseConnection(coreConnection);
+            reject(err);
+          }
+          // Make sure the connection is healthy
+          coreConnection.ping(onPingOk, onPingError);
         }
       });
     });


### PR DESCRIPTION
Looks like the connection from the pool are not checked, after long inactivity this may lead to issue with the other side closing the connection and the client not knowing (https://stackoverflow.com/questions/56919129/econnreset-etimedout-error-with-mysql2-nodejs-pooled-connection)

Since mysql2 is based off mysql, i found out that pinging the connection is an ok first solution (https://github.com/mysqljs/mysql/blob/master/lib/Pool.js#L119), this very rough PR is to start addressing that.
Keep in mind that i am not that familiar with this lib/js so this may be lacking...