### PR TITLE
Fix Connection.connect callback may never be executed (#1136)

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -717,6 +717,12 @@ class Connection extends EventEmitter {
     if (!cb) {
       return;
     }
+    if (this._fatalError || this._protocolError) {
+      return cb(this._fatalError || this._protocolError);
+    }
+    if (this._handshakePacket) {
+      return cb(null, this);
+    }
     let connectCalled = 0;
     function callbackOnce(isErrorHandler) {
       return function(param) {

--- a/test/integration/connection/test-connect-after-connection-error.js
+++ b/test/integration/connection/test-connect-after-connection-error.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const mysql = require('../../../index.js');
+const assert = require('assert');
+
+const ERROR_TEXT = 'Connection lost: The server closed the connection.';
+
+const portfinder = require('portfinder');
+portfinder.getPort((err, port) => {
+  const server = mysql.createServer();
+  let serverConnection;
+  server.listen(port);
+  server.on('connection', conn => {
+    console.log('Here!');
+    conn.serverHandshake({
+      serverVersion: '5.6.10',
+      capabilityFlags: 2181036031
+    });
+    serverConnection = conn;
+  });
+
+  const clientConnection = mysql.createConnection({
+    host: 'localhost',
+    port: port,
+    user: 'testuser',
+    database: 'testdatabase',
+    password: 'testpassword'
+  });
+
+  clientConnection.on('connect', () => {
+    serverConnection.close();
+  });
+
+  clientConnection.once('error', () => {
+    clientConnection.connect(err => {
+      assert.equal(err.message, ERROR_TEXT);
+      clientConnection.close();
+      server._server.close();
+    });
+  });
+});

--- a/test/integration/connection/test-connect-after-connection.js
+++ b/test/integration/connection/test-connect-after-connection.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const common = require('../../common');
+const connection = common.createConnection();
+const assert = require('assert');
+
+let connection2;
+
+connection.once('connect', () => {
+  connection.connect((err, _connection) => {
+    if (err) {
+      throw err;
+    }
+    connection2 = _connection;
+    connection.end();
+  });
+});
+
+process.on('exit', () => {
+  assert.equal(connection, connection2);
+});


### PR DESCRIPTION
I wasn't able to find a way to test _fatalError - it wasn't set when either destroying or closing the server connection, however _protocolError was set, so I was at least able to test this.

I suspect there will still be some cases where an error occurs by neither _fatalError or _protocolError are set. In this case `connection.connect` will pass a closed / invalid connection to the callback and any attempt to use this should result in an error, which I think is still acceptable.