### PR TITLE
Add getter function for connection private property _fatalError

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -397,7 +397,7 @@ class Connection extends EventEmitter {
     this.emit('error', err);
   }
   
-  getFatalError() {
+  get fatalError() {
     return this._fatalError;
   }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -396,6 +396,10 @@ class Connection extends EventEmitter {
     err.code = code || 'PROTOCOL_ERROR';
     this.emit('error', err);
   }
+  
+  getFatalError() {
+    return this._fatalError;
+  }
 
   handlePacket(packet) {
     if (this._paused) {


### PR DESCRIPTION
I ran into the problems described in https://github.com/knex/knex/pull/2175 recently and I saw that the proposed solution in this issue (expose _fatalError as part of the public api of connection -> use getter in knex) was never implemented. Here's a stab at exposing that property as a getter, and I'll follow up with a PR for knex if this is accepted.