### PR TITLE
fixed #476

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -564,6 +564,10 @@ class Connection extends EventEmitter {
       options.sql = sql;
       options.values = values;
     }
+    if (/in.*\(.*\)/i.test(options.sql)) {
+      options.sql = this.format(options.sql, options.values);
+      options.values = undefined;
+    }
     this._resolveNamedPlaceholders(options);
     // check for values containing undefined
     if (options.values) {


### PR DESCRIPTION
Fixed issue #476: https://github.com/sidorares/node-mysql2/issues/476#issuecomment-264342349

This is a confusing issue, and I know that the two-step execution can greatly improve performance. But in cases where the statement contains an `IN (?)` this will cause some unexpected code failures. Many known issues are related to this.

In my opinion, the correctness of code is more important than performance. I suggest that when the SQL command contains `IN (?)`, the formatter should be used first to format the command. Although this will lead to additional preparation processes, this simple modification can ensure that the code execution meets the expectations of most engineers in most cases.

Thanks for your excellent work!