### PR TITLE
connection.js: remove double check of options.values array

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -582,12 +582,6 @@ class Connection extends EventEmitter {
         );
       }
       options.values.forEach(val => {
-        //If namedPlaceholder is not enabled and object is passed as bind parameters
-        if (!Array.isArray(options.values)) {
-          throw new TypeError(
-            'Bind parameters must be array if namedPlaceholders parameter is not enabled'
-          );
-        }
         if (val === undefined) {
           throw new TypeError(
             'Bind parameters must not contain undefined. To pass SQL NULL specify JS null'


### PR DESCRIPTION
options.values is checked to be an array in line 579, `if (!Array.isArray(options.values)) {`

I don't think its needed also to perform the same check again, for each entry in the array?