### PR TITLE
Keep alive

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -43,6 +43,10 @@ class Connection extends EventEmitter {
     } else {
       this.stream = opts.config.stream;
     }
+
+    // Enable keep-alive on the socket.
+    this.stream.setKeepAlive(true, 10000);
+
     this._internalId = _connectionId++;
     this._commands = new Queue();
     this._command = null;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -44,8 +44,10 @@ class Connection extends EventEmitter {
       this.stream = opts.config.stream;
     }
 
-    // Enable keep-alive on the socket.
-    this.stream.setKeepAlive(true, 10000);
+    // Enable keep-alive on the socket.  It's disabled by default, but the
+    // user can enable it and supply an initial delay.
+    if (typeof this.stream.setKeepAlive === 'function' && this.config.enableKeepAlive)
+      this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
 
     this._internalId = _connectionId++;
     this._commands = new Queue();

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -18,10 +18,12 @@ const validOptions = {
   dateStrings: 1,
   debug: 1,
   decimalNumbers: 1,
+  enableKeepAlive: 1,
   flags: 1,
   host: 1,
   insecureAuth: 1,
   isServer: 1,
+  keepAliveInitialDelay: 1,
   localAddress: 1,
   maxPreparedStatements: 1,
   multipleStatements: 1,
@@ -93,6 +95,8 @@ class ConnectionConfig {
     this.debug = options.debug;
     this.trace = options.trace !== false;
     this.stringifyObjects = options.stringifyObjects || false;
+    this.enableKeepAlive = !!options.enableKeepAlive;
+    this.keepAliveInitialDelay = options.keepAliveInitialDelay || 0;
     if (
       options.timezone &&
       !/^(?:local|Z|[ +-]\d\d:\d\d)$/.test(options.timezone)


### PR DESCRIPTION
This PR allows the user to enable keep-alive on the underlying socket with a configurable `initialDelay` parameter, in milliseconds.  Keep-alive is disabled by default.  Example usage:

```js
const pool = mysql.createPool({
  host: 'db',
  user: process.env.MYSQL_USER,
  password: process.env.MYSQL_PASSWORD,
  database: process.env.MYSQL_DATABASE,
  connectionLimit: 2,
  waitForConnections: true,
  queueLimit: 0,
  keepAliveInitialDelay: 10000, // 0 by default.
  enableKeepAlive: true, // false by default.
});