### PR TITLE
replace deprecated inspect with symbol inspect

### DIFF
--- a/lib/packets/column_definition.js
+++ b/lib/packets/column_definition.js
@@ -4,6 +4,8 @@ const Packet = require('../packets/packet');
 const StringParser = require('../parsers/string');
 const CharsetToEncoding = require('../constants/charset_encodings.js');
 
+const inspect = Symbol.for('nodejs.util.inspect.custom');
+
 const fields = ['catalog', 'schema', 'table', 'orgTable', 'name', 'orgName'];
 
 // creating JS string is relatively expensive (compared to
@@ -54,7 +56,7 @@ class ColumnDefinition {
     this.decimals = packet.readInt8();
   }
 
-  inspect() {
+  [inspect]() {
     return {
       catalog: this.catalog,
       schema: this.schema,


### PR DESCRIPTION
inspect function is no longer supported as mention in https://nodejs.org/api/deprecations.html#deprecations_dep0079_custom_inspection_function_on_objects_via_inspect and according to https://nodejs.org/api/util.html#util_util_inspect_custom it is defined as a shared symbol.