### PR TITLE
Move require to top level of the module

### DIFF
--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -8,6 +8,7 @@ const ClientConstants = require('../constants/client.js');
 const ServerSatusFlags = require('../constants/server_status.js');
 
 const EncodingToCharset = require('../constants/encoding_charset.js');
+const sessionInfoTypes = require('../constants/session_track.js');
 
 class ResultSetHeader {
   constructor(packet, connection) {
@@ -36,7 +37,6 @@ class ResultSetHeader {
     }
     let stateChanges = null;
     if (isSet('SESSION_TRACK') && packet.offset < packet.end) {
-      const sessionInfoTypes = require('../constants/session_track.js');
       this.info = packet.readLengthCodedString(encoding);
 
       if (this.serverStatus && ServerSatusFlags.SERVER_SESSION_STATE_CHANGED) {


### PR DESCRIPTION
Conditionally importing does not seem to be required (constants only).

When running tests in parallel with Jest and a mysql2 connection we receive warnings as below

```
ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.

      at new ResultSetHeader (node_modules/mysql2/lib/packets/resultset_header.js:39:32)
      at Query.resultsetHeader (node_modules/mysql2/lib/commands/query.js:102:16)
      at Query.execute (node_modules/mysql2/lib/commands/command.js:39:22)
      at Connection.handlePacket (node_modules/mysql2/lib/connection.js:417:32)
      at PacketParser.onPacket (node_modules/mysql2/lib/connection.js:75:12)
```

If the require statement is moved to the top of the file as per this commit the issue is resolved.