### PR TITLE
Make node-mysql2 compatible with minification

### DIFF
--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,8 +1,27 @@
 'use strict';
 
-'client_handshake server_handshake query prepare close_statement execute ping register_slave binlog_dump change_user quit'
-  .split(' ')
-  .forEach(name => {
-    const ctor = require(`./${name}.js`);
-    module.exports[ctor.name] = ctor;
-  });
+const ClientHandshake = require('./client_handshake.js');
+const ServerHandshake = require('./server_handshake.js');
+const Query = require('./query.js');
+const Prepare = require('./prepare.js');
+const CloseStatement = require('./close_statement.js');
+const Execute = require('./execute.js');
+const Ping = require('./ping.js');
+const RegisterSlave = require('./register_slave.js');
+const BinlogDump = require('./binlog_dump.js');
+const ChangeUser = require('./change_user.js');
+const Quit = require('./quit.js');
+
+module.exports = {
+  ClientHandshake,
+  ServerHandshake,
+  Query,
+  Prepare,
+  CloseStatement,
+  Execute,
+  Ping,
+  RegisterSlave,
+  BinlogDump,
+  ChangeUser,
+  Quit
+};

--- a/lib/packets/index.js
+++ b/lib/packets/index.js
@@ -1,22 +1,58 @@
 'use strict';
 
-'auth_switch_request auth_switch_response auth_switch_request_more_data binlog_dump register_slave ssl_request handshake handshake_response query resultset_header column_definition text_row binary_row prepare_statement close_statement prepared_statement_header execute change_user'
-  .split(' ')
-  .forEach(name => {
-    const ctor = require(`./${name}.js`);
-    module.exports[ctor.name] = ctor;
-    // monkey-patch it to include name if debug is on
-    if (process.env.NODE_DEBUG) {
-      if (ctor.prototype.toPacket) {
-        const old = ctor.prototype.toPacket;
-        ctor.prototype.toPacket = function() {
-          const p = old.call(this);
-          p._name = ctor.name;
-          return p;
-        };
-      }
+const AuthSwitchRequest = require('./auth_switch_request');
+const AuthSwitchRequestMoreData = require('./auth_switch_request_more_data');
+const AuthSwitchResponse = require('./auth_switch_response');
+const BinaryRow = require('./binary_row');
+const BinlogDump = require('./binlog_dump');
+const ChangeUser = require('./change_user');
+const CloseStatement = require('./close_statement');
+const ColumnDefinition = require('./column_definition');
+const Execute = require('./execute');
+const Handshake = require('./handshake');
+const HandshakeResponse = require('./handshake_response');
+const PrepareStatement = require('./prepare_statement');
+const PreparedStatementHeader = require('./prepared_statement_header');
+const Query = require('./query');
+const RegisterSlave = require('./register_slave');
+const ResultsetHeader = require('./resultset_header');
+const SslRequest = require('./ssl_request');
+const TextRow = require('./text_row');
+
+const ctorArr = [
+  AuthSwitchRequest,
+  AuthSwitchRequestMoreData,
+  AuthSwitchResponse,
+  BinaryRow,
+  BinlogDump,
+  ChangeUser,
+  CloseStatement,
+  ColumnDefinition,
+  Execute,
+  Handshake,
+  HandshakeResponse,
+  PrepareStatement,
+  PreparedStatementHeader,
+  Query,
+  RegisterSlave,
+  ResultsetHeader,
+  SslRequest,
+  TextRow
+];
+ctorArr.forEach(ctor => {
+  module.exports[ctor.name] = ctor;
+  // monkey-patch it to include name if debug is on
+  if (process.env.NODE_DEBUG) {
+    if (ctor.prototype.toPacket) {
+      const old = ctor.prototype.toPacket;
+      ctor.prototype.toPacket = function() {
+        const p = old.call(this);
+        p._name = ctor.name;
+        return p;
+      };
     }
-  });
+  }
+});
 
 // simple packets:
 const Packet = require('./packet');


### PR DESCRIPTION
Fixes https://github.com/sidorares/node-mysql2/issues/890

I tried to create some automated tests for this in the package itself, but that was too hard without bringing in a bunch of dependencies that don't belong in here. So, I just tested it by creating a minimal application that imports my fork of node-mysql2, establishes a connection to a local MySQL instance, and queries a table.

This may not work with all minification libraries or bundlers, but it works with webpack and a minimal babel config that just uses the env preset. 