### PR TITLE
Pooling connections destroy

### DIFF
--- a/documentation/Extras.md
+++ b/documentation/Extras.md
@@ -96,3 +96,16 @@ const pool = mysql.createPool({
 ```
 
 In addition to password `createConnection()`, `createPool()` and `changeUser()` accept `passwordSha1` option. This is useful when implementing proxies as plaintext password might be not available.
+
+
+`idleTime` property in config to set the timeout in milliseconds,after which the connection with the pool will be destroyed.If property not added then it will executed as default.
+
+```js
+  const pool = mysql.createPool({
+      host: 'localhost',
+      user: 'root',
+      password:'root',
+      database: 'dbname',
+      idleTime:5000
+    });
+```

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -47,7 +47,8 @@ const validOptions = {
   connectionLimit: 1,
   Promise: 1,
   queueLimit: 1,
-  waitForConnections: 1
+  waitForConnections: 1,
+  idleTime: 1
 };
 
 class ConnectionConfig {

--- a/lib/pool_config.js
+++ b/lib/pool_config.js
@@ -18,6 +18,9 @@ class PoolConfig {
     this.queueLimit = isNaN(options.queueLimit)
       ? 0
       : Number(options.queueLimit);
+    this.idleTime = isNaN(options.idleTime) 
+      ? undefined 
+      : Number(options.idleTime);
   }
 }
 

--- a/lib/pool_connection.js
+++ b/lib/pool_connection.js
@@ -22,6 +22,10 @@ class PoolConnection extends Connection {
     if (!this._pool || this._pool._closed) {
       return;
     }
+    if (this._pool.config.idleTime)
+      this.idleTimer = setTimeout(() => {
+        this.destroy();
+      }, this._pool.config.idleTime);
     this._pool.releaseConnection(this);
   }
 
@@ -55,6 +59,13 @@ class PoolConnection extends Connection {
     const pool = this._pool;
     this._pool = null;
     pool._removeConnection(this);
+  }
+
+  query(...arg) {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+    }
+    return super.query(...arg);
   }
 }
 


### PR DESCRIPTION
Created a config property `idleTime` to destroy the pool connection.If not set then it will work as default.