### PR TITLE
MockServer: Reset sequence ID in handshake and after each command.

### DIFF
--- a/lib/commands/server_handshake.js
+++ b/lib/commands/server_handshake.js
@@ -23,7 +23,7 @@ class ServerHandshake extends Command {
   start(packet, connection) {
     const serverHelloPacket = new Packets.Handshake(this.args);
     this.serverHello = serverHelloPacket;
-    serverHelloPacket.setScrambleData(err => {
+    serverHelloPacket.setScrambleData((err) => {
       if (err) {
         connection.emit('error', new Error('Error generating random bytes'));
         return;
@@ -66,6 +66,7 @@ class ServerHandshake extends Command {
     } else {
       connection.writeOk();
     }
+    connection._resetSequenceId();
     return ServerHandshake.prototype.dispatchCommands;
   }
 
@@ -130,6 +131,7 @@ class ServerHandshake extends Command {
       // eslint-disable-next-line no-console
       console.log('Unknown command:', commandCode);
     }
+    connection._resetSequenceId();
     return ServerHandshake.prototype.dispatchCommands;
   }
 }

--- a/lib/commands/server_handshake.js
+++ b/lib/commands/server_handshake.js
@@ -23,7 +23,7 @@ class ServerHandshake extends Command {
   start(packet, connection) {
     const serverHelloPacket = new Packets.Handshake(this.args);
     this.serverHello = serverHelloPacket;
-    serverHelloPacket.setScrambleData((err) => {
+    serverHelloPacket.setScrambleData(err => {
       if (err) {
         connection.emit('error', new Error('Error generating random bytes'));
         return;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,14 +32,17 @@ class Connection extends EventEmitter {
       if (opts.config.socketPath) {
         this.stream = Net.connect(opts.config.socketPath);
       } else {
-        this.stream = Net.connect(opts.config.port, opts.config.host);
+        this.stream = Net.connect(
+          opts.config.port,
+          opts.config.host
+        );
 
         // Enable keep-alive on the socket.  It's disabled by default, but the
         // user can enable it and supply an initial delay.
         this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
       }
       // if stream is a function, treat it as "stream agent / factory"
-    } else if (typeof opts.config.stream === 'function') {
+    } else if (typeof opts.config.stream === 'function')  {
       this.stream = opts.config.stream(opts);
     } else {
       this.stream = opts.config.stream;
@@ -52,7 +55,7 @@ class Connection extends EventEmitter {
     this._paused_packets = new Queue();
     this._statements = new LRU({
       max: this.config.maxPreparedStatements,
-      dispose: function (key, statement) {
+      dispose: function(key, statement) {
         statement.close();
       }
     });
@@ -68,10 +71,10 @@ class Connection extends EventEmitter {
     this.clientEncoding = CharsetToEncoding[this.config.charsetNumber];
     this.stream.on('error', this._handleNetworkError.bind(this));
     // see https://gist.github.com/khoomeister/4985691#use-that-instead-of-bind
-    this.packetParser = new PacketParser((p) => {
+    this.packetParser = new PacketParser(p => {
       this.handlePacket(p);
     });
-    this.stream.on('data', (data) => {
+    this.stream.on('data', data => {
       if (this.connectTimeout) {
         Timers.clearTimeout(this.connectTimeout);
         this.connectTimeout = null;
@@ -106,7 +109,7 @@ class Connection extends EventEmitter {
         this.threadId = handshakeCommand.handshake.connectionId;
         this.emit('connect', handshakeCommand.handshake);
       });
-      handshakeCommand.on('error', (err) => {
+      handshakeCommand.on('error', err => {
         this._closing = true;
         this._notifyError(err);
       });
@@ -185,7 +188,7 @@ class Connection extends EventEmitter {
     if (this.connectTimeout) {
       Timers.clearTimeout(this.connectTimeout);
       this.connectTimeout = null;
-    }
+    }    
     // prevent from emitting 'PROTOCOL_CONNECTION_LOST' after EPIPE or ECONNRESET
     if (this._fatalError) {
       return;
@@ -224,7 +227,7 @@ class Connection extends EventEmitter {
   }
 
   write(buffer) {
-    const result = this.stream.write(buffer, (err) => {
+    const result = this.stream.write(buffer, err => {
       if (err) {
         this._handleNetworkError(err);
       }
@@ -265,19 +268,11 @@ class Connection extends EventEmitter {
       if (this.config.debug) {
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${
-            this._command._commandName
-          }#${this._command.stateName()}(${[
-            this.sequenceId,
-            packet._name,
-            packet.length()
-          ].join(',')})`
+          `${this._internalId} ${this.connectionId} <== ${this._command._commandName}#${this._command.stateName()}(${[this.sequenceId, packet._name, packet.length()].join(',')})`
         );
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${
-            this.connectionId
-          } <== ${packet.buffer.toString('hex')}`
+          `${this._internalId} ${this.connectionId} <== ${packet.buffer.toString('hex')}`
         );
       }
       this._bumpSequenceId(1);
@@ -290,13 +285,7 @@ class Connection extends EventEmitter {
         );
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${
-            this._command._commandName
-          }#${this._command.stateName()}(${[
-            this.sequenceId,
-            packet._name,
-            packet.length()
-          ].join(',')})`
+          `${this._internalId} ${this.connectionId} <== ${this._command._commandName}#${this._command.stateName()}(${[this.sequenceId, packet._name, packet.length()].join(',')})`
         );
       }
       for (offset = 4; offset < 4 + length; offset += MAX_PACKET_LENGTH) {
@@ -341,7 +330,7 @@ class Connection extends EventEmitter {
       isServer: false
     });
     // error handler for secure socket
-    secureSocket.on('_tlsError', (err) => {
+    secureSocket.on('_tlsError', err => {
       if (secureEstablished) {
         this._handleNetworkError(err);
       } else {
@@ -352,10 +341,10 @@ class Connection extends EventEmitter {
       secureEstablished = true;
       onSecure(rejectUnauthorized ? secureSocket.ssl.verifyError() : null);
     });
-    secureSocket.on('data', (data) => {
+    secureSocket.on('data', data => {
       this.packetParser.execute(data);
     });
-    this.write = (buffer) => {
+    this.write = buffer => {
       secureSocket.write(buffer);
     };
     // start TLS communications
@@ -368,7 +357,7 @@ class Connection extends EventEmitter {
         this.packetParser.execute(data, start, end);
       };
     } else {
-      this.stream.on('data', (data) => {
+      this.stream.on('data', data => {
         this.packetParser.execute(
           data.parent,
           data.offset,
@@ -421,13 +410,7 @@ class Connection extends EventEmitter {
           : '(no command)';
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${
-            this.connectionId
-          } ==> ${commandName}#${stateName}(${[
-            packet.sequenceId,
-            packet.type(),
-            packet.length()
-          ].join(',')})`
+          `${this._internalId} ${this.connectionId} ==> ${commandName}#${stateName}(${[packet.sequenceId, packet.type(), packet.length()].join(',')})`
         );
       }
     }
@@ -507,7 +490,7 @@ class Connection extends EventEmitter {
       if (Array.isArray(options.values)) {
         // if an array is provided as the values, assume the conversion is not necessary.
         // this allows the usage of unnamed placeholders even if the namedPlaceholders flag is enabled.
-        return;
+        return
       }
       if (convertNamedPlaceholders === null) {
         convertNamedPlaceholders = require('named-placeholders')();
@@ -526,10 +509,7 @@ class Connection extends EventEmitter {
       cmdQuery = Connection.createQuery(sql, values, cb, this.config);
     }
     this._resolveNamedPlaceholders(cmdQuery);
-    const rawSql = this.format(
-      cmdQuery.sql,
-      cmdQuery.values !== undefined ? cmdQuery.values : []
-    );
+    const rawSql = this.format(cmdQuery.sql, cmdQuery.values !== undefined ? cmdQuery.values : []);
     cmdQuery.sql = rawSql;
     return this.addCommand(cmdQuery);
   }
@@ -605,7 +585,7 @@ class Connection extends EventEmitter {
           'Bind parameters must be array if namedPlaceholders parameter is not enabled'
         );
       }
-      options.values.forEach((val) => {
+      options.values.forEach(val => {
         //If namedPlaceholder is not enabled and object is passed as bind parameters
         if (!Array.isArray(options.values)) {
           throw new TypeError(
@@ -629,7 +609,7 @@ class Connection extends EventEmitter {
       if (err) {
         // skip execute command if prepare failed, we have main
         // combined callback here
-        executeCommand.start = function () {
+        executeCommand.start = function() {
           return null;
         };
         if (cb) {
@@ -666,7 +646,7 @@ class Connection extends EventEmitter {
           charsetNumber: charsetNumber,
           currentConfig: this.config
         },
-        (err) => {
+        err => {
           if (err) {
             err.fatal = true;
           }
@@ -723,14 +703,14 @@ class Connection extends EventEmitter {
     // TODO: use through2
     let test = 1;
     const stream = new Readable({ objectMode: true });
-    stream._read = function () {
+    stream._read = function() {
       return {
         data: test++
       };
     };
     this._registerSlave(opts, () => {
       const dumpCmd = this._binlogDump(opts);
-      dumpCmd.on('event', (ev) => {
+      dumpCmd.on('event', ev => {
         stream.push(ev);
       });
       dumpCmd.on('eof', () => {
@@ -757,7 +737,7 @@ class Connection extends EventEmitter {
     }
     let connectCalled = 0;
     function callbackOnce(isErrorHandler) {
-      return function (param) {
+      return function(param) {
         if (!connectCalled) {
           if (isErrorHandler) {
             cb(param);
@@ -777,7 +757,7 @@ class Connection extends EventEmitter {
   // ===================================
   writeColumns(columns) {
     this.writePacket(Packets.ResultSetHeader.toPacket(columns.length));
-    columns.forEach((column) => {
+    columns.forEach(column => {
       this.writePacket(
         Packets.ColumnDefinition.toPacket(column, this.serverConfig.encoding)
       );
@@ -794,9 +774,9 @@ class Connection extends EventEmitter {
 
   writeTextResult(rows, columns) {
     this.writeColumns(columns);
-    rows.forEach((row) => {
+    rows.forEach(row => {
       const arrayRow = new Array(columns.length);
-      columns.forEach((column) => {
+      columns.forEach(column => {
         arrayRow.push(row[column.name]);
       });
       this.writeTextRow(arrayRow);
@@ -871,9 +851,9 @@ class Connection extends EventEmitter {
   }
 
   static statementKey(options) {
-    return `${typeof options.nestTables}/${options.nestTables}/${
-      options.rowsAsArray
-    }${options.sql}`;
+    return (
+      `${typeof options.nestTables}/${options.nestTables}/${options.rowsAsArray}${options.sql}`
+    );
   }
 }
 
@@ -909,10 +889,10 @@ if (Tls.TLSSocket) {
     stream.removeAllListeners('data');
     stream.pipe(securePair.encrypted);
     securePair.encrypted.pipe(stream);
-    securePair.cleartext.on('data', (data) => {
+    securePair.cleartext.on('data', data => {
       this.packetParser.execute(data);
     });
-    this.write = function (buffer) {
+    this.write = function(buffer) {
       securePair.cleartext.write(buffer);
     };
     securePair.on('secure', () => {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,17 +32,14 @@ class Connection extends EventEmitter {
       if (opts.config.socketPath) {
         this.stream = Net.connect(opts.config.socketPath);
       } else {
-        this.stream = Net.connect(
-          opts.config.port,
-          opts.config.host
-        );
+        this.stream = Net.connect(opts.config.port, opts.config.host);
 
         // Enable keep-alive on the socket.  It's disabled by default, but the
         // user can enable it and supply an initial delay.
         this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
       }
       // if stream is a function, treat it as "stream agent / factory"
-    } else if (typeof opts.config.stream === 'function')  {
+    } else if (typeof opts.config.stream === 'function') {
       this.stream = opts.config.stream(opts);
     } else {
       this.stream = opts.config.stream;
@@ -55,7 +52,7 @@ class Connection extends EventEmitter {
     this._paused_packets = new Queue();
     this._statements = new LRU({
       max: this.config.maxPreparedStatements,
-      dispose: function(key, statement) {
+      dispose: function (key, statement) {
         statement.close();
       }
     });
@@ -71,10 +68,10 @@ class Connection extends EventEmitter {
     this.clientEncoding = CharsetToEncoding[this.config.charsetNumber];
     this.stream.on('error', this._handleNetworkError.bind(this));
     // see https://gist.github.com/khoomeister/4985691#use-that-instead-of-bind
-    this.packetParser = new PacketParser(p => {
+    this.packetParser = new PacketParser((p) => {
       this.handlePacket(p);
     });
-    this.stream.on('data', data => {
+    this.stream.on('data', (data) => {
       if (this.connectTimeout) {
         Timers.clearTimeout(this.connectTimeout);
         this.connectTimeout = null;
@@ -109,7 +106,7 @@ class Connection extends EventEmitter {
         this.threadId = handshakeCommand.handshake.connectionId;
         this.emit('connect', handshakeCommand.handshake);
       });
-      handshakeCommand.on('error', err => {
+      handshakeCommand.on('error', (err) => {
         this._closing = true;
         this._notifyError(err);
       });
@@ -188,7 +185,7 @@ class Connection extends EventEmitter {
     if (this.connectTimeout) {
       Timers.clearTimeout(this.connectTimeout);
       this.connectTimeout = null;
-    }    
+    }
     // prevent from emitting 'PROTOCOL_CONNECTION_LOST' after EPIPE or ECONNRESET
     if (this._fatalError) {
       return;
@@ -227,7 +224,7 @@ class Connection extends EventEmitter {
   }
 
   write(buffer) {
-    const result = this.stream.write(buffer, err => {
+    const result = this.stream.write(buffer, (err) => {
       if (err) {
         this._handleNetworkError(err);
       }
@@ -268,11 +265,19 @@ class Connection extends EventEmitter {
       if (this.config.debug) {
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${this._command._commandName}#${this._command.stateName()}(${[this.sequenceId, packet._name, packet.length()].join(',')})`
+          `${this._internalId} ${this.connectionId} <== ${
+            this._command._commandName
+          }#${this._command.stateName()}(${[
+            this.sequenceId,
+            packet._name,
+            packet.length()
+          ].join(',')})`
         );
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${packet.buffer.toString('hex')}`
+          `${this._internalId} ${
+            this.connectionId
+          } <== ${packet.buffer.toString('hex')}`
         );
       }
       this._bumpSequenceId(1);
@@ -285,7 +290,13 @@ class Connection extends EventEmitter {
         );
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${this._command._commandName}#${this._command.stateName()}(${[this.sequenceId, packet._name, packet.length()].join(',')})`
+          `${this._internalId} ${this.connectionId} <== ${
+            this._command._commandName
+          }#${this._command.stateName()}(${[
+            this.sequenceId,
+            packet._name,
+            packet.length()
+          ].join(',')})`
         );
       }
       for (offset = 4; offset < 4 + length; offset += MAX_PACKET_LENGTH) {
@@ -330,7 +341,7 @@ class Connection extends EventEmitter {
       isServer: false
     });
     // error handler for secure socket
-    secureSocket.on('_tlsError', err => {
+    secureSocket.on('_tlsError', (err) => {
       if (secureEstablished) {
         this._handleNetworkError(err);
       } else {
@@ -341,10 +352,10 @@ class Connection extends EventEmitter {
       secureEstablished = true;
       onSecure(rejectUnauthorized ? secureSocket.ssl.verifyError() : null);
     });
-    secureSocket.on('data', data => {
+    secureSocket.on('data', (data) => {
       this.packetParser.execute(data);
     });
-    this.write = buffer => {
+    this.write = (buffer) => {
       secureSocket.write(buffer);
     };
     // start TLS communications
@@ -357,7 +368,7 @@ class Connection extends EventEmitter {
         this.packetParser.execute(data, start, end);
       };
     } else {
-      this.stream.on('data', data => {
+      this.stream.on('data', (data) => {
         this.packetParser.execute(
           data.parent,
           data.offset,
@@ -410,7 +421,13 @@ class Connection extends EventEmitter {
           : '(no command)';
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} ==> ${commandName}#${stateName}(${[packet.sequenceId, packet.type(), packet.length()].join(',')})`
+          `${this._internalId} ${
+            this.connectionId
+          } ==> ${commandName}#${stateName}(${[
+            packet.sequenceId,
+            packet.type(),
+            packet.length()
+          ].join(',')})`
         );
       }
     }
@@ -426,8 +443,7 @@ class Connection extends EventEmitter {
     if (done) {
       this._command = this._commands.shift();
       if (this._command) {
-        this.sequenceId = 0;
-        this.compressedSequenceId = 0;
+        this._resetSequenceId();
         this.handlePacket();
       }
     }
@@ -491,7 +507,7 @@ class Connection extends EventEmitter {
       if (Array.isArray(options.values)) {
         // if an array is provided as the values, assume the conversion is not necessary.
         // this allows the usage of unnamed placeholders even if the namedPlaceholders flag is enabled.
-        return
+        return;
       }
       if (convertNamedPlaceholders === null) {
         convertNamedPlaceholders = require('named-placeholders')();
@@ -510,7 +526,10 @@ class Connection extends EventEmitter {
       cmdQuery = Connection.createQuery(sql, values, cb, this.config);
     }
     this._resolveNamedPlaceholders(cmdQuery);
-    const rawSql = this.format(cmdQuery.sql, cmdQuery.values !== undefined ? cmdQuery.values : []);
+    const rawSql = this.format(
+      cmdQuery.sql,
+      cmdQuery.values !== undefined ? cmdQuery.values : []
+    );
     cmdQuery.sql = rawSql;
     return this.addCommand(cmdQuery);
   }
@@ -586,7 +605,7 @@ class Connection extends EventEmitter {
           'Bind parameters must be array if namedPlaceholders parameter is not enabled'
         );
       }
-      options.values.forEach(val => {
+      options.values.forEach((val) => {
         //If namedPlaceholder is not enabled and object is passed as bind parameters
         if (!Array.isArray(options.values)) {
           throw new TypeError(
@@ -610,7 +629,7 @@ class Connection extends EventEmitter {
       if (err) {
         // skip execute command if prepare failed, we have main
         // combined callback here
-        executeCommand.start = function() {
+        executeCommand.start = function () {
           return null;
         };
         if (cb) {
@@ -647,7 +666,7 @@ class Connection extends EventEmitter {
           charsetNumber: charsetNumber,
           currentConfig: this.config
         },
-        err => {
+        (err) => {
           if (err) {
             err.fatal = true;
           }
@@ -704,14 +723,14 @@ class Connection extends EventEmitter {
     // TODO: use through2
     let test = 1;
     const stream = new Readable({ objectMode: true });
-    stream._read = function() {
+    stream._read = function () {
       return {
         data: test++
       };
     };
     this._registerSlave(opts, () => {
       const dumpCmd = this._binlogDump(opts);
-      dumpCmd.on('event', ev => {
+      dumpCmd.on('event', (ev) => {
         stream.push(ev);
       });
       dumpCmd.on('eof', () => {
@@ -738,7 +757,7 @@ class Connection extends EventEmitter {
     }
     let connectCalled = 0;
     function callbackOnce(isErrorHandler) {
-      return function(param) {
+      return function (param) {
         if (!connectCalled) {
           if (isErrorHandler) {
             cb(param);
@@ -758,7 +777,7 @@ class Connection extends EventEmitter {
   // ===================================
   writeColumns(columns) {
     this.writePacket(Packets.ResultSetHeader.toPacket(columns.length));
-    columns.forEach(column => {
+    columns.forEach((column) => {
       this.writePacket(
         Packets.ColumnDefinition.toPacket(column, this.serverConfig.encoding)
       );
@@ -775,9 +794,9 @@ class Connection extends EventEmitter {
 
   writeTextResult(rows, columns) {
     this.writeColumns(columns);
-    rows.forEach(row => {
+    rows.forEach((row) => {
       const arrayRow = new Array(columns.length);
-      columns.forEach(column => {
+      columns.forEach((column) => {
         arrayRow.push(row[column.name]);
       });
       this.writeTextRow(arrayRow);
@@ -852,9 +871,9 @@ class Connection extends EventEmitter {
   }
 
   static statementKey(options) {
-    return (
-      `${typeof options.nestTables}/${options.nestTables}/${options.rowsAsArray}${options.sql}`
-    );
+    return `${typeof options.nestTables}/${options.nestTables}/${
+      options.rowsAsArray
+    }${options.sql}`;
   }
 }
 
@@ -890,10 +909,10 @@ if (Tls.TLSSocket) {
     stream.removeAllListeners('data');
     stream.pipe(securePair.encrypted);
     securePair.encrypted.pipe(stream);
-    securePair.cleartext.on('data', data => {
+    securePair.cleartext.on('data', (data) => {
       this.packetParser.execute(data);
     });
-    this.write = function(buffer) {
+    this.write = function (buffer) {
       securePair.cleartext.write(buffer);
     };
     securePair.on('secure', () => {

--- a/test/integration/connection/test-connect-sha1.js
+++ b/test/integration/connection/test-connect-sha1.js
@@ -25,7 +25,7 @@ const portfinder = require('portfinder');
 portfinder.getPort((err, port) => {
   const server = mysql.createServer();
   server.listen(port);
-  server.on('connection', (conn) => {
+  server.on('connection', conn => {
     conn.serverHandshake({
       protocolVersion: 10,
       serverVersion: 'node.js rocks',
@@ -35,12 +35,12 @@ portfinder.getPort((err, port) => {
       capabilityFlags: 0xffffff,
       authCallback: authenticate
     });
-    conn.on('query', (sql) => {
+    conn.on('query', sql => {
       assert.equal(sql, 'select 1+1');
       queryCalls++;
       conn.close();
     });
-    conn.on('warn', (err) => {
+    conn.on('warn', err => {
       assert.fail(err);
     });
   });
@@ -52,21 +52,21 @@ portfinder.getPort((err, port) => {
     passwordSha1: Buffer.from('8bb6118f8fd6935ad0876a3be34a717d32708ffd', 'hex')
   });
 
-  connection.on('error', (err) => {
+  connection.on('error', err => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
   });
 
-  connection.query('select 1+1', (err) => {
+  connection.query('select 1+1', err => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
     server._server.close();
   });
 
-  connection.query('select 1+2', (err) => {
+  connection.query('select 1+2', err => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
     _1_2 = true;
   });
 
-  connection.query('select 1+3', (err) => {
+  connection.query('select 1+3', err => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
     _1_3 = true;
   });

--- a/test/integration/connection/test-connect-sha1.js
+++ b/test/integration/connection/test-connect-sha1.js
@@ -25,7 +25,7 @@ const portfinder = require('portfinder');
 portfinder.getPort((err, port) => {
   const server = mysql.createServer();
   server.listen(port);
-  server.on('connection', conn => {
+  server.on('connection', (conn) => {
     conn.serverHandshake({
       protocolVersion: 10,
       serverVersion: 'node.js rocks',
@@ -35,10 +35,13 @@ portfinder.getPort((err, port) => {
       capabilityFlags: 0xffffff,
       authCallback: authenticate
     });
-    conn.on('query', sql => {
+    conn.on('query', (sql) => {
       assert.equal(sql, 'select 1+1');
       queryCalls++;
       conn.close();
+    });
+    conn.on('warn', (err) => {
+      assert.fail(err);
     });
   });
 
@@ -49,21 +52,21 @@ portfinder.getPort((err, port) => {
     passwordSha1: Buffer.from('8bb6118f8fd6935ad0876a3be34a717d32708ffd', 'hex')
   });
 
-  connection.on('error', err => {
+  connection.on('error', (err) => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
   });
 
-  connection.query('select 1+1', err => {
+  connection.query('select 1+1', (err) => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
     server._server.close();
   });
 
-  connection.query('select 1+2', err => {
+  connection.query('select 1+2', (err) => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
     _1_2 = true;
   });
 
-  connection.query('select 1+3', err => {
+  connection.query('select 1+3', (err) => {
     assert.equal(err.code, 'PROTOCOL_CONNECTION_LOST');
     _1_3 = true;
   });

--- a/test/integration/connection/test-disconnects.js
+++ b/test/integration/connection/test-disconnects.js
@@ -18,11 +18,11 @@ const server = common.createServer(
 
       rows = _rows;
       fields = _fields;
-      connection.on('error', (_err) => {
+      connection.on('error', _err => {
         err = _err;
       });
 
-      connections.forEach((conn) => {
+      connections.forEach(conn => {
         conn.stream.end();
       });
       server._server.close(() => {
@@ -31,11 +31,11 @@ const server = common.createServer(
     });
     // TODO: test connection.end() etc where we expect disconnect to happen
   },
-  (conn) => {
+  conn => {
     connections.push(conn);
     conn.on('query', () => {
       conn.writeTextResult(
-        [{ 1: '1' }],
+        [{ '1': '1' }],
         [
           {
             catalog: 'def',
@@ -53,7 +53,7 @@ const server = common.createServer(
         ]
       );
     });
-    conn.on('warn', (err) => {
+    conn.on('warn', err => {
       assert.fail(err);
     });
   }

--- a/test/integration/connection/test-disconnects.js
+++ b/test/integration/connection/test-disconnects.js
@@ -18,11 +18,11 @@ const server = common.createServer(
 
       rows = _rows;
       fields = _fields;
-      connection.on('error', _err => {
+      connection.on('error', (_err) => {
         err = _err;
       });
 
-      connections.forEach(conn => {
+      connections.forEach((conn) => {
         conn.stream.end();
       });
       server._server.close(() => {
@@ -31,11 +31,11 @@ const server = common.createServer(
     });
     // TODO: test connection.end() etc where we expect disconnect to happen
   },
-  conn => {
+  (conn) => {
     connections.push(conn);
     conn.on('query', () => {
       conn.writeTextResult(
-        [{ '1': '1' }],
+        [{ 1: '1' }],
         [
           {
             catalog: 'def',
@@ -52,6 +52,9 @@ const server = common.createServer(
           }
         ]
       );
+    });
+    conn.on('warn', (err) => {
+      assert.fail(err);
     });
   }
 );

--- a/test/integration/connection/test-mock-server-sequence-id.js
+++ b/test/integration/connection/test-mock-server-sequence-id.js
@@ -25,14 +25,14 @@ const server = common.createServer(
       });
     });
   },
-  (conn) => {
+  conn => {
     conn.on('quit', () => {
       // COM_QUIT
       conn.stream.end();
       server.close();
     });
 
-    conn.on('query', (q) => {
+    conn.on('query', q => {
       const d = q.match(/SELECT (\d+)/);
       const req = d[1];
       const seq = String(conn.sequenceId);
@@ -69,7 +69,7 @@ const server = common.createServer(
       );
     });
 
-    conn.on('warn', (err) => {
+    conn.on('warn', err => {
       assert.fail(err);
     });
   }

--- a/test/integration/connection/test-mock-server-sequence-id.js
+++ b/test/integration/connection/test-mock-server-sequence-id.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../../common');
+const results = [];
+const server = common.createServer(
+  () => {
+    const connection = common.createConnection({ port: server._port });
+
+    function addResult(err, rows) {
+      if (err) {
+        throw err;
+      }
+      results.push(rows[0]);
+    }
+
+    connection.query('SELECT 1', (err, rows) => {
+      addResult(err, rows);
+      connection.query('SELECT 2', (err, rows) => {
+        addResult(err, rows);
+        connection.query('SELECT 3', (err, rows) => {
+          addResult(err, rows);
+          connection.end();
+        });
+      });
+    });
+  },
+  (conn) => {
+    conn.on('quit', () => {
+      // COM_QUIT
+      conn.stream.end();
+      server.close();
+    });
+
+    conn.on('query', (q) => {
+      const d = q.match(/SELECT (\d+)/);
+      const req = d[1];
+      const seq = String(conn.sequenceId);
+      conn.writeTextResult(
+        [{ req, seq }],
+        [
+          {
+            catalog: 'def',
+            schema: '',
+            table: '',
+            orgTable: '',
+            name: 'req',
+            orgName: '',
+            characterSet: 63,
+            columnLength: 1,
+            columnType: 8,
+            flags: 129,
+            decimals: 0
+          },
+          {
+            catalog: 'def',
+            schema: '',
+            table: '',
+            orgTable: '',
+            name: 'seq',
+            orgName: '',
+            characterSet: 63,
+            columnLength: 1,
+            columnType: 8,
+            flags: 129,
+            decimals: 0
+          }
+        ]
+      );
+    });
+
+    conn.on('warn', (err) => {
+      assert.fail(err);
+    });
+  }
+);
+
+process.on('exit', () => {
+  assert.deepEqual(results, [
+    // for each query/command the sequence-id must start from 1
+    { req: 1, seq: 1 },
+    { req: 2, seq: 1 },
+    { req: 3, seq: 1 }
+  ]);
+});

--- a/test/integration/connection/test-protocol-errors.js
+++ b/test/integration/connection/test-protocol-errors.js
@@ -18,17 +18,17 @@ const server = common.createServer(
       fields = _fields;
     });
 
-    connection.on('error', err => {
+    connection.on('error', (err) => {
       error = err;
       if (server._server._handle) {
         server.close();
       }
     });
   },
-  conn => {
+  (conn) => {
     conn.on('query', () => {
       conn.writeTextResult(
-        [{ '1': '1' }],
+        [{ 1: '1' }],
         [
           {
             catalog: 'def',
@@ -47,6 +47,9 @@ const server = common.createServer(
       );
       // this is extra (incorrect) packet - client should emit error on receiving it
       conn.writeOk();
+    });
+    conn.on('warn', (err) => {
+      assert.fail(err);
     });
   }
 );

--- a/test/integration/connection/test-protocol-errors.js
+++ b/test/integration/connection/test-protocol-errors.js
@@ -18,17 +18,17 @@ const server = common.createServer(
       fields = _fields;
     });
 
-    connection.on('error', (err) => {
+    connection.on('error', err => {
       error = err;
       if (server._server._handle) {
         server.close();
       }
     });
   },
-  (conn) => {
+  conn => {
     conn.on('query', () => {
       conn.writeTextResult(
-        [{ 1: '1' }],
+        [{ '1': '1' }],
         [
           {
             catalog: 'def',
@@ -48,7 +48,7 @@ const server = common.createServer(
       // this is extra (incorrect) packet - client should emit error on receiving it
       conn.writeOk();
     });
-    conn.on('warn', (err) => {
+    conn.on('warn', err => {
       assert.fail(err);
     });
   }

--- a/test/integration/connection/test-quit.js
+++ b/test/integration/connection/test-quit.js
@@ -21,7 +21,7 @@ const server = common.createServer(
       connection.end();
     });
   },
-  conn => {
+  (conn) => {
     conn.on('quit', () => {
       // COM_QUIT
       quitReceived = true;
@@ -29,10 +29,10 @@ const server = common.createServer(
       server.close();
     });
 
-    conn.on('query', q => {
+    conn.on('query', (q) => {
       queryServ = q;
       conn.writeTextResult(
-        [{ '1': '1' }],
+        [{ 1: '1' }],
         [
           {
             catalog: 'def',
@@ -49,6 +49,10 @@ const server = common.createServer(
           }
         ]
       );
+    });
+
+    conn.on('warn', (err) => {
+      assert.fail(err);
     });
   }
 );

--- a/test/integration/connection/test-quit.js
+++ b/test/integration/connection/test-quit.js
@@ -21,7 +21,7 @@ const server = common.createServer(
       connection.end();
     });
   },
-  (conn) => {
+  conn => {
     conn.on('quit', () => {
       // COM_QUIT
       quitReceived = true;
@@ -29,10 +29,10 @@ const server = common.createServer(
       server.close();
     });
 
-    conn.on('query', (q) => {
+    conn.on('query', q => {
       queryServ = q;
       conn.writeTextResult(
-        [{ 1: '1' }],
+        [{ '1': '1' }],
         [
           {
             catalog: 'def',
@@ -51,7 +51,7 @@ const server = common.createServer(
       );
     });
 
-    conn.on('warn', (err) => {
+    conn.on('warn', err => {
       assert.fail(err);
     });
   }

--- a/test/integration/connection/test-stream-errors.js
+++ b/test/integration/connection/test-stream-errors.js
@@ -13,20 +13,20 @@ const query = 'SELECT 1';
 const server = common.createServer(
   () => {
     clientConnection = common.createConnection({ port: server._port });
-    clientConnection.query(query, (err) => {
+    clientConnection.query(query, err => {
       receivedError1 = err;
     });
     clientConnection.query('second query, should not be executed', () => {
       receivedError2 = err;
       clientConnection.query(
         'trying to enqueue command to a connection which is already in error state',
-        (err1) => {
+        err1 => {
           receivedError3 = err1;
         }
       );
     });
   },
-  (conn) => {
+  conn => {
     conn.on('query', () => {
       conn.writeColumns([
         {
@@ -48,7 +48,7 @@ const server = common.createServer(
       clientConnection.stream.end();
       server.close();
     });
-    conn.on('warn', (err) => {
+    conn.on('warn', err => {
       assert.fail(err);
     });
   }

--- a/test/integration/connection/test-stream-errors.js
+++ b/test/integration/connection/test-stream-errors.js
@@ -13,20 +13,20 @@ const query = 'SELECT 1';
 const server = common.createServer(
   () => {
     clientConnection = common.createConnection({ port: server._port });
-    clientConnection.query(query, err => {
+    clientConnection.query(query, (err) => {
       receivedError1 = err;
     });
     clientConnection.query('second query, should not be executed', () => {
       receivedError2 = err;
       clientConnection.query(
         'trying to enqueue command to a connection which is already in error state',
-        err1 => {
+        (err1) => {
           receivedError3 = err1;
         }
       );
     });
   },
-  conn => {
+  (conn) => {
     conn.on('query', () => {
       conn.writeColumns([
         {
@@ -47,6 +47,9 @@ const server = common.createServer(
       clientConnection.stream.emit('error', err);
       clientConnection.stream.end();
       server.close();
+    });
+    conn.on('warn', (err) => {
+      assert.fail(err);
     });
   }
 );

--- a/test/integration/test-auth-switch.js
+++ b/test/integration/test-auth-switch.js
@@ -53,6 +53,7 @@ class TestAuthSwitchHandshake extends Command {
       return TestAuthSwitchHandshake.prototype.readClientAuthSwitchResponse;
     }
     connection.writeOk();
+    connection._resetSequenceId();
     return TestAuthSwitchHandshake.prototype.dispatchCommands;
   }
 
@@ -64,7 +65,7 @@ class TestAuthSwitchHandshake extends Command {
   }
 }
 
-const server = mysql.createServer(conn => {
+const server = mysql.createServer((conn) => {
   conn.serverConfig = {};
   conn.serverConfig.encoding = 'cesu8';
   conn.addCommand(
@@ -79,9 +80,9 @@ const server = mysql.createServer(conn => {
 
 const portfinder = require('portfinder');
 portfinder.getPort((err, port) => {
-  const makeSwitchHandler = function() {
+  const makeSwitchHandler = function () {
     let count = 0;
-    return function(data, cb) {
+    return function (data, cb) {
       if (count === 0) {
         assert.equal(data.pluginName, 'auth_test_plugin');
       } else {
@@ -103,7 +104,7 @@ portfinder.getPort((err, port) => {
     connectAttributes: connectAttributes
   });
 
-  conn.on('connect', data => {
+  conn.on('connect', (data) => {
     assert.equal(data.serverVersion, 'node.js rocks');
     assert.equal(data.connectionId, 1234);
 

--- a/test/integration/test-auth-switch.js
+++ b/test/integration/test-auth-switch.js
@@ -65,7 +65,7 @@ class TestAuthSwitchHandshake extends Command {
   }
 }
 
-const server = mysql.createServer((conn) => {
+const server = mysql.createServer(conn => {
   conn.serverConfig = {};
   conn.serverConfig.encoding = 'cesu8';
   conn.addCommand(
@@ -80,9 +80,9 @@ const server = mysql.createServer((conn) => {
 
 const portfinder = require('portfinder');
 portfinder.getPort((err, port) => {
-  const makeSwitchHandler = function () {
+  const makeSwitchHandler = function() {
     let count = 0;
-    return function (data, cb) {
+    return function(data, cb) {
       if (count === 0) {
         assert.equal(data.pluginName, 'auth_test_plugin');
       } else {
@@ -104,7 +104,7 @@ portfinder.getPort((err, port) => {
     connectAttributes: connectAttributes
   });
 
-  conn.on('connect', (data) => {
+  conn.on('connect', data => {
     assert.equal(data.serverVersion, 'node.js rocks');
     assert.equal(data.connectionId, 1234);
 


### PR DESCRIPTION
This change solves "Warning: got packets out of order. Expected X but received Y" warnings emitted on mock server's connections. Before the change this message is printed 23 times during `npm run test:raw` and never after the change.