### PR TITLE
Optimize string decoding by removing the use of slice()

### DIFF
--- a/lib/packets/column_definition.js
+++ b/lib/packets/column_definition.js
@@ -45,8 +45,10 @@ class ColumnDefinition {
     this.characterSet = packet.readInt16();
     this.encoding = CharsetToEncoding[this.characterSet];
     this.name = StringParser.decode(
-      this._buf.slice(_nameStart, _nameStart + _nameLength),
-      this.encoding === 'binary' ? this._clientEncoding : this.encoding
+      this._buf,
+      this.encoding === 'binary' ? this._clientEncoding : this.encoding,
+      _nameStart, 
+      _nameStart + _nameLength
     );
     this.columnLength = packet.readInt32();
     this.columnType = packet.readInt8();
@@ -113,8 +115,10 @@ const addString = function(name) {
       const start = this[`_${name}Start`];
       const end = start + this[`_${name}Length`];
       const val = StringParser.decode(
-        this._buf.slice(start, end),
-        this.encoding === 'binary' ? this._clientEncoding : this.encoding
+        this._buf,
+        this.encoding === 'binary' ? this._clientEncoding : this.encoding,
+        start, 
+        end
       );
       
       Object.defineProperty(this, name, {

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -387,8 +387,10 @@ class Packet {
     // TODO: Use characterSetCode to get proper encoding
     // https://github.com/sidorares/node-mysql2/pull/374
     return StringParser.decode(
-      this.buffer.slice(this.offset - len, this.offset),
-      encoding
+      this.buffer,
+      encoding,
+      this.offset - len,
+      this.offset
     );
   }
 
@@ -407,7 +409,7 @@ class Packet {
       end = end + 1; // TODO: handle OOB check
     }
     this.offset = end + 1;
-    return StringParser.decode(this.buffer.slice(start, end), encoding);
+    return StringParser.decode(this.buffer, encoding, start, end);
   }
 
   // TODO reuse?
@@ -421,8 +423,10 @@ class Packet {
     }
     this.offset += len;
     return StringParser.decode(
-      this.buffer.slice(this.offset - len, this.offset),
-      encoding
+      this.buffer,
+      encoding,
+      this.offset - len, 
+      this.offset
     );
   }
 

--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -2,14 +2,14 @@
 
 const Iconv = require('iconv-lite');
 
-exports.decode = function(buffer, encoding, options) {
+exports.decode = function(buffer, encoding, start, end, options) {
   if (Buffer.isEncoding(encoding)) {
-    return buffer.toString(encoding);
+    return buffer.toString(encoding, start, end);
   }
 
   const decoder = Iconv.getDecoder(encoding, options || {});
 
-  const res = decoder.write(buffer);
+  const res = decoder.write(buffer.slice(start, end));
   const trail = decoder.end();
 
   return trail ? res + trail : res;


### PR DESCRIPTION
Previously, when we want to decode a string from a range in a Buffer, we
chose to slice it first and then decode it. However, Buffer.toString()
already does it internally already. In addition to that, toString()
seems to be more efficient when working with native buffer rather than
the wrapper FastBuffer created by slice()

From a simple test with large buffer and short string, it seems to yield
about 10-15% performance improvement