### PR TITLE
Add the authPlugins types to ConnectionOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -142,7 +142,11 @@ export interface Pool extends mysql.Connection {
   on(event: 'enqueue', listener: () => any): this;
   promise(promiseImpl?: PromiseConstructor): PromisePool;
 }
-
+    
+type authPlugins =
+    (pluginMetadata: { connection: Connection; command: string }) =>
+        (pluginData: Buffer) => Promise<string>;
+    
 export interface ConnectionOptions extends mysql.ConnectionOptions {
   charsetNumber?: number;
   compress?: boolean;
@@ -162,6 +166,9 @@ export interface ConnectionOptions extends mysql.ConnectionOptions {
   Promise?: any;
   queueLimit?: number;
   waitForConnections?: boolean;
+  authPlugins?: {
+      [key: string]: authPlugins;
+  };
 }
 
 export interface PoolOptions extends mysql.PoolOptions, ConnectionOptions {}


### PR DESCRIPTION
My builds started failing today with error 

> TS2339: Property 'authPlugins' does not exist on type 'ConnectionOptions'. 

I've copied the `authPlugins` type declaration from @types/mysql2