### PR TITLE
Add missing `connection` property from the `PoolConnection` type

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -81,6 +81,7 @@ export interface Connection extends EventEmitter {
 }
 
 export interface PoolConnection extends Connection {
+  connection: Connection;
   release(): void;
 }
 

--- a/typings/mysql/lib/PoolConnection.d.ts
+++ b/typings/mysql/lib/PoolConnection.d.ts
@@ -2,6 +2,7 @@
 import Connection = require('./Connection');
 
 declare class PoolConnection extends Connection {
+    connection: Connection;
     release(): void;
 }
 


### PR DESCRIPTION
A `PoolConnection` object exposes a `connection` property, but that is missing from the typing.

This is the same as a PR I merged on the types/mysql2 project earlier in the year:
https://github.com/types/mysql2/pull/40