### PR TITLE
Follow enableKeepAlive option

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -39,10 +39,7 @@ class Connection extends EventEmitter {
 
         // Enable keep-alive on the socket.
         // It's enabled by default and user can supply an initial delay.
-        if (
-          this.config.enableKeepAlive === undefined ||
-          this.config.enableKeepAlive
-        ) {
+        if (this.config.enableKeepAlive) {
           this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
         }
       }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -37,9 +37,14 @@ class Connection extends EventEmitter {
           opts.config.host
         );
 
-        // Enable keep-alive on the socket.  It's disabled by default, but the
-        // user can enable it and supply an initial delay.
-        this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
+        // Enable keep-alive on the socket.
+        // It's enabled by default and user can supply an initial delay.
+        if (
+          this.config.enableKeepAlive === undefined ||
+          this.config.enableKeepAlive
+        ) {
+          this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
+        }
       }
       // if stream is a function, treat it as "stream agent / factory"
     } else if (typeof opts.config.stream === 'function')  {

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -95,7 +95,8 @@ class ConnectionConfig {
     this.debug = options.debug;
     this.trace = options.trace !== false;
     this.stringifyObjects = options.stringifyObjects || false;
-    this.enableKeepAlive = !!options.enableKeepAlive;
+    this.enableKeepAlive =
+      options.enableKeepAlive === undefined || options.enableKeepAlive;
     this.keepAliveInitialDelay = options.keepAliveInitialDelay || 0;
     if (
       options.timezone &&

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -33,8 +33,7 @@ declare namespace Pool {
         queueLimit?: number;
 
         /**
-         * Enable keep-alive on the socket.  It's disabled by default, but the
-         * user can enable it and supply an initial delay.
+         * Enable keep-alive on the socket. It's enabled by default.
          */
         enableKeepAlive?: true;
 


### PR DESCRIPTION
It seems `enableKeepAlive` option is ignored since the setting for enabling keep-alive is hardcoded to "true".
https://github.com/sidorares/node-mysql2/blob/a640d471f043eb078c09ab0d6016030c315bd879/lib/connection.js#L42

This pull request changes the behavior: enabling TCP keep-alive when `enableKeepAlive` is not set, or `enableKeepAlive` is set to true. The `enableKeepAlive` is **true by default** even before this change so I also edit comments in the source code.

Related issue:
- https://github.com/sidorares/node-mysql2/issues/1229