### PR TITLE
Adds the optional column changedRows to ResultSetHeader interface

### DIFF
--- a/typings/mysql/lib/protocol/packets/ResultSetHeader.d.ts
+++ b/typings/mysql/lib/protocol/packets/ResultSetHeader.d.ts
@@ -9,6 +9,7 @@ declare interface ResultSetHeader {
     insertId: number;
     serverStatus: number;
     warningStatus: number;
+    changedRows?: number;
 }
 
 export = ResultSetHeader;


### PR DESCRIPTION
This row is already returned when I use JavaScript. I added to the interface to avoid compilation error on Typescript and it is useful to check how many rows was changed easily.