### PR TITLE
Update how the ECONNRESET error is caught when connection already closing

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -174,7 +174,7 @@ class Connection extends EventEmitter {
       this.connectTimeout = null;
     }
     // Do not throw an error when a connection ends with a RST,ACK packet
-    if (err.errno === 'ECONNRESET' && this._closing) {
+    if (err.code === 'ECONNRESET' && this._closing) {
       return;
     }
     this._handleFatalError(err);

--- a/test/integration/connection/test-connection-reset-while-closing.js
+++ b/test/integration/connection/test-connection-reset-while-closing.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const assert = require('assert');
+const common = require('../../common')
+
+const error = new Error('read ECONNRESET');
+error.code = 'ECONNRESET'
+error.errno = -54
+error.syscall = 'read';
+
+const connection = common.createConnection();
+
+// Test that we ignore a ECONNRESET error if the connection
+// is already closing, we close and then emit the error
+connection.query(`select 1`, (err, rows) => {
+  assert.equal(rows[0]['1'], 1);
+  connection.close();
+  connection.stream.emit('error', error);
+});
+
+process.on('uncaughtException', err => {
+  assert.notEqual(err.code, 'ECONNRESET')
+});


### PR DESCRIPTION
Hello 👋 ,

I was having a problem similar to #766 while moving our MySQL database from AWS to Azure.  I would get a successful response AND an `ECONNRESET` error when querying the Azure database.

The fix for #766 didn't seem to be working for me. After digging in a bit, I saw that the error I was getting had a number for the `errno`  property and not the `ECONNRESET` string:
```
Error: read ECONNRESET
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:209:20)
    at TLSWrap.callbackTrampoline (internal/async_hooks.js:131:14) {
  errno: -54,
  code: 'ECONNRESET',
  syscall: 'read',
  fatal: true
}
```

It looks like the `errno` property changed in [node v13](https://nodejs.org/docs/latest-v13.x/api/errors.html#errors_error_errno)
> The error.errno property is a negative number which corresponds to the error code defined in libuv Error handling.

Previously, in [node v12](https://nodejs.org/docs/latest-v12.x/api/errors.html#errors_error_errno):
> The error.errno property is a number or a string. If it is a number, it is a negative value which corresponds to the error code defined in libuv Error handling. ...  In case of a string, it is the same as error.code.

I believe changing `err.errno` to `err.code` is backwards compatible given the description in the node v12 docs.  It also follows how this error is caught in [mysqljs/mysql](
https://github.com/mysqljs/mysql/blob/3430c513d6b0ca279fb7c79b210c9301e9315658/lib/protocol/sequences/Quit.js#L28-L32)

If I apply this change locally, our application behaves much better.  I attempted to add a test before opening this PR as there didn't seem to be coverage but was not successful.  Hopefully the provided documentation and explanation will be enough. 🤞 

For additional context, I ran a simple query using our sequelize setup and `NODE_DEBUG=net npm run console` to see the sequence of events.
<img width="500" alt="Screen Shot 2021-10-28 at 2 59 17 PM" src="https://user-images.githubusercontent.com/30075/139342188-a410cdb6-d79e-4cfc-b993-7deb3c2d03f2.png">


