### PR TITLE
bugfix: Do not set 'CONNECT_WITH_DB' flag when database is not set

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -187,7 +187,6 @@ class ConnectionConfig {
       'LONG_PASSWORD',
       'FOUND_ROWS',
       'LONG_FLAG',
-      'CONNECT_WITH_DB',
       'ODBC',
       'LOCAL_FILES',
       'IGNORE_SPACE',
@@ -202,6 +201,9 @@ class ConnectionConfig {
     ];
     if (options && options.multipleStatements) {
       defaultFlags.push('MULTI_STATEMENTS');
+    }
+    if (options && options.database) {
+      defaultFlags.push('CONNECT_WITH_DB');
     }
     defaultFlags.push('PLUGIN_AUTH');
     defaultFlags.push('PLUGIN_AUTH_LENENC_CLIENT_DATA');


### PR DESCRIPTION
Hello, I have a problem while connect to out MySQL database  when i **DO NOT** set the 'database' attribute.

when I set the 'debug' mode to true, I saw that the **connect with db** flag have send to the server in the handshake packet. 

I think if the `database` is not set, the `CONNECT_WITH_DB` flag should not be set, right?

---
The full trace as follow, focus on the **Sending handshake packet**.

```bash
Welcome to Node.js v14.17.6.
Type ".help" for more information.
> const mysql = require('mysql2')
undefined
> const _ = mysql.createConnection({host: '----', port: ----, user: '----', password: '----', debug: true}).connect()
Add command: ClientHandshake
undefined
>
>  raw: 0a382e302e31382d746d7973716c2d342e312e3100fb2a76000706037b49782f0400dff72102006fc615000000000000000000007e58515963015e7f3942600a006d7973716c5f6e61746976655f70617373776f726400
Trace
    at Connection.handlePacket (/app/node_modules/mysql2/lib/connection.js:427:17)
    at PacketParser.onPacket (/app/node_modules/mysql2/lib/connection.js:85:12)
    at PacketParser.executeStart (/app/node_modules/mysql2/lib/packet_parser.js:75:16)
    at Socket.<anonymous> (/app/node_modules/mysql2/lib/connection.js:92:25)
    at Socket.emit (events.js:400:28)
    at Socket.emit (domain.js:532:15)
    at addChunk (internal/streams/readable.js:290:12)
    at readableAddChunk (internal/streams/readable.js:265:9)
    at Socket.Readable.push (internal/streams/readable.js:204:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:188:23)
0 undefined ==> ClientHandshake#unknown name(0,,91)
Server hello packet: capability flags:3329226719=(long password, found rows, long flag, connect with db, no schema, odbc, local files, ignore space, protocol 41, interactive, ignore sigpipe, transactions, reserved, secure connection, multi statements, multi results, ps multi results, plugin auth, plugin auth lenenc client data, can handle expired passwords, ssl verify server cert, remember options)
Sending handshake packet: flags:11203535=(long password, found rows, long flag, connect with db, odbc, local files, ignore space, protocol 41, ignore sigpipe, transactions, reserved, secure connection, multi results, plugin auth, plugin auth lenenc client data, session track)
0 7744251 <== ClientHandshake#unknown name(1,,89)
0 7744251 <== 55000001cff3aa0000000000e000000000000000000000000000000000000000000000006c657373636f646500142bb6eb25634c7caa76edf8ebc226f8df8a35ae78006d7973716c5f6e61746976655f70617373776f726400
Uncaught:
<ref *1> Error: Connection lost: The server closed the connection.
    at Socket.<anonymous> (/app/node_modules/mysql2/lib/connection.js:101:31)
    at Socket.emit (events.js:400:28)
    at Socket.emit (domain.js:532:15)
```