### PR TITLE
exposing pool cluster in the promise-based implementations

### DIFF
--- a/examples/promise-co-await/await.js
+++ b/examples/promise-co-await/await.js
@@ -56,13 +56,30 @@ async function test() {
   end = +new Date();
   console.log(end - start);
   await p.end();
+
+  const cluster = mysql.createPoolCluster();
+  cluster.add('test', {
+    port: 3306,
+    user: 'testuser',
+    namedPlaceholders: true,
+    password: 'testpassword'
+  });
+  const selected = cluster.of('test', 'ORDER');
+  console.log(
+    await Promise.all([
+      selected.query('select 1+1 as aaa'),
+      selected.query('select 2+2 as bbb')
+    ])
+  );
+
+  await cluster.end();
 }
 
 test()
   .then(() => {
     console.log('done');
   })
-  .catch(err => {
+  .catch((err) => {
     console.log('error!', err);
     throw err;
   });

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -32,17 +32,13 @@ class Connection extends EventEmitter {
       if (opts.config.socketPath) {
         this.stream = Net.connect(opts.config.socketPath);
       } else {
-        this.stream = Net.connect(
-          opts.config.port,
-          opts.config.host
-        );
-
+        this.stream = Net.connect(opts.config.port, opts.config.host);
         // Enable keep-alive on the socket.  It's disabled by default, but the
         // user can enable it and supply an initial delay.
         this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
       }
       // if stream is a function, treat it as "stream agent / factory"
-    } else if (typeof opts.config.stream === 'function')  {
+    } else if (typeof opts.config.stream === 'function') {
       this.stream = opts.config.stream(opts);
     } else {
       this.stream = opts.config.stream;
@@ -55,7 +51,7 @@ class Connection extends EventEmitter {
     this._paused_packets = new Queue();
     this._statements = new LRU({
       max: this.config.maxPreparedStatements,
-      dispose: function(key, statement) {
+      dispose: function (key, statement) {
         statement.close();
       }
     });
@@ -71,10 +67,10 @@ class Connection extends EventEmitter {
     this.clientEncoding = CharsetToEncoding[this.config.charsetNumber];
     this.stream.on('error', this._handleNetworkError.bind(this));
     // see https://gist.github.com/khoomeister/4985691#use-that-instead-of-bind
-    this.packetParser = new PacketParser(p => {
+    this.packetParser = new PacketParser((p) => {
       this.handlePacket(p);
     });
-    this.stream.on('data', data => {
+    this.stream.on('data', (data) => {
       if (this.connectTimeout) {
         Timers.clearTimeout(this.connectTimeout);
         this.connectTimeout = null;
@@ -109,7 +105,7 @@ class Connection extends EventEmitter {
         this.threadId = handshakeCommand.handshake.connectionId;
         this.emit('connect', handshakeCommand.handshake);
       });
-      handshakeCommand.on('error', err => {
+      handshakeCommand.on('error', (err) => {
         this._closing = true;
         this._notifyError(err);
       });
@@ -188,7 +184,7 @@ class Connection extends EventEmitter {
     if (this.connectTimeout) {
       Timers.clearTimeout(this.connectTimeout);
       this.connectTimeout = null;
-    }    
+    }
     // prevent from emitting 'PROTOCOL_CONNECTION_LOST' after EPIPE or ECONNRESET
     if (this._fatalError) {
       return;
@@ -227,7 +223,7 @@ class Connection extends EventEmitter {
   }
 
   write(buffer) {
-    const result = this.stream.write(buffer, err => {
+    const result = this.stream.write(buffer, (err) => {
       if (err) {
         this._handleNetworkError(err);
       }
@@ -268,11 +264,19 @@ class Connection extends EventEmitter {
       if (this.config.debug) {
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${this._command._commandName}#${this._command.stateName()}(${[this.sequenceId, packet._name, packet.length()].join(',')})`
+          `${this._internalId} ${this.connectionId} <== ${
+            this._command._commandName
+          }#${this._command.stateName()}(${[
+            this.sequenceId,
+            packet._name,
+            packet.length()
+          ].join(',')})`
         );
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${packet.buffer.toString('hex')}`
+          `${this._internalId} ${
+            this.connectionId
+          } <== ${packet.buffer.toString('hex')}`
         );
       }
       this._bumpSequenceId(1);
@@ -285,7 +289,13 @@ class Connection extends EventEmitter {
         );
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} <== ${this._command._commandName}#${this._command.stateName()}(${[this.sequenceId, packet._name, packet.length()].join(',')})`
+          `${this._internalId} ${this.connectionId} <== ${
+            this._command._commandName
+          }#${this._command.stateName()}(${[
+            this.sequenceId,
+            packet._name,
+            packet.length()
+          ].join(',')})`
         );
       }
       for (offset = 4; offset < 4 + length; offset += MAX_PACKET_LENGTH) {
@@ -330,7 +340,7 @@ class Connection extends EventEmitter {
       isServer: false
     });
     // error handler for secure socket
-    secureSocket.on('_tlsError', err => {
+    secureSocket.on('_tlsError', (err) => {
       if (secureEstablished) {
         this._handleNetworkError(err);
       } else {
@@ -341,10 +351,10 @@ class Connection extends EventEmitter {
       secureEstablished = true;
       onSecure(rejectUnauthorized ? secureSocket.ssl.verifyError() : null);
     });
-    secureSocket.on('data', data => {
+    secureSocket.on('data', (data) => {
       this.packetParser.execute(data);
     });
-    this.write = buffer => {
+    this.write = (buffer) => {
       secureSocket.write(buffer);
     };
     // start TLS communications
@@ -357,7 +367,7 @@ class Connection extends EventEmitter {
         this.packetParser.execute(data, start, end);
       };
     } else {
-      this.stream.on('data', data => {
+      this.stream.on('data', (data) => {
         this.packetParser.execute(
           data.parent,
           data.offset,
@@ -410,7 +420,13 @@ class Connection extends EventEmitter {
           : '(no command)';
         // eslint-disable-next-line no-console
         console.log(
-          `${this._internalId} ${this.connectionId} ==> ${commandName}#${stateName}(${[packet.sequenceId, packet.type(), packet.length()].join(',')})`
+          `${this._internalId} ${
+            this.connectionId
+          } ==> ${commandName}#${stateName}(${[
+            packet.sequenceId,
+            packet.type(),
+            packet.length()
+          ].join(',')})`
         );
       }
     }
@@ -491,7 +507,7 @@ class Connection extends EventEmitter {
       if (Array.isArray(options.values)) {
         // if an array is provided as the values, assume the conversion is not necessary.
         // this allows the usage of unnamed placeholders even if the namedPlaceholders flag is enabled.
-        return
+        return;
       }
       if (convertNamedPlaceholders === null) {
         convertNamedPlaceholders = require('named-placeholders')();
@@ -510,7 +526,10 @@ class Connection extends EventEmitter {
       cmdQuery = Connection.createQuery(sql, values, cb, this.config);
     }
     this._resolveNamedPlaceholders(cmdQuery);
-    const rawSql = this.format(cmdQuery.sql, cmdQuery.values !== undefined ? cmdQuery.values : []);
+    const rawSql = this.format(
+      cmdQuery.sql,
+      cmdQuery.values !== undefined ? cmdQuery.values : []
+    );
     cmdQuery.sql = rawSql;
     return this.addCommand(cmdQuery);
   }
@@ -586,7 +605,7 @@ class Connection extends EventEmitter {
           'Bind parameters must be array if namedPlaceholders parameter is not enabled'
         );
       }
-      options.values.forEach(val => {
+      options.values.forEach((val) => {
         //If namedPlaceholder is not enabled and object is passed as bind parameters
         if (!Array.isArray(options.values)) {
           throw new TypeError(
@@ -610,7 +629,7 @@ class Connection extends EventEmitter {
       if (err) {
         // skip execute command if prepare failed, we have main
         // combined callback here
-        executeCommand.start = function() {
+        executeCommand.start = function () {
           return null;
         };
         if (cb) {
@@ -647,7 +666,7 @@ class Connection extends EventEmitter {
           charsetNumber: charsetNumber,
           currentConfig: this.config
         },
-        err => {
+        (err) => {
           if (err) {
             err.fatal = true;
           }
@@ -704,14 +723,14 @@ class Connection extends EventEmitter {
     // TODO: use through2
     let test = 1;
     const stream = new Readable({ objectMode: true });
-    stream._read = function() {
+    stream._read = function () {
       return {
         data: test++
       };
     };
     this._registerSlave(opts, () => {
       const dumpCmd = this._binlogDump(opts);
-      dumpCmd.on('event', ev => {
+      dumpCmd.on('event', (ev) => {
         stream.push(ev);
       });
       dumpCmd.on('eof', () => {
@@ -738,7 +757,7 @@ class Connection extends EventEmitter {
     }
     let connectCalled = 0;
     function callbackOnce(isErrorHandler) {
-      return function(param) {
+      return function (param) {
         if (!connectCalled) {
           if (isErrorHandler) {
             cb(param);
@@ -758,7 +777,7 @@ class Connection extends EventEmitter {
   // ===================================
   writeColumns(columns) {
     this.writePacket(Packets.ResultSetHeader.toPacket(columns.length));
-    columns.forEach(column => {
+    columns.forEach((column) => {
       this.writePacket(
         Packets.ColumnDefinition.toPacket(column, this.serverConfig.encoding)
       );
@@ -775,9 +794,9 @@ class Connection extends EventEmitter {
 
   writeTextResult(rows, columns) {
     this.writeColumns(columns);
-    rows.forEach(row => {
+    rows.forEach((row) => {
       const arrayRow = new Array(columns.length);
-      columns.forEach(column => {
+      columns.forEach((column) => {
         arrayRow.push(row[column.name]);
       });
       this.writeTextRow(arrayRow);
@@ -852,9 +871,9 @@ class Connection extends EventEmitter {
   }
 
   static statementKey(options) {
-    return (
-      `${typeof options.nestTables}/${options.nestTables}/${options.rowsAsArray}${options.sql}`
-    );
+    return `${typeof options.nestTables}/${options.nestTables}/${
+      options.rowsAsArray
+    }${options.sql}`;
   }
 }
 
@@ -890,10 +909,10 @@ if (Tls.TLSSocket) {
     stream.removeAllListeners('data');
     stream.pipe(securePair.encrypted);
     securePair.encrypted.pipe(stream);
-    securePair.cleartext.on('data', data => {
+    securePair.cleartext.on('data', (data) => {
       this.packetParser.execute(data);
     });
-    this.write = function(buffer) {
+    this.write = function (buffer) {
       securePair.cleartext.write(buffer);
     };
     securePair.on('secure', () => {

--- a/lib/pool_cluster.js
+++ b/lib/pool_cluster.js
@@ -5,6 +5,7 @@ const process = require('process');
 const Pool = require('./pool.js');
 const PoolConfig = require('./pool_config.js');
 const EventEmitter = require('events').EventEmitter;
+const Connection = require('./connection.js');
 
 /**
  * Selector
@@ -12,22 +13,23 @@ const EventEmitter = require('events').EventEmitter;
 const makeSelector = {
   RR() {
     let index = 0;
-    return clusterIds => clusterIds[index++ % clusterIds.length];
+    return (clusterIds) => clusterIds[index++ % clusterIds.length];
   },
   RANDOM() {
-    return clusterIds =>
+    return (clusterIds) =>
       clusterIds[Math.floor(Math.random() * clusterIds.length)];
   },
   ORDER() {
-    return clusterIds => clusterIds[0];
+    return (clusterIds) => clusterIds[0];
   }
 };
 
 class PoolNamespace {
-  constructor(cluster, pattern, selector) {
+  constructor(cluster, pattern, selector, config = {}) {
     this._cluster = cluster;
     this._pattern = pattern;
     this._selector = makeSelector[selector]();
+    this._config = config;
   }
 
   getConnection(cb) {
@@ -56,6 +58,32 @@ class PoolNamespace {
         ? foundNodeIds[0]
         : this._selector(foundNodeIds);
     return this._cluster._getNode(nodeId);
+  }
+
+  query(sql, values, cb) {
+    const cmdQuery = Connection.createQuery(sql, values, cb, this._config);
+    if (typeof cmdQuery.namedPlaceholders === 'undefined') {
+      cmdQuery.namedPlaceholders = this._config.namedPlaceholders;
+    }
+    this.getConnection((err, conn) => {
+      if (err) {
+        if (typeof cmdQuery.onResult === 'function') {
+          cmdQuery.onResult(err);
+        } else {
+          cmdQuery.emit('error', err);
+        }
+        return;
+      }
+      try {
+        conn.query(cmdQuery).once('end', () => {
+          conn.release();
+        });
+      } catch (e) {
+        conn.release();
+        throw e;
+      }
+    });
+    return cmdQuery;
   }
 }
 
@@ -124,11 +152,11 @@ class PoolCluster extends EventEmitter {
     const cb =
       callback !== undefined
         ? callback
-        : err => {
-          if (err) {
-            throw err;
-          }
-        };
+        : (err) => {
+            if (err) {
+              throw err;
+            }
+          };
     if (this._closed) {
       process.nextTick(cb);
       return;
@@ -137,7 +165,7 @@ class PoolCluster extends EventEmitter {
 
     let calledBack = false;
     let waitingClose = 0;
-    const onEnd = err => {
+    const onEnd = (err) => {
       if (!calledBack && (err || --waitingClose <= 0)) {
         calledBack = true;
         return cb(err);
@@ -167,7 +195,7 @@ class PoolCluster extends EventEmitter {
     } else {
       // wild matching
       const keyword = pattern.substring(pattern.length - 1, 0);
-      foundNodeIds = this._serviceableNodeIds.filter(id =>
+      foundNodeIds = this._serviceableNodeIds.filter((id) =>
         id.startsWith(keyword)
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1262,7 +1262,7 @@
     },
     "is-property": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://artifactory.foc.zone:443/artifactory/api/npm/npm-public-virtual/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-regexp": {
@@ -2164,7 +2164,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://artifactory.foc.zone:443/artifactory/api/npm/npm-public-virtual/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "pump": {
@@ -2336,7 +2336,7 @@
     },
     "seq-queue": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "resolved": "https://artifactory.foc.zone:443/artifactory/api/npm/npm-public-virtual/seq-queue/-/seq-queue-0.0.5.tgz",
       "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
     },
     "shebang-command": {

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -5,7 +5,8 @@ import {
   FieldPacket,
   QueryOptions,
   ConnectionOptions,
-  PoolOptions
+  PoolOptions,
+  PoolClusterOptions
 } from './index';
 
 import { EventEmitter } from 'events';
@@ -131,8 +132,29 @@ export interface Pool extends EventEmitter {
   end(): Promise<void>;
 }
 
+export interface PoolCluster extends EventEmitter {
+  of(pattern: string, selector?: string): PoolCluster;
+  add(group: string, config: Pool.PoolOptions): void;
+
+  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+    sql: string
+  ): Promise<[T, FieldPacket[]]>;
+  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+    sql: string,
+    values: any | any[] | { [param: string]: any }
+  ): Promise<[T, FieldPacket[]]>;
+  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+    options: QueryOptions
+  ): Promise<[T, FieldPacket[]]>;
+  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
+    options: QueryOptions,
+    values: any | any[] | { [param: string]: any }
+  ): Promise<[T, FieldPacket[]]>;
+}
+
 export function createConnection(connectionUri: string): Promise<Connection>;
 export function createConnection(
   config: ConnectionOptions
 ): Promise<Connection>;
 export function createPool(config: PoolOptions): Pool;
+export function createPoolCluster(config?: PoolClusterOptions): PoolCluster;

--- a/promise.js
+++ b/promise.js
@@ -21,7 +21,7 @@ function makeDoneCb(resolve, reject, localErr) {
 function inheritEvents(source, target, events) {
   const listeners = {};
   target
-    .on('newListener', eventName => {
+    .on('newListener', (eventName) => {
       if (events.indexOf(eventName) >= 0 && !target.listenerCount(eventName)) {
         source.on(
           eventName,
@@ -34,7 +34,7 @@ function inheritEvents(source, target, events) {
         );
       }
     })
-    .on('removeListener', eventName => {
+    .on('removeListener', (eventName) => {
       if (events.indexOf(eventName) >= 0 && !target.listenerCount(eventName)) {
         source.removeListener(eventName, listeners[eventName]);
         delete listeners[eventName];
@@ -62,7 +62,7 @@ class PromisePreparedStatementInfo {
   }
 
   close() {
-    return new this.Promise(resolve => {
+    return new this.Promise((resolve) => {
       this.statement.close();
       resolve();
     });
@@ -124,7 +124,7 @@ class PromiseConnection extends EventEmitter {
   }
 
   end() {
-    return new this.Promise(resolve => {
+    return new this.Promise((resolve) => {
       this.connection.end(resolve);
     });
   }
@@ -212,7 +212,7 @@ class PromiseConnection extends EventEmitter {
     const c = this.connection;
     const localErr = new Error();
     return new this.Promise((resolve, reject) => {
-      c.changeUser(options, err => {
+      c.changeUser(options, (err) => {
         if (err) {
           localErr.message = err.message;
           localErr.code = err.code;
@@ -243,15 +243,15 @@ function createConnection(opts) {
   if (!thePromise) {
     throw new Error(
       'no Promise implementation available.' +
-      'Use promise-enabled node version or pass userland Promise' +
-      " implementation as parameter, for example: { Promise: require('bluebird') }"
+        'Use promise-enabled node version or pass userland Promise' +
+        " implementation as parameter, for example: { Promise: require('bluebird') }"
     );
   }
   return new thePromise((resolve, reject) => {
     coreConnection.once('connect', () => {
       resolve(new PromiseConnection(coreConnection, thePromise));
     });
-    coreConnection.once('error', err => {
+    coreConnection.once('error', (err) => {
       createConnectionErr.message = err.message;
       createConnectionErr.code = err.code;
       createConnectionErr.errno = err.errno;
@@ -375,7 +375,7 @@ class PromisePool extends EventEmitter {
     const corePool = this.pool;
     const localErr = new Error();
     return new this.Promise((resolve, reject) => {
-      corePool.end(err => {
+      corePool.end((err) => {
         if (err) {
           localErr.message = err.message;
           localErr.code = err.code;
@@ -397,8 +397,8 @@ function createPool(opts) {
   if (!thePromise) {
     throw new Error(
       'no Promise implementation available.' +
-      'Use promise-enabled node version or pass userland Promise' +
-      " implementation as parameter, for example: { Promise: require('bluebird') }"
+        'Use promise-enabled node version or pass userland Promise' +
+        " implementation as parameter, for example: { Promise: require('bluebird') }"
     );
   }
 
@@ -427,8 +427,86 @@ function createPool(opts) {
   'format'
 ]);
 
+class PromisePoolCluster extends EventEmitter {
+  constructor(poolCluster, thePromise) {
+    super();
+    this.poolCluster = poolCluster;
+    this.Promise = thePromise || Promise;
+    inheritEvents(poolCluster, this, [
+      'acquire',
+      'connection',
+      'enqueue',
+      'release'
+    ]);
+  }
+
+  of(pattern, selector) {
+    return new PromisePoolCluster(
+      this.poolCluster.of(pattern, selector),
+      this.Promise
+    );
+  }
+
+  add(id, config) {
+    this.poolCluster.add(id, config);
+  }
+
+  query(sql, args) {
+    const coreCluster = this.poolCluster;
+    const localErr = new Error();
+    if (typeof args === 'function') {
+      throw new Error(
+        'Callback function is not available with promise clients.'
+      );
+    }
+    return new this.Promise((resolve, reject) => {
+      const done = makeDoneCb(resolve, reject, localErr);
+
+      if (args !== undefined) {
+        coreCluster.query(sql, args, done);
+      } else {
+        coreCluster.query(sql, null, done);
+      }
+    });
+  }
+
+  end() {
+    const coreCluster = this.poolCluster;
+    const localErr = new Error();
+    return new this.Promise((resolve, reject) => {
+      coreCluster.end((err) => {
+        if (err) {
+          localErr.message = err.message;
+          localErr.code = err.code;
+          localErr.errno = err.errno;
+          localErr.sqlState = err.sqlState;
+          localErr.sqlMessage = err.sqlMessage;
+          reject(localErr);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+function createPoolCluster(opts) {
+  const coreCluster = core.createPoolCluster(opts);
+  const thePromise = (opts && opts.Promise) || Promise;
+  if (!thePromise) {
+    throw new Error(
+      'no Promise implementation available.' +
+        'Use promise-enabled node version or pass userland Promise' +
+        " implementation as parameter, for example: { Promise: require('bluebird') }"
+    );
+  }
+
+  return new PromisePoolCluster(coreCluster, thePromise);
+}
+
 exports.createConnection = createConnection;
 exports.createPool = createPool;
+exports.createPoolCluster = createPoolCluster;
 exports.escape = core.escape;
 exports.escapeId = core.escapeId;
 exports.format = core.format;
@@ -436,3 +514,4 @@ exports.raw = core.raw;
 exports.PromisePool = PromisePool;
 exports.PromiseConnection = PromiseConnection;
 exports.PromisePoolConnection = PromisePoolConnection;
+exports.PromisePoolCluster = PromisePoolCluster;

--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -1,6 +1,7 @@
 
 import Connection = require('./Connection');
 import PoolConnection = require('./PoolConnection');
+import Pool = require('./Pool')
 import {EventEmitter} from 'events';
 
 declare namespace PoolCluster {
@@ -39,6 +40,7 @@ declare class PoolCluster extends EventEmitter {
 
     add(config: PoolCluster.PoolClusterOptions): void;
     add(group: string, config: PoolCluster.PoolClusterOptions): void;
+    add(group: string, config: Pool.PoolOptions): void;
 
     end(): void;
 


### PR DESCRIPTION
Originally my changes were to expose query as a function of PoolCluster (as it was in the mysqljs library - https://github.com/mysqljs/mysql/blob/3430c513d6b0ca279fb7c79b210c9301e9315658/lib/PoolNamespace.js#L58)

In order to achieve that, I had to expose PoolCluster in the promise based implementation. This exposes PoolCluster in promise.js, along with adding the types in the promise typing files.

This is my first time working on the code for this library, so any feedback would be appreciated! I tried to follow the same coding practices and styles as much as I could.