### PR TITLE
Remove unused option acquireTimeout from typings

### DIFF
--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -9,12 +9,6 @@ declare namespace Pool {
 
     export interface PoolOptions extends Connection.ConnectionOptions {
         /**
-         * The milliseconds before a timeout occurs during the connection acquisition. This is slightly different from connectTimeout,
-         * because acquiring a pool connection does not always involve making a connection. (Default: 10 seconds)
-         */
-        acquireTimeout?: number;
-
-        /**
          * Determines the pool's action when no connections are available and the limit has been reached. If true, the pool will queue
          * the connection request and call it when one becomes available. If false, the pool will immediately call back with an error.
          * (Default: true)


### PR DESCRIPTION
Remove parameter that apparently has never actually been supported

If you try including `acquireTimeout` in the PoolOptions from the TypeScript interface, then `mysql2.createPool` logs this warning (from https://github.com/sidorares/node-mysql2/pull/815): `Ignoring invalid configuration option passed to Connection: acquireTimeout. This is currently a warning, but in future versions of MySQL2, an error will be thrown if you pass an invalid configuration option to a Connection`. 