### PR TITLE
Add missing authPlugins assignment in ConnectionConfig

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -6,6 +6,7 @@ const Charsets = require('./constants/charsets');
 let SSLProfiles = null;
 
 const validOptions = {
+  authPlugins: 1,
   authSwitchHandler: 1,
   bigNumberStrings: 1,
   charset: 1,
@@ -138,6 +139,7 @@ class ConnectionConfig {
       ? ConnectionConfig.getCharsetNumber(options.charset)
       : options.charsetNumber || Charsets.UTF8MB4_UNICODE_CI;
     this.compress = options.compress || false;
+    this.authPlugins = options.authPlugins;
     this.authSwitchHandler = options.authSwitchHandler;
     this.clientFlags = ConnectionConfig.mergeFlags(
       ConnectionConfig.getDefaultFlags(options),


### PR DESCRIPTION
Hi!
Using `authPlugins` as an option in `createConnection` does not seem to work.
In `connection_config.js`, you get a warning as it is not in the `validOptions` object and is also not assigned to the class further down in the constructor.

In this PR, this is fixed so that `auth_switch.js` can correctly utilize the plugin as it would otherwise not be able to because `connection.config.authPlugins[pluginName]` would be undefined.

I am not sure how `authPlugins` and the new API is supposed to work, but using this code at least works. Please tell me if it is supposed to used in another way.