### PR TITLE
Release connection on exception

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -144,9 +144,14 @@ class Pool extends EventEmitter {
         }
         return;
       }
-      conn.query(cmdQuery).once('end', () => {
+      try {
+        conn.query(cmdQuery).once('end', () => {
+          conn.release();
+        });
+      } catch (e) {
         conn.release();
-      });
+        throw e;
+      }
     });
     return cmdQuery;
   }
@@ -163,8 +168,7 @@ class Pool extends EventEmitter {
         return cb(err);
       }
       try {
-        const executeCmd = conn.execute(sql, values, cb);
-        executeCmd.once('end', () => {
+        conn.execute(sql, values, cb).once('end', () => {
           conn.release();
         });
       } catch (e) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -162,10 +162,15 @@ class Pool extends EventEmitter {
       if (err) {
         return cb(err);
       }
-      const executeCmd = conn.execute(sql, values, cb);
-      executeCmd.once('end', () => {
+      try {
+        const executeCmd = conn.execute(sql, values, cb);
+        executeCmd.once('end', () => {
+          conn.release();
+        });
+      } catch (e) {
         conn.release();
-      });
+        throw e;
+      }
     });
   }
 


### PR DESCRIPTION
If a synchronous exception is thrown (primarily by `execute()`), then the connection must be released.  I also made the same changes in #938