### PR TITLE
fix(json parsing): moved json parse to fix issue 1418

### DIFF
--- a/lib/parsers/text_parser.js
+++ b/lib/parsers/text_parser.js
@@ -60,7 +60,7 @@ function readCodeFor(type, charset, encodingExpr, config, options) {
       // Since for JSON columns mysql always returns charset 63 (BINARY),
       // we have to handle it according to JSON specs and use "utf8",
       // see https://github.com/sidorares/node-mysql2/issues/409
-      return 'JSON.parse(packet.readLengthCodedString("utf8"))';
+      return 'packet.readLengthCodedString("utf8")';
     default:
       if (charset === Charsets.BINARY) {
         return 'packet.readLengthCodedBuffer()';
@@ -103,6 +103,10 @@ function compile(fields, options, config) {
         config,
         options
       );
+      let readNext = `_this.${readCode}`
+      if (fields[i].columnType === Types.JSON) {
+        readNext = `JSON.parse(_this.${readCode})`
+      }
       parserFn(`this.wrap${i} = {
         type: ${helpers.srcEscape(typeNames[field.columnType])},
         length: ${helpers.srcEscape(field.columnLength)},
@@ -119,7 +123,7 @@ function compile(fields, options, config) {
           return _this.packet.parseGeometryValue();
         },
         readNext: function() {
-          return _this.${readCode};
+          return ${readNext};
         }
       };`);
     }


### PR DESCRIPTION
fixes the issue with JSON data types that was introduced on version v2.3.1 as reported on issue https://github.com/sidorares/node-mysql2/issues/1418, notice the issue was first reported with sequelize but JSON data type will likely fail with all enviroments.