### PR TITLE
typings: export PromisePool

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import {
   Pool as PromisePool,
   PoolConnection as PromisePoolConnection
 } from './promise';
+export { Pool as PromisePool } from './promise';
 
 import * as mysql from './typings/mysql';
 export * from './typings/mysql';


### PR DESCRIPTION
I can't find any type for `createPool({}).promise()`, so I think we should export interface Pool in promise.d.ts as PromisePool. 