### PR TITLE
[typings] Expose base connection on PoolConnection

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -5,7 +5,8 @@ import {
   FieldPacket,
   QueryOptions,
   ConnectionOptions,
-  PoolOptions
+  PoolOptions,
+  Connection as BaseConnection
 } from './index';
 
 import { EventEmitter } from 'events';
@@ -81,6 +82,7 @@ export interface Connection extends EventEmitter {
 }
 
 export interface PoolConnection extends Connection {
+  connection: BaseConnection;
   release(): void;
 }
 


### PR DESCRIPTION
This is a simple typings change in `promise.d.ts` to expose the underlying base `connection` on `PoolConnection`. 

The goal is to support row streaming as described here: https://github.com/mysqljs/mysql#streaming-query-rows. In our case, we use `mysql2/promise` to get a connection from the pool, but still need to stream the rows.