### PR TITLE
Improved formatting for TIME-type columns

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -368,10 +368,12 @@ class Packet {
       ms *= sign;
       return ms;
     }
+    // Format follows mySQL TIME format ([-][h]hh:mm:ss[.u[u[u[u[u[u]]]]]])
+    // For positive times below 24 hours, this makes it equal to ISO 8601 times
     return (
       (sign === -1 ? '-' : '') +
-      [d ? d * 24 + H : H, leftPad(2, M), leftPad(2, S)].join(':') +
-      (ms ? `.${ms}` : '')
+      [leftPad(2, d * 24 + H), leftPad(2, M), leftPad(2, S)].join(':') +
+      (ms ? `.${ms}`.replace(/0+$/, '') : '')
     );
   }
 
@@ -410,9 +412,9 @@ class Packet {
 
   // TODO reuse?
   readString(len, encoding) {
-    if ((typeof len === 'string') && (typeof encoding === 'undefined')) {
-      encoding = len
-      len = undefined
+    if (typeof len === 'string' && typeof encoding === 'undefined') {
+      encoding = len;
+      len = undefined;
     }
     if (typeof len === 'undefined') {
       len = this.end - this.offset;
@@ -899,7 +901,7 @@ class Packet {
   }
 
   static MockBuffer() {
-    const noop = function() {};
+    const noop = function () {};
     const res = Buffer.alloc(0);
     for (const op in NativeBuffer.prototype) {
       if (typeof res[op] === 'function') {

--- a/test/unit/packets/test-time.js
+++ b/test/unit/packets/test-time.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+const packets = require('../../../lib/packets/index.js');
+
+[
+  ['01:23:45', '0b000004000008000000000001172d'], // CONVERT('01:23:45', TIME)
+  ['01:23:45.123456', '0f00000400000c000000000001172d40e20100'], // DATE_ADD(CONVERT('01:23:45', TIME), INTERVAL 0.123456 SECOND)
+  ['-01:23:44.876544', '0f00000400000c010000000001172c00600d00'], // DATE_ADD(CONVERT('-01:23:45', TIME), INTERVAL 0.123456 SECOND)
+  ['-81:23:44.876544', '0f00000400000c010300000009172c00600d00'], // DATE_ADD(CONVERT('-81:23:45', TIME), INTERVAL 0.123456 SECOND)
+  ['81:23:45', '0b000004000008000300000009172d'], // CONVERT('81:23:45', TIME)
+  ['123:23:45.123456', '0f00000400000c000500000003172d40e20100'], // DATE_ADD(CONVERT('123:23:45', TIME), INTERVAL 0.123456 SECOND)
+  ['-121:23:45', '0b000004000008010500000001172d'], // CONVERT('-121:23:45', TIME)
+  ['-01:23:44.88', '0f00000400000c010000000001172c806d0d00'] //DATE_ADD(CONVERT('-01:23:45', TIME), INTERVAL 0.12 SECOND)
+].forEach(([expected, buffer]) => {
+  let buf = Buffer.from(buffer, 'hex');
+  let packet = new packets.Packet(4, buf, 0, buf.length);
+  packet.readInt16(); // unused
+  let d = packet.readTimeString(false);
+  assert.equal(d, expected);
+});


### PR DESCRIPTION
Solves #1365

This PR makes sure the default format for TIME columns adheres to the format outlined [here](https://dev.mysql.com/doc/refman/5.6/en/time.html): 
`[-][h]hh:mm:ss[.u[u[u[u[u[u]]]]]]`