### PR TITLE
Add threadId and config getters to PromiseConnection

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -217,6 +217,10 @@ class PromiseConnection extends EventEmitter {
     });
   }
 
+  get config() {
+    return this.connection.config;
+  }
+
   get threadId() {
     return this.connection.threadId;
   }

--- a/promise.js
+++ b/promise.js
@@ -216,6 +216,10 @@ class PromiseConnection extends EventEmitter {
       });
     });
   }
+
+  get threadId() {
+    return this.connection.threadId;
+  }
 }
 
 function createConnection(opts) {

--- a/test/integration/promise-wrappers/test-promise-wrappers.js
+++ b/test/integration/promise-wrappers/test-promise-wrappers.js
@@ -393,6 +393,24 @@ function testChangeUser() {
     });
 }
 
+function testConnectionProperties() {
+  let connResolved;
+  createConnection(config)
+    .then(conn => {
+      connResolved = conn;
+      assert.equal(typeof conn.config, 'object');
+      assert.ok('queryFormat' in conn.config);
+      assert.equal(typeof conn.threadId, 'number');
+      return connResolved.end();
+    })
+    .catch(err => {
+      if (connResolved) {
+        connResolved.end();
+      }
+      throw err;
+    });
+}
+
 function timebomb(fuse) {
   let timebomb;
 
@@ -434,6 +452,7 @@ testErrorsPool();
 testObjParamsPool();
 testEventsPool();
 testChangeUser();
+testConnectionProperties();
 testPoolConnectionDestroy();
 testPromiseLibrary();
 


### PR DESCRIPTION
These properties are documented in `mysqljs/mysql` [[`config`](https://github.com/mysqljs/mysql#custom-format)] [[`threadId`](https://github.com/mysqljs/mysql#getting-the-connection-id)] and typed in [`types/mysql2`](https://github.com/types/mysql2/blob/master/promise.d.ts#L8) but not directly exposed in `PromiseConnection`.