### PR TITLE
Pass in the callback when ending the pool connection.

### DIFF
--- a/lib/pool_cluster.js
+++ b/lib/pool_cluster.js
@@ -146,7 +146,7 @@ class PoolCluster extends EventEmitter {
 
     for (const id in this._nodes) {
       waitingClose++;
-      this._nodes[id].pool.end();
+      this._nodes[id].pool.end(onEnd);
     }
     if (waitingClose === 0) {
       process.nextTick(onEnd);


### PR DESCRIPTION
This fixes an issue when you close a connection using replication, the `end()` method on pool do not resolve the promise coz of missing callback.