### PR TITLE
Add 'promise.js' to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   ],
   "exports": {
     ".": "./index.js",
-    "./promise": "./promise.js"
+    "./promise": "./promise.js",
+    "./promise.js": "./promise.js"
   },
   "engines": {
     "node": ">= 8.0"


### PR DESCRIPTION
Prior to 2.2.0, an ES6 import of the promise wrapper had to specify a file
extension ("import mysql from 'mysql2/promise.js';"), which made #1100 a
breaking change as only the extensionless version was included in the exports;
this restores promise.js as a valid import.