### PR TITLE
Hotfix: incorrect argument type in PoolCluster add method

### DIFF
--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -1,7 +1,7 @@
 
-import Connection = require('./Connection');
 import PoolConnection = require('./PoolConnection');
 import {EventEmitter} from 'events';
+import { PoolOptions } from './Pool';
 
 declare namespace PoolCluster {
 
@@ -37,8 +37,8 @@ declare class PoolCluster extends EventEmitter {
 
     config: PoolCluster.PoolClusterOptions;
 
-    add(config: PoolCluster.PoolClusterOptions): void;
-    add(group: string, config: PoolCluster.PoolClusterOptions): void;
+    add(config: PoolOptions): void;
+    add(group: string, config: PoolOptions): void;
 
     end(): void;
 

--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -1,7 +1,7 @@
 
 import PoolConnection = require('./PoolConnection');
 import {EventEmitter} from 'events';
-import { PoolOptions } from './Pool';
+import {PoolOptions} from './Pool';
 
 declare namespace PoolCluster {
 


### PR DESCRIPTION
`createPoolCluster` method takes `BasePoolCluster.PoolClusterOptions` [type](https://github.com/sidorares/node-mysql2/blob/07a429d9765dcbb24af4264654e973847236e0de/typings/mysql/lib/PoolCluster.d.ts#L8) as argument to create a [pool cluster](https://github.com/mysqljs/mysql#poolcluster-options).

When adding nodes to the PoolCluster using the `add` method this parameter type is not correct since we need to pass options to define where nodes are and how to authenticate against them (`host`, `port`, etc.). 
These options are defined in the `PoolOptions` [type](https://github.com/sidorares/node-mysql2/blob/master/typings/mysql/lib/Pool.d.ts#L10) which extends the `Connection.ConnectionOptions` class. 