### PR TITLE
Fix missing close type on Connection

### DIFF
--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -227,6 +227,8 @@ declare class Connection extends EventEmitter {
 
     destroy(): void;
 
+    close(): void;
+
     pause(): void;
 
     resume(): void;


### PR DESCRIPTION
The type of `close` is missing from Connection.