### PR TITLE
Pool should extend mysql.Pool, not mysql.Connection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,6 +144,7 @@ export interface Pool extends mysql.Pool {
   getConnection(
     callback: (err: NodeJS.ErrnoException, connection: PoolConnection) => any
   ): void;
+  releaseConnection(connection: PoolConnection): void;
   on(event: 'connection', listener: (connection: PoolConnection) => any): this;
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
   on(event: 'release', listener: (connection: PoolConnection) => any): this;

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,7 +78,7 @@ export interface PoolConnection extends mysql.PoolConnection, Connection {
   promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
 }
 
-export interface Pool extends mysql.Connection {
+export interface Pool extends mysql.Pool {
   execute<
     T extends
       | mysql.RowDataPacket[][]


### PR DESCRIPTION
The current `index.d.ts` shows `Pool` extending `mysql.Connection`, which leads to faulty typings -- in particular, a `Pool` does not have transaction methods (`beginTransaction`, `commit`, `rollback`) where a `Connection` _does_

It's a minor correction, but I just spent time wondering why my code was complaining about missing methods at runtime when the typings suggested they should be there ):