### PR TITLE
Fix promise methods

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -90,9 +90,14 @@ class PromiseConnection extends EventEmitter {
   query(query, params) {
     const c = this.connection;
     const localErr = new Error();
+    if (typeof params === 'function') {
+      throw new Error(
+        'Callback function is not available with promise clients.'
+      );
+    }
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, localErr);
-      if (typeof params !== 'function') {
+      if (params) {
         c.query(query, params, done);
       } else {
         c.query(query, done);
@@ -103,9 +108,14 @@ class PromiseConnection extends EventEmitter {
   execute(query, params) {
     const c = this.connection;
     const localErr = new Error();
+    if (typeof params === 'function') {
+      throw new Error(
+        'Callback function is not available with promise clients.'
+      );
+    }
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, localErr);
-      if (typeof params !== 'function') {
+      if (params) {
         c.execute(query, params, done);
       } else {
         c.execute(query, done);
@@ -328,9 +338,14 @@ class PromisePool extends EventEmitter {
   query(sql, args) {
     const corePool = this.pool;
     const localErr = new Error();
+    if (typeof args === 'function') {
+      throw new Error(
+        'Callback function is not available with promise clients.'
+      );
+    }
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, localErr);
-      if (typeof args !== 'function') {
+      if (args) {
         corePool.query(sql, args, done);
       } else {
         corePool.query(sql, done);
@@ -341,9 +356,14 @@ class PromisePool extends EventEmitter {
   execute(sql, args) {
     const corePool = this.pool;
     const localErr = new Error();
+    if (typeof args === 'function') {
+      throw new Error(
+        'Callback function is not available with promise clients.'
+      );
+    }
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, localErr);
-      if (typeof args !== 'function') {
+      if (args) {
         corePool.execute(sql, args, done);
       } else {
         corePool.execute(sql, done);

--- a/promise.js
+++ b/promise.js
@@ -4,7 +4,7 @@ const core = require('./index.js');
 const EventEmitter = require('events').EventEmitter;
 
 function makeDoneCb(resolve, reject, localErr) {
-  return function(err, rows, fields) {
+  return function (err, rows, fields) {
     if (err) {
       localErr.message = err.message;
       localErr.code = err.code;
@@ -25,7 +25,7 @@ function inheritEvents(source, target, events) {
       if (events.indexOf(eventName) >= 0 && !target.listenerCount(eventName)) {
         source.on(
           eventName,
-          (listeners[eventName] = function() {
+          (listeners[eventName] = function () {
             const args = [].slice.call(arguments);
             args.unshift(eventName);
 
@@ -92,7 +92,7 @@ class PromiseConnection extends EventEmitter {
     const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, localErr);
-      if (params) {
+      if (typeof params !== 'function') {
         c.query(query, params, done);
       } else {
         c.query(query, done);
@@ -233,8 +233,8 @@ function createConnection(opts) {
   if (!Promise) {
     throw new Error(
       'no Promise implementation available.' +
-        'Use promise-enabled node version or pass userland Promise' +
-        " implementation as parameter, for example: { Promise: require('bluebird') }"
+      'Use promise-enabled node version or pass userland Promise' +
+      " implementation as parameter, for example: { Promise: require('bluebird') }"
     );
   }
   return new Promise((resolve, reject) => {
@@ -259,7 +259,7 @@ function createConnection(opts) {
 // implemented with PromiseConnection
 
 // proxy synchronous functions only
-(function(functionsToWrap) {
+(function (functionsToWrap) {
   for (let i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
     const func = functionsToWrap[i];
 
@@ -268,7 +268,7 @@ function createConnection(opts) {
       PromiseConnection.prototype[func] === undefined
     ) {
       PromiseConnection.prototype[func] = (function factory(funcName) {
-        return function() {
+        return function () {
           return core.Connection.prototype[funcName].apply(
             this.connection,
             arguments
@@ -330,7 +330,7 @@ class PromisePool extends EventEmitter {
     const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, localErr);
-      if (args) {
+      if (typeof args !== 'function') {
         corePool.query(sql, args, done);
       } else {
         corePool.query(sql, done);
@@ -372,15 +372,15 @@ function createPool(opts) {
   if (!Promise) {
     throw new Error(
       'no Promise implementation available.' +
-        'Use promise-enabled node version or pass userland Promise' +
-        " implementation as parameter, for example: { Promise: require('bluebird') }"
+      'Use promise-enabled node version or pass userland Promise' +
+      " implementation as parameter, for example: { Promise: require('bluebird') }"
     );
   }
 
   return new PromisePool(corePool, Promise);
 }
 
-(function(functionsToWrap) {
+(function (functionsToWrap) {
   for (let i = 0; functionsToWrap && i < functionsToWrap.length; i++) {
     const func = functionsToWrap[i];
 
@@ -389,7 +389,7 @@ function createPool(opts) {
       PromisePool.prototype[func] === undefined
     ) {
       PromisePool.prototype[func] = (function factory(funcName) {
-        return function() {
+        return function () {
           return core.Pool.prototype[funcName].apply(this.pool, arguments);
         };
       })(func);

--- a/promise.js
+++ b/promise.js
@@ -105,7 +105,7 @@ class PromiseConnection extends EventEmitter {
     const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, localErr);
-      if (params) {
+      if (typeof params !== 'function') {
         c.execute(query, params, done);
       } else {
         c.execute(query, done);
@@ -338,11 +338,16 @@ class PromisePool extends EventEmitter {
     });
   }
 
-  execute(sql, values) {
+  execute(sql, args) {
     const corePool = this.pool;
     const localErr = new Error();
     return new this.Promise((resolve, reject) => {
-      corePool.execute(sql, values, makeDoneCb(resolve, reject, localErr));
+      const done = makeDoneCb(resolve, reject, localErr);
+      if (typeof args !== 'function') {
+        corePool.execute(sql, args, done);
+      } else {
+        corePool.execute(sql, done);
+      }
     });
   }
 


### PR DESCRIPTION
Filter out callback functions that went wrong as input argument in  methods of PromiseConnection and PromisePool.

When **query** & **execute** methods in PromiseConnection & PromisePool get **callback function** as the second argument(which is invalid), it is filtered so that **callback function** cannot be passed to query & execute  method in **connection** & **pool**