### PR TITLE
Avoid setting numeric config options to NaN

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -82,8 +82,9 @@ class ConnectionConfig {
     this.password = options.password || undefined;
     this.passwordSha1 = options.passwordSha1 || undefined;
     this.database = options.database;
-    this.connectTimeout =
-      options.connectTimeout === undefined ? 10 * 1000 : options.connectTimeout;
+    this.connectTimeout = isNaN(options.connectTimeout)
+      ? 10 * 1000
+      : options.connectTimeout;
     this.insecureAuth = options.insecureAuth || false;
     this.supportBigNumbers = options.supportBigNumbers || false;
     this.bigNumberStrings = options.bigNumberStrings || false;
@@ -153,7 +154,9 @@ class ConnectionConfig {
     let flags = 0x0,
       i;
     if (!Array.isArray(user_flags)) {
-      user_flags = String(user_flags || '').toUpperCase().split(/\s*,+\s*/);
+      user_flags = String(user_flags || '')
+        .toUpperCase()
+        .split(/\s*,+\s*/);
     }
     // add default flags unless "blacklisted"
     for (i in default_flags) {

--- a/lib/pool_config.js
+++ b/lib/pool_config.js
@@ -12,12 +12,12 @@ class PoolConfig {
       options.waitForConnections === undefined
         ? true
         : Boolean(options.waitForConnections);
-    this.connectionLimit =
-      options.connectionLimit === undefined
-        ? 10
-        : Number(options.connectionLimit);
-    this.queueLimit =
-      options.queueLimit === undefined ? 0 : Number(options.queueLimit);
+    this.connectionLimit = isNaN(options.connectionLimit)
+      ? 10
+      : Number(options.connectionLimit);
+    this.queueLimit = isNaN(options.queueLimit)
+      ? 0
+      : Number(options.queueLimit);
   }
 }
 


### PR DESCRIPTION
Instead, treat NaN (as well as undefined) as an absent option and use
the default value.

Fixes #721 where a connectionLimit of NaN would render the pool silently
unable to acquire connections.