### PR TITLE
add sqlMessage to QueryError interface

### DIFF
--- a/typings/mysql/lib/protocol/sequences/Query.d.ts
+++ b/typings/mysql/lib/protocol/sequences/Query.d.ts
@@ -79,19 +79,9 @@ declare namespace Query {
          */
         code: string;
 
-        /**
-         * The sql state marker
-         */
         sqlStateMarker?: string;
-
-        /**
-         * The sql state
-         */
         sqlState?: string;
-
-        /**
-         * The field count
-         */
+        sqlMessage?: string;
         fieldCount?: number;
 
         /**


### PR DESCRIPTION
it should be there; it's usually set. also delete redundant comments of the form `/** the variable name, but with spaces */`.