### PR TITLE
declutter promise typing for query() and execute()

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -25,41 +25,15 @@ export interface Connection extends EventEmitter {
   changeUser(options: ConnectionOptions): Promise<void>;
 
   query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any },
   ): Promise<[T, FieldPacket[]]>;
 
   execute<
     T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
   >(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any },
   ): Promise<[T, FieldPacket[]]>;
 
   unprepare(sql: string): void;
@@ -86,41 +60,15 @@ export interface PoolConnection extends Connection {
 
 export interface Pool extends EventEmitter {
   query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any },
   ): Promise<[T, FieldPacket[]]>;
 
   execute<
     T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
   >(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any },
   ): Promise<[T, FieldPacket[]]>;
 
   getConnection(): Promise<PoolConnection>;


### PR DESCRIPTION
the overloading makes the function types harder to work with and adds no type refinement value.  prefer a single, more concise interface.

this commit leaves the `any | any[] | { [param: string]: any }` typing for documentation benefits, even though it's identical to just `any`.