### PR TITLE
feat: allow using `dateStrings` with specific types

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -48,3 +48,16 @@ function printDebugWithCode(msg, code) {
 }
 
 exports.printDebugWithCode = printDebugWithCode;
+
+/**
+ * checks whether the `type` is in the `list`
+ */
+function typeMatch(type, list, Types) {
+  if (Array.isArray(list)) {
+    return list.some(t => type === Types[t]);
+  }
+
+  return !!list;
+}
+
+exports.typeMatch = typeMatch;

--- a/lib/parsers/binary_parser.js
+++ b/lib/parsers/binary_parser.js
@@ -16,6 +16,7 @@ function readCodeFor(field, config, options, fieldNum) {
     options.supportBigNumbers || config.supportBigNumbers;
   const bigNumberStrings = options.bigNumberStrings || config.bigNumberStrings;
   const timezone = options.timezone || config.timezone;
+  const dateStrings = options.dateStrings || config.dateStrings;
   const unsigned = field.flags & FieldFlags.UNSIGNED;
   switch (field.columnType) {
     case Types.TINY:
@@ -37,7 +38,7 @@ function readCodeFor(field, config, options, fieldNum) {
     case Types.DATETIME:
     case Types.TIMESTAMP:
     case Types.NEWDATE:
-      if (config.dateStrings) {
+      if (helpers.typeMatch(field.columnType, dateStrings, Types)) {
         return `packet.readDateTimeString(${field.decimals});`;
       }
       return `packet.readDateTime('${timezone}');`;

--- a/lib/parsers/text_parser.js
+++ b/lib/parsers/text_parser.js
@@ -16,6 +16,7 @@ function readCodeFor(type, charset, encodingExpr, config, options) {
     options.supportBigNumbers || config.supportBigNumbers;
   const bigNumberStrings = options.bigNumberStrings || config.bigNumberStrings;
   const timezone = options.timezone || config.timezone;
+  const dateStrings = options.dateStrings || config.dateStrings;
 
   switch (type) {
     case Types.TINY:
@@ -41,13 +42,13 @@ function readCodeFor(type, charset, encodingExpr, config, options) {
       }
       return 'packet.readLengthCodedString("ascii")';
     case Types.DATE:
-      if (config.dateStrings) {
+      if (helpers.typeMatch(type, dateStrings, Types)) {
         return 'packet.readLengthCodedString("ascii")';
       }
       return `packet.parseDate('${timezone}')`;
     case Types.DATETIME:
     case Types.TIMESTAMP:
-      if (config.dateStrings) {
+      if (helpers.typeMatch(type, dateStrings, Types)) {
         return 'packet.readLengthCodedString("ascii")';
       }
       return `packet.parseDateTime('${timezone}')`;

--- a/test/integration/connection/test-datetime.js
+++ b/test/integration/connection/test-datetime.js
@@ -3,6 +3,7 @@
 const common = require('../../common');
 const connection = common.createConnection();
 const connection1 = common.createConnection({ dateStrings: true });
+const connection2 = common.createConnection({ dateStrings: ['DATE'] });
 const connectionZ = common.createConnection({ timezone: 'Z' });
 const connection0930 = common.createConnection({ timezone: '+09:30' });
 const assert = require('assert');
@@ -18,7 +19,8 @@ let rows,
   rows4,
   rows5,
   rows6,
-  rows7;
+  rows7,
+  rows8;
 
 const date = new Date('1990-01-01 08:15:11 UTC');
 const datetime = new Date('2010-12-10 14:12:09.019473');
@@ -71,6 +73,18 @@ connection1.query(
   'CREATE TEMPORARY TABLE t (d1 DATE, d2 TIMESTAMP, d3 DATETIME, d4 DATETIME, d5 DATETIME(6), d6 DATETIME(3))'
 );
 connection1.query('INSERT INTO t set d1=?, d2=?, d3=?, d4=?, d5=?, d6=?', [
+  date,
+  date1,
+  date2,
+  date3,
+  date4,
+  date5
+]);
+
+connection2.query(
+  'CREATE TEMPORARY TABLE t (d1 DATE, d2 TIMESTAMP, d3 DATETIME, d4 DATETIME, d5 DATETIME(6), d6 DATETIME(3))'
+);
+connection2.query('INSERT INTO t set d1=?, d2=?, d3=?, d4=?, d5=?, d6=?', [
   date,
   date1,
   date2,
@@ -212,6 +226,14 @@ connection1.execute(
   }
 );
 
+connection2.execute('select * from t', (err, _rows) => {
+  if (err) {
+    throw err;
+  }
+  rows8 = _rows;
+  connection2.end();
+});
+
 connection0930.execute(
   'select *, cast(d1 as char) as d4, cast(d2 as char) as d5, cast(d3 as char) as d6 from t',
   (err, _rows) => {
@@ -290,6 +312,15 @@ process.on('exit', () => {
   assert.deepEqual(rows4, dateAsStringExpected);
   assert.deepEqual(rows5, dateAsStringExpected);
   assert.equal(rows6.length, 1);
+
+  // dateStrings as array
+  assert.equal(rows8[0].d1, '1990-01-01');
+  assert.equal(rows8[0].d1.constructor, String);
+  assert.equal(rows8[0].d2.constructor, Date);
+  assert.equal(rows8[0].d3.constructor, Date);
+  assert.equal(rows8[0].d4, null);
+  assert.equal(rows8[0].d5.constructor, Date);
+  assert.equal(rows8[0].d6.constructor, Date);
 
   // +09:30
   const tzOffset = -570;


### PR DESCRIPTION
This aligns the `dateStrings` option with mysqljs, allowing to set `dateStrings: ['DATE']` to return
the DATE type as string, but keeping other datetime types processed to Date.

Related: #99