### PR TITLE
Support ConnectionConfig.flags as an array

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -152,7 +152,9 @@ class ConnectionConfig {
   static mergeFlags(default_flags, user_flags) {
     let flags = 0x0,
       i;
-    user_flags = (user_flags || '').toUpperCase().split(/\s*,+\s*/);
+    if (!Array.isArray(user_flags)) {
+      user_flags = String(user_flags || '').toUpperCase().split(/\s*,+\s*/);
+    }
     // add default flags unless "blacklisted"
     for (i in default_flags) {
       if (user_flags.indexOf(`-${default_flags[i]}`) >= 0) {

--- a/test/unit/connection/test-connection_config.js
+++ b/test/unit/connection/test-connection_config.js
@@ -30,3 +30,15 @@ assert.doesNotThrow(() => {
     ssl: sslProfile
   });
 }, 'Error, the constructor accepts a string but throws an exception');
+
+assert.doesNotThrow(() => {
+  new ConnectionConfig({
+    flags: '-FOUND_ROWS'
+  });
+}, 'Error, the constructor threw an exception due to a flags string');
+
+assert.doesNotThrow(() => {
+  new ConnectionConfig({
+    flags: ['-FOUND_ROWS']
+  });
+}, 'Error, the constructor threw an exception due to a flags array');


### PR DESCRIPTION
[mysqljs/mysql supports a string or an array for flags](https://github.com/mysqljs/mysql/blob/master/lib/ConnectionConfig.js#L146)
and the TypeScript bindings expect an array (until [this upstream fix](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/37722) can be integrated)