### PR TITLE
Fix crashing when session info packet does not start with length-coded string

### DIFF
--- a/lib/constants/session_track.js
+++ b/lib/constants/session_track.js
@@ -1,3 +1,5 @@
+'use strict';
+
 exports.SYSTEM_VARIABLES = 0;
 exports.SCHEMA = 1;
 exports.STATE_CHANGE = 2;

--- a/lib/constants/session_track.js
+++ b/lib/constants/session_track.js
@@ -1,0 +1,9 @@
+exports.SYSTEM_VARIABLES = 0;
+exports.SCHEMA = 1;
+exports.STATE_CHANGE = 2;
+exports.STATE_GTIDS = 3;
+exports.TRANSACTION_CHARACTERISTICS = 4;
+exports.TRANSACTION_STATE = 5;
+
+exports.FIRST_KEY = exports.SYSTEM_VARIABLES;
+exports.LAST_KEY = exports.TRANSACTION_STATE;

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -15,6 +15,7 @@ class ResultSetHeader {
     const encoding = connection.serverEncoding;
     const flags = connection._handshakePacket.capabilityFlags;
     const isSet = function(flag) {
+      console.log('isSet?', flag, ClientConstants[flag]);
       return flags & ClientConstants[flag];
     };
     if (packet.buffer[packet.offset] !== 0) {
@@ -36,7 +37,9 @@ class ResultSetHeader {
     }
     let stateChanges = null;
     if (isSet('SESSION_TRACK') && packet.offset < packet.end) {
+      const sessionInfoTypes = require('../constants/session_track.js');
       this.info = packet.readLengthCodedString(encoding);
+
       if (this.serverStatus && ServerSatusFlags.SERVER_SESSION_STATE_CHANGED) {
         // session change info record - see
         // https://dev.mysql.com/doc/internals/en/packet-OK_Packet.html#cs-sect-packet-ok-sessioninfo
@@ -48,7 +51,6 @@ class ResultSetHeader {
           stateChanges = {
             systemVariables: {},
             schema: null,
-            // gtids: {},
             trackStateChange: null
           };
         }
@@ -56,23 +58,23 @@ class ResultSetHeader {
           type = packet.readInt8();
           len = packet.readLengthCodedNumber();
           stateEnd = packet.offset + len;
-          key = packet.readLengthCodedString(encoding);
-          if (type === 0) {
+          if (type === sessionInfoTypes.SYSTEM_VARIABLES) {
+            key = packet.readLengthCodedString(encoding);
             const val = packet.readLengthCodedString(encoding);
             stateChanges.systemVariables[key] = val;
             if (key === 'character_set_client') {
               const charsetNumber = EncodingToCharset[val];
               connection.config.charsetNumber = charsetNumber;
             }
-          } else if (type === 1) {
-            // TODO double check it's supposed to be the only value, not a list.
+          } else if (type === sessionInfoTypes.SCHEMA) {
+            key = packet.readLengthCodedString(encoding);
             stateChanges.schema = key;
-          } else if (type === 2) {
+          } else if (type === sessionInfoTypes.STATE_CHANGE) {
             stateChanges.trackStateChange = packet.readLengthCodedString(
               encoding
             );
           } else {
-            // GTIDs (type == 3) or unknown type - just skip for now
+            // unsupported session track type. For now just ignore
           }
           packet.offset = stateEnd;
         }

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -15,7 +15,6 @@ class ResultSetHeader {
     const encoding = connection.serverEncoding;
     const flags = connection._handshakePacket.capabilityFlags;
     const isSet = function(flag) {
-      console.log('isSet?', flag, ClientConstants[flag]);
       return flags & ClientConstants[flag];
     };
     if (packet.buffer[packet.offset] !== 0) {

--- a/test/unit/packets/test-ok-sessiontrack.js
+++ b/test/unit/packets/test-ok-sessiontrack.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const assert = require('assert');
+const Packet = require('./lib/packets/packet');
+const ResultSetHeader = require('./lib/packets/resultset_header.js');
+const clientConstants = require('../../../lib/constants/client');
+
+const mockConnection = {
+  config: {},
+  serverEncoding: 'utf8',
+  _handshakePacket: {
+    capabilityFlags: clientConstants.PROTOCOL_41 + clientConstants.SESSION_TRACK
+  }
+};
+
+const mkpacket = str => {
+  const buf = Buffer.from(str.split(/[ \n]+/).join(''), 'hex');
+  return new Packet(0, buf, 0, buf.length);
+};
+
+const packet2 = mkpacket(
+  '15 00 00 01 00 01 fc 41 0d 03 40 00 00 00 0a 14 08 fe 1a 54 1c 06 00 00 00'
+);
+
+const unknownTypeSession = hexbuf(
+  `1b 00 00 01
+     00 
+     01 fe 65 96 fc 02 00 00 00 00 03 40 00 00 00 0a 14 08 fe 60 63 9b 05 00 00 00
+    `
+);
+
+const ResultSetHeader = mkpacket('./lib/packets/resultset_header.js');
+const rs = new ResultSetHeader(p, mockConnection);
+console.log(rs);

--- a/test/unit/packets/test-ok-sessiontrack.js
+++ b/test/unit/packets/test-ok-sessiontrack.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const assert = require('assert');
-const Packet = require('./lib/packets/packet');
-const ResultSetHeader = require('./lib/packets/resultset_header.js');
+const Packet = require('../../../lib/packets/packet');
+const ResultSetHeader = require('../../../lib/packets/resultset_header.js');
 const clientConstants = require('../../../lib/constants/client');
 
 const mockConnection = {
@@ -18,17 +18,21 @@ const mkpacket = str => {
   return new Packet(0, buf, 0, buf.length);
 };
 
-const packet2 = mkpacket(
-  '15 00 00 01 00 01 fc 41 0d 03 40 00 00 00 0a 14 08 fe 1a 54 1c 06 00 00 00'
-);
+// regression examples from https://github.com/sidorares/node-mysql2/issues/989
 
-const unknownTypeSession = hexbuf(
-  `1b 00 00 01
-     00 
-     01 fe 65 96 fc 02 00 00 00 00 03 40 00 00 00 0a 14 08 fe 60 63 9b 05 00 00 00
-    `
-);
+assert.doesNotThrow(() => {
+  const packet = mkpacket(
+    `1b 00 00 01
+           00 
+           01 fe 65 96 fc 02 00 00 00 00 03 40 00 00 00 0a 14 08 fe 60 63 9b 05 00 00 00
+          `
+  );
+  new ResultSetHeader(packet, mockConnection);
+});
 
-const ResultSetHeader = mkpacket('./lib/packets/resultset_header.js');
-const rs = new ResultSetHeader(p, mockConnection);
-console.log(rs);
+assert.doesNotThrow(() => {
+  const packet = mkpacket(
+    `13 00 00 01 00 01 00 02 40 00 00 00 0a 14 08 fe 18 25 e7 06 00 00 00`
+  );
+  new ResultSetHeader(packet, mockConnection);
+});


### PR DESCRIPTION
While all known session info types have string following session type int apparently there are cases when rest of the data after type is something different. Simple fix is to only try to read content of known types
ref #989 