### PR TITLE
Mysql cluster 8.0.22 + mysql2 bug of collation

### DIFF
--- a/test/integration/connection/test-execute-bind-ascii.js
+++ b/test/integration/connection/test-execute-bind-ascii.js
@@ -15,15 +15,6 @@ connection.query(`INSERT INTO ${table} (a, b) VALUES ('test', 1)`);
 connection.query(`INSERT INTO ${table} (a, b) VALUES ('super', 2)`);
 connection.execute(
   `SELECT a FROM ${table} WHERE a=? AND b=?`,
-  ['DE', 1],
-  err => {
-    if (err) {
-      throw err;
-    }
-  }
-);
-connection.execute(
-  `SELECT a FROM ${table} WHERE a=? AND b=?`,
   ['test', 1],
   (err, _rows) => {
     if (err) {

--- a/test/integration/connection/test-execute-bind-ascii.js
+++ b/test/integration/connection/test-execute-bind-ascii.js
@@ -16,7 +16,7 @@ connection.query(`INSERT INTO ${table} (a, b) VALUES ('super', 2)`);
 connection.execute(
   `SELECT a FROM ${table} WHERE a=? AND b=?`,
   ['DE', 1],
-  (err) => {
+  err => {
     if (err) {
       throw err;
     }

--- a/test/integration/connection/test-execute-bind-ascii.js
+++ b/test/integration/connection/test-execute-bind-ascii.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../../common');
+const connection = common.createConnection();
+const assert = require('assert');
+
+const table = 'asciitest';
+
+let rows;
+connection.query(`DROP TABLE IF EXISTS ${table}`);
+connection.query(
+  `CREATE TABLE IF NOT EXISTS ${table} (a char (64) ascii not null, b int unsigned not null) character set utf8`
+);
+connection.query(`INSERT INTO ${table} (a, b) VALUES ('test', 1)`);
+connection.query(`INSERT INTO ${table} (a, b) VALUES ('super', 2)`);
+connection.execute(
+  `SELECT a FROM ${table} WHERE a=? AND b=?`,
+  ['DE', 1],
+  (err) => {
+    if (err) {
+      throw err;
+    }
+  }
+);
+connection.execute(
+  `SELECT a FROM ${table} WHERE a=? AND b=?`,
+  ['test', 1],
+  (err, _rows) => {
+    if (err) {
+      throw err;
+    }
+    rows = _rows;
+    connection.end();
+  }
+);
+
+process.on('exit', () => {
+  assert.deepEqual(rows, [{ a: 'test' }]);
+});


### PR DESCRIPTION
In my project i found very strange bug after upgrade `mysql-cluster` 8.0.21 -> 8.0.22 `mysql-cluster` package (`Ubuntu 18.04`)
My mysql statements throwed SQL errors "Illegal mix of collations"
I researched all docs of Mysql. There is [Rerertoire](https://dev.mysql.com/doc/refman/8.0/en/charset-repertoire.html) term. 
This bug manifests itself as if this mechanism does not work in mysql-cluster 8.0.22. But i cannot reproduced by hand through `mysql` command. 
This gave me the idea that the problem lies somewhere either in your module, or not in compatibility due to a change in mysql-cluster 8.0.22. I wrote a test for this problem and i was able to reproduce the problem. What is most interesting, it manifests itself only in `execute` (not `query`) and when the table has a second field. So i think it's prepared statement related problem.

I got error in tests:

```
[0:00:18 0 41/108 38.0% node test/integration/connection/test-execute-bind-ascii.js]    
  
  /home/perlover/tmp/node-mysql2/test/integration/connection/test-execute-bind-ascii.js:21
        throw err;
        ^
  
  Error: Illegal mix of collations (latin1_swedish_ci,IMPLICIT) and (utf8mb4_unicode_ci,COERCIBLE) for operation '='
      at Packet.asError (/home/perlover/tmp/node-mysql2/lib/packets/packet.js:712:17)
      at Execute.execute (/home/perlover/tmp/node-mysql2/lib/commands/command.js:28:26)
      at Connection.handlePacket (/home/perlover/tmp/node-mysql2/lib/connection.js:425:32)
      at PacketParser.onPacket (/home/perlover/tmp/node-mysql2/lib/connection.js:75:12)
      at PacketParser.executeStart (/home/perlover/tmp/node-mysql2/lib/packet_parser.js:75:16)
      at Socket.<anonymous> (/home/perlover/tmp/node-mysql2/lib/connection.js:82:25)
      at Socket.emit (events.js:314:20)
      at addChunk (_stream_readable.js:298:12)
      at readableAddChunk (_stream_readable.js:273:9)
      at Socket.Readable.push (_stream_readable.js:214:10) {
    code: 'ER_CANT_AGGREGATE_2COLLATIONS',
    errno: 1267,
    sqlState: 'HY000',
    sqlMessage: "Illegal mix of collations (latin1_swedish_ci,IMPLICIT) and (utf8mb4_unicode_ci,COERCIBLE) for operation '='"
  }
```
