### PR TITLE
Updated exports to add  "./lib/constants/types"

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "exports": {
     ".": "./index.js",
     "./promise": "./promise.js",
-    "./promise.js": "./promise.js"
+    "./promise.js": "./promise.js",
+    "./lib/constants/types": "./lib/constants/types.js"
   },
   "engines": {
     "node": ">= 8.0"


### PR DESCRIPTION
On Node12.8, the library is throwing a runtime error -
uncaughtException: Package subpath './lib/constants/types' is not defined by \"exports\" in /home/ec2-user/ucep-api/node_modules/mysql2/package.json\nError [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/constants/types' is not defined by \"exports\" in /home/ec2-user/ucep-api/node_modules/mysql2/package.json.