### PR TITLE
test(poolCluster): add unit tests

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -165,6 +165,14 @@ exports.createPool = function(args) {
   return driver.createPool(exports.getConfig(args));
 };
 
+exports.createPoolCluster = function(args = {}) {
+  let driver = require('../index.js');
+  if (process.env.BENCHMARK_MYSQL1) {
+    driver = require('mysql');
+  }
+  return driver.createPoolCluster(args)
+}
+
 exports.createConnectionWithURI = function() {
   const driver = require('../index.js');
 

--- a/test/unit/pool-cluster/test-connection-error-remove.js
+++ b/test/unit/pool-cluster/test-connection-error-remove.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const assert  = require('assert');
+const portfinder = require('portfinder');
+
+const common  = require('../../common');
+const mysql = require('../../../index.js');
+const { exit } = require('process');
+
+const cluster = common.createPoolCluster({
+  removeNodeErrorCount : 1
+});
+
+let connCount = 0;
+
+const server1   = mysql.createServer();
+const server2   = mysql.createServer();
+
+console.log('test pool cluster error remove');
+
+portfinder.getPort((err,port) => {
+
+  cluster.add('SLAVE1', {port: port + 0});
+  cluster.add('SLAVE2', {port: port + 1});
+
+  server1.listen(port + 0, err => {
+    assert.ifError(err);
+  
+    server2.listen(port + 1, err => {
+      assert.ifError(err);
+  
+      const pool = cluster.of('*', 'ORDER');
+      let removedNodeId;
+  
+      cluster.on('remove', nodeId => {
+        removedNodeId = nodeId;
+      });
+  
+      pool.getConnection((err, connection) => {
+        assert.ifError(err);
+
+        assert.equal(connCount, 2);
+        assert.equal(connection._clusterId, 'SLAVE2');
+        assert.equal(removedNodeId, 'SLAVE1');
+        assert.deepEqual(cluster._serviceableNodeIds, [ 'SLAVE2' ]);
+        console.log('done')
+
+        connection.release();
+
+        cluster.end(err => {
+          assert.ifError(err);
+          // throw error if no exit() 
+          exit();
+          // server1.close();
+          // server2.close();
+        });
+      });
+    });
+  });
+  
+  server1.on('connection', conn => {
+    connCount += 1;
+    conn.close();
+  });
+  
+  server2.on('connection', conn => {
+    connCount += 1;
+    conn.serverHandshake({
+      serverVersion: 'node.js rocks',
+    });
+  });
+});

--- a/test/unit/pool-cluster/test-connection-order.js
+++ b/test/unit/pool-cluster/test-connection-order.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert  = require('assert');
+const common  = require('../../common');
+const cluster = common.createPoolCluster();
+
+const order = [];
+
+const poolConfig = common.getConfig();
+cluster.add('SLAVE1', poolConfig);
+cluster.add('SLAVE2', poolConfig);
+
+const done = function() {
+  assert.deepEqual(order, [
+    'SLAVE1',
+    'SLAVE1',
+    'SLAVE1',
+    'SLAVE1',
+    'SLAVE1'
+  ]);
+  cluster.end();
+  console.log('done');
+};
+
+const pool = cluster.of('SLAVE*', 'ORDER');
+
+console.log('test pool cluster connection ORDER');
+
+let count = 0;
+
+function getConnection(i) {
+  pool.getConnection((err, conn) => {
+    assert.ifError(err);
+    order[i] = conn._clusterId;
+    conn.release();
+
+    count += 1;
+
+    if(count <= 4) {
+      getConnection(count);
+    } else {
+      done();
+    }
+  });
+}
+
+getConnection(0);

--- a/test/unit/pool-cluster/test-connection-restore.js
+++ b/test/unit/pool-cluster/test-connection-restore.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert  = require('assert');
+const portfinder = require('portfinder');
+const common  = require('../../common');
+const mysql = require('../../../index.js');
+const cluster = common.createPoolCluster({
+  canRetry             : true,
+  removeNodeErrorCount : 1,
+  restoreNodeTimeout   : 100
+});
+
+let connCount = 0;
+
+const server = mysql.createServer();
+
+console.log('test pool cluster restore');
+
+portfinder.getPort((err,port) => {
+  cluster.add('MASTER', { port });
+
+  server.listen(port + 0, err => {
+    assert.ifError(err);
+  
+    const pool = cluster.of('*', 'ORDER');
+    let removedNodeId;
+
+    cluster.on('remove', nodeId => {
+      removedNodeId = nodeId;
+    });
+
+    pool.getConnection(err => {
+      assert.ok(err);
+      console.log(connCount, cluster._serviceableNodeIds, removedNodeId)
+    });
+
+    setTimeout(() => {
+      pool.getConnection(() => {
+        // TODO: restoreNodeTimeout is not supported now
+        console.log(connCount, cluster._serviceableNodeIds, removedNodeId)
+
+        cluster.end(err => {
+          assert.ifError(err);
+          server._server.close();
+        });
+      });
+    }, 200)
+  });
+  
+  server.on('connection', conn => {
+    connCount += 1;
+    console.log(connCount);
+    if(connCount < 2) {
+      conn.close();
+    } else {
+      conn.serverHandshake({
+        serverVersion: 'node.js rocks',
+      });
+    }
+  });
+});

--- a/test/unit/pool-cluster/test-connection-rr.js
+++ b/test/unit/pool-cluster/test-connection-rr.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const assert  = require('assert');
+const common  = require('../../common');
+const cluster = common.createPoolCluster();
+
+const order = [];
+
+const poolConfig = common.getConfig();
+cluster.add('SLAVE1', poolConfig);
+cluster.add('SLAVE2', poolConfig);
+
+const done = function() {
+  assert.deepEqual(order, [
+    'SLAVE1',
+    'SLAVE2',
+    'SLAVE1',
+    'SLAVE2',
+    'SLAVE1'
+  ]);
+  cluster.end();
+  console.log('done');
+};
+
+const pool = cluster.of('SLAVE*', 'RR');
+
+console.log('test pool cluster connection RR');
+
+let count = 0;
+
+function getConnection(i) {
+  pool.getConnection((err, conn) => {
+    assert.ifError(err);
+    order[i] = conn._clusterId;
+    conn.release();
+
+    count += 1;
+
+    if(count <= 4) {
+      getConnection(count);
+    } else {
+      done();
+    }
+  });
+}
+
+getConnection(0);

--- a/test/unit/pool-cluster/test-query.js
+++ b/test/unit/pool-cluster/test-query.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert  = require('assert');
+const common  = require('../../common');
+const cluster = common.createPoolCluster();
+const poolConfig = common.getConfig();
+
+
+cluster.add('MASTER', poolConfig);
+cluster.add('SLAVE1', poolConfig);
+cluster.add('SLAVE2', poolConfig);
+
+const connection = cluster.of('*');
+
+console.log('test pool cluster connection query');
+
+connection.query('SELECT 1', (err, rows) => {
+  assert.ifError(err);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]['1'], 1);
+  assert.deepEqual(cluster._serviceableNodeIds, [ 'MASTER', 'SLAVE1', 'SLAVE2' ])
+
+  cluster.end();
+  console.log('done');
+});


### PR DESCRIPTION
add unit tests for `poolCluster`.
And I found that `node-mysql2` not support `restoreNodeTimeout` now, I will make a PR later.