### PR TITLE
Allow unnamed placeholders even if the namedPlaceholders flag is enabled

### DIFF
--- a/documentation/Extras.md
+++ b/documentation/Extras.md
@@ -2,7 +2,7 @@
 
 ## Named placeholders
 
-You can use named placeholders for parameters by setting `namedPlaceholders` config value or query/execute time option. Named placeholders are converted to unnamed `?` on the client (mysql protocol does not support named parameters). If you reference parameter multiple times under the same name it is sent to server multiple times.
+You can use named placeholders for parameters by setting `namedPlaceholders` config value or query/execute time option. Named placeholders are converted to unnamed `?` on the client (mysql protocol does not support named parameters). If you reference parameter multiple times under the same name it is sent to server multiple times. Unnamed placeholders can still be used by providing the values as an array instead of an object.
 
 ```js
 connection.config.namedPlaceholders = true;
@@ -18,7 +18,13 @@ connection.execute('select :x + :x as z', { x: 1 }, (err, rows) => {
 connection.query('select :x + :x as z', { x: 1 }, (err, rows) => {
   // query select 1 + 1 as z
 });
+
+// unnamed placeholders are still valid if the values are provided in an array
+connection.query('select ? + ? as z', [1, 1], (err, rows) => {
+  // query select 1 + 1 as z
+});
 ```
+
 
 ## Receiving rows as array of columns instead of hash with column name as key:
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -488,6 +488,11 @@ class Connection extends EventEmitter {
   _resolveNamedPlaceholders(options) {
     let unnamed;
     if (this.config.namedPlaceholders || options.namedPlaceholders) {
+      if (Array.isArray(options.values)) {
+        // if an array is provided as the values, assume the conversion is not necessary.
+        // this allows the usage of unnamed placeholders even if the namedPlaceholders flag is enabled.
+        return
+      }
       if (convertNamedPlaceholders === null) {
         convertNamedPlaceholders = require('named-placeholders')();
       }

--- a/test/integration/connection/test-named-placeholders.js
+++ b/test/integration/connection/test-named-placeholders.js
@@ -71,11 +71,23 @@ connection.query('SELECT :a + :a as sum', { a: 2 }, (err, rows) => {
   connection.end();
 });
 
-const sql = connection.format(
+const namedSql = connection.format(
   'SELECT * from test_table where num1 < :numParam and num2 > :lParam',
   { lParam: 100, numParam: 2 }
 );
-assert.equal(sql, 'SELECT * from test_table where num1 < 2 and num2 > 100');
+assert.equal(
+  namedSql,
+  'SELECT * from test_table where num1 < 2 and num2 > 100'
+);
+
+const unnamedSql = connection.format(
+  'SELECT * from test_table where num1 < ? and num2 > ?',
+  [2, 100]
+);
+assert.equal(
+  unnamedSql,
+  'SELECT * from test_table where num1 < 2 and num2 > 100'
+);
 
 const pool = common.createPool();
 pool.config.connectionConfig.namedPlaceholders = true;


### PR DESCRIPTION
In a project using this package we are trying to transition into using named placeholders. We would like to do this gradually, as some parts of the code cannot be easily transitioned. This change allows the use of unnamed placeholders even when the flag is enabled.