### PR TITLE
mysql_clear_password can have string type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -154,7 +154,9 @@ export interface Pool extends mysql.Connection {
 type authPlugins = (pluginMetadata: {
   connection: Connection;
   command: string;
-}) => (pluginData: Buffer) => Promise<string> | string;
+}) => (
+  pluginData: Buffer
+) => Promise<string> | string | Buffer | Promise<Buffer> | null;
 
 export interface ConnectionOptions extends mysql.ConnectionOptions {
   charsetNumber?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -151,9 +151,10 @@ export interface Pool extends mysql.Connection {
   promise(promiseImpl?: PromiseConstructor): PromisePool;
 }
 
-type authPlugins =
-    (pluginMetadata: { connection: Connection; command: string }) =>
-        (pluginData: Buffer) => Promise<string>;
+type authPlugins = (pluginMetadata: {
+  connection: Connection;
+  command: string;
+}) => (pluginData: Buffer) => Promise<string> | string;
 
 export interface ConnectionOptions extends mysql.ConnectionOptions {
   charsetNumber?: number;
@@ -175,7 +176,7 @@ export interface ConnectionOptions extends mysql.ConnectionOptions {
   queueLimit?: number;
   waitForConnections?: boolean;
   authPlugins?: {
-      [key: string]: authPlugins;
+    [key: string]: authPlugins;
   };
 }
 


### PR DESCRIPTION
- mysql_clear_password in authPlugins currently only supports
Promise<string> type. However AWS.RDS.Signer.getAuthToken returns string, which
causes type error "Type 'string' is not assignable"

getAuthToken Type
<img width="540" alt="Screen Shot 2020-10-03 at 11 23 46 AM" src="https://user-images.githubusercontent.com/6277118/94999086-c1714e80-056b-11eb-9466-31efc1a0bc24.png">

Error message:
<img width="818" alt="Screen Shot 2020-10-03 at 11 27 26 AM" src="https://user-images.githubusercontent.com/6277118/94999094-cd5d1080-056b-11eb-81a5-36cac0cee65e.png">

- This fix will add support for string type as well