### PR TITLE
Fixed import issue with ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "promise.js"
   ],
   "exports": {
+    ".": "./index.js",
     "./promise": "./promise.js"
   },
   "engines": {


### PR DESCRIPTION
When importing mysql2 on newer version of node, an error occurs:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main resolved in node_modules/mysql2/package.json
    at applyExports (internal/modules/cjs/loader.js:487:9)
    at resolveExports (internal/modules/cjs/loader.js:503:23)
    at Function.Module._findPath (internal/modules/cjs/loader.js:631:31)
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:949:27)
    at Function.Module._load (internal/modules/cjs/loader.js:838:27)
    at Module.require (internal/modules/cjs/loader.js:1022:19)
    at require (internal/modules/cjs/helpers.js:72:18)
 {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

This appears to be caused by this PR
https://github.com/sidorares/node-mysql2/pull/1100

Adding ".": "./index.js" to the exports appears to resolve the issue