### PR TITLE
[#1029] fix/prevent calls to "packet.readString()" w/ wrong signature

### DIFF
--- a/lib/commands/server_handshake.js
+++ b/lib/commands/server_handshake.js
@@ -84,7 +84,7 @@ class ServerHandshake extends Command {
         break;
       case CommandCode.INIT_DB:
         if (connection.listeners('init_db').length) {
-          const schemaName = packet.readString(encoding);
+          const schemaName = packet.readString(undefined, encoding);
           connection.emit('init_db', schemaName);
         } else {
           connection.writeOk();
@@ -104,7 +104,7 @@ class ServerHandshake extends Command {
       case CommandCode.FIELD_LIST:
         if (connection.listeners('field_list').length) {
           const table = packet.readNullTerminatedString();
-          const fields = packet.readString(encoding);
+          const fields = packet.readString(undefined, encoding);
           connection.emit('field_list', table, fields);
         } else {
           connection.writeError({

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -400,6 +400,10 @@ class Packet {
 
   // TODO reuse?
   readString(len, encoding) {
+    if ((typeof len === 'string') && (typeof encoding === 'undefined')) {
+      encoding = len
+      len = undefined
+    }
     if (typeof len === 'undefined') {
       len = this.end - this.offset;
     }


### PR DESCRIPTION
there were no other calls to `packet.readString(len, encoding)` that forgot to pass a `len` parameter.

![matches](https://user-images.githubusercontent.com/6810270/66622897-57afa600-eb9e-11e9-8eea-e8a21c2a08bc.png)

We didn't discuss my change to `packet.readString()` that detects this error and automagically fixes it. I'll remove it if you dislike.