### PR TITLE
Add mysql_clear_password auth plugin

### DIFF
--- a/lib/auth_plugins/mysql_clear_password.js
+++ b/lib/auth_plugins/mysql_clear_password.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = pluginOptions => ({ connection, command }) => {
+  const password =
+    command.password || pluginOptions.password || connection.config.password;
+
+  return Buffer.from(`${password}\0`)
+};

--- a/lib/commands/auth_switch.js
+++ b/lib/commands/auth_switch.js
@@ -9,11 +9,13 @@ const Packets = require('../packets/index.js');
 const sha256_password = require('../auth_plugins/sha256_password');
 const caching_sha2_password = require('../auth_plugins/caching_sha2_password.js');
 const mysql_native_password = require('../auth_plugins/mysql_native_password.js');
+const mysql_clear_password = require('../auth_plugins/mysql_clear_password.js');
 
 const standardAuthPlugins = {
   sha256_password: sha256_password({}),
   caching_sha2_password: caching_sha2_password({}),
-  mysql_native_password: mysql_native_password({})
+  mysql_native_password: mysql_native_password({}),
+  mysql_clear_password: mysql_clear_password({})
 };
 
 function warnLegacyAuthSwitch() {


### PR DESCRIPTION
This seems like it comes up fairly frequently here (and has come up [on my repo too](https://github.com/beekeeper-studio/beekeeper-studio/issues/832), so figured I'd add this as a core supported plugin.

Not sure if you want to do this or not, but figured I'd open a PR just to see. Seems like a simple fix.

Let me know!