### PR TITLE
Optimize Query.row call

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -44,7 +44,8 @@ class Query extends Command {
     throw new Error(err);
   }
 
-  start(packet, connection) {
+  /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */
+  start(_packet, connection) {
     if (connection.config.debug) {
       // eslint-disable-next-line
       console.log('        Sending query command: %s', this.sql);
@@ -226,7 +227,8 @@ class Query extends Command {
     return this.row;
   }
 
-  row(packet) {
+  /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */
+  row(packet, _connection) { 
     if (packet.isEOF()) {
       const status = packet.eofStatusFlags();
       const moreResults = status & ServerStatus.SERVER_MORE_RESULTS_EXISTS;


### PR DESCRIPTION
Query.row was called with two arguments but the declaration has only one
argument. By changing it to two-argument function, it eliminates the
need for V8 to create an additional Argument Adapter Trampoline to
bridge between the caller and the callee. This optimization is mainly
for Node JS < 16.0.0 as V8 8.9 has already incorporated some
optimization for this case. (https://v8.dev/blog/adaptor-frame)

For query with a lot of rows, some benefit can be seen ~1%

