### PR TITLE
fix for scope of sandbox without "global" and "global.process"

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const process = require('process');
+
 const Readable = require('stream').Readable;
 
 const Command = require('./command.js');

--- a/lib/packets/index.js
+++ b/lib/packets/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const process = require('process');
+
 const AuthSwitchRequest = require('./auth_switch_request');
 const AuthSwitchRequestMoreData = require('./auth_switch_request_more_data');
 const AuthSwitchResponse = require('./auth_switch_response');

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const process = require('process');
 const mysql = require('../index.js');
 
 const EventEmitter = require('events').EventEmitter;

--- a/lib/pool_cluster.js
+++ b/lib/pool_cluster.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const process = require('process');
+
 const Pool = require('./pool.js');
 const PoolConfig = require('./pool_config.js');
 const EventEmitter = require('events').EventEmitter;

--- a/promise.js
+++ b/promise.js
@@ -73,7 +73,7 @@ class PromiseConnection extends EventEmitter {
   constructor(connection, promiseImpl) {
     super();
     this.connection = connection;
-    this.Promise = promiseImpl || global.Promise;
+    this.Promise = promiseImpl || Promise;
     inheritEvents(connection, this, [
       'error',
       'drain',
@@ -229,17 +229,17 @@ class PromiseConnection extends EventEmitter {
 function createConnection(opts) {
   const coreConnection = core.createConnection(opts);
   const createConnectionErr = new Error();
-  const Promise = opts.Promise || global.Promise;
-  if (!Promise) {
+  const thePromise = opts.Promise || Promise;
+  if (!thePromise) {
     throw new Error(
       'no Promise implementation available.' +
         'Use promise-enabled node version or pass userland Promise' +
         " implementation as parameter, for example: { Promise: require('bluebird') }"
     );
   }
-  return new Promise((resolve, reject) => {
+  return new thePromise((resolve, reject) => {
     coreConnection.once('connect', () => {
-      resolve(new PromiseConnection(coreConnection, Promise));
+      resolve(new PromiseConnection(coreConnection, thePromise));
     });
     coreConnection.once('error', err => {
       createConnectionErr.message = err.message;
@@ -305,10 +305,10 @@ class PromisePoolConnection extends PromiseConnection {
 }
 
 class PromisePool extends EventEmitter {
-  constructor(pool, Promise) {
+  constructor(pool, thePromise) {
     super();
     this.pool = pool;
-    this.Promise = Promise || global.Promise;
+    this.Promise = thePromise || Promise;
     inheritEvents(pool, this, ['acquire', 'connection', 'enqueue', 'release']);
   }
 
@@ -368,8 +368,8 @@ class PromisePool extends EventEmitter {
 
 function createPool(opts) {
   const corePool = core.createPool(opts);
-  const Promise = opts.Promise || global.Promise;
-  if (!Promise) {
+  const thePromise = opts.Promise || Promise;
+  if (!thePromise) {
     throw new Error(
       'no Promise implementation available.' +
         'Use promise-enabled node version or pass userland Promise' +
@@ -377,7 +377,7 @@ function createPool(opts) {
     );
   }
 
-  return new PromisePool(corePool, Promise);
+  return new PromisePool(corePool, thePromise);
 }
 
 (function(functionsToWrap) {


### PR DESCRIPTION
here is a small fix for some industry sandbox env that doesn't have object "global" / "global.process". 