### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,15 +59,18 @@ exports.__defineGetter__(
   () => require('./promise.js').createPoolCluster
 );
 
+exports.__defineGetter__('CharsetToEncoding', () => require('./lib/constants/charset_encodings.js'));
+exports.__defineGetter__('Charsets', () => require('./lib/constants/charsets.js'));
+exports.__defineGetter__('ClientFlags', () => require('./lib/constants/client.js'));
+exports.__defineGetter__('Commands', () => require('./lib/constants/commands.js'));
+exports.__defineGetter__('Cursor', () => require('./lib/constants/cursor.js'));
+exports.__defineGetter__('EncodingToCharset', () => require('./lib/constants/encoding_charset.js'));
+exports.__defineGetter__('Errors', () => require('./lib/constants/errors.js'));
+exports.__defineGetter__('FieldFlags', () => require('./lib/constants/field_flags.js'));
+exports.__defineGetter__('ServerStatus', () => require('./lib/constants/server_status.js'));
+exports.__defineGetter__('SessionTrack', () => require('./lib/constants/session_track.js'));
+exports.__defineGetter__('SslProfiles', () => require('./lib/constants/ssl_profiles.js'));
 exports.__defineGetter__('Types', () => require('./lib/constants/types.js'));
-
-exports.__defineGetter__('Charsets', () =>
-  require('./lib/constants/charsets.js')
-);
-
-exports.__defineGetter__('CharsetToEncoding', () =>
-  require('./lib/constants/charset_encodings.js')
-);
 
 exports.setMaxParserCache = function(max) {
   parserCache.setMaxCache(max);


### PR DESCRIPTION
Adding other constants modules as top-level getters. This will resolve a number of open bugs, including

* https://github.com/sidorares/node-mysql2/issues/1224
* https://github.com/sidorares/node-mysql2/issues/1216
* https://github.com/sidorares/node-mysql2/issues/1084

In my own use case, we had been importing `mysql2/lib/constants/errors` in order to support retry-after-deadlock logic, which is now broken since the `exports` are defined in a more limited fashion in `package.json`. This will allow us to simply `import mysql from 'mysql2'` and use `mysql.Errors` for our situation.