### PR TITLE
fix(typing & documentation): prepared statements usage

### DIFF
--- a/documentation/Prepared-Statements.md
+++ b/documentation/Prepared-Statements.md
@@ -13,8 +13,11 @@ connection.execute('select 1 + ? + ? as result', [5, 6], (err, rows) => {
 // close cached statement for 'select 1 + ? + ? as result'. noop if not in cache
 connection.unprepare('select 1 + ? + ? as result');
 ```
+Note that `connection.execute()` will cache the prepared statement for better performance, remove the cache with `connection.unprepare()` when you're done.
 
 ## Manual prepare / execute
+
+Manually prepared statements doesn't comes with LRU cache and SHOULD be closed using `statement.close()` instead of `connection.unprepare()`.
 
 ```js
 connection.prepare('select ? + ? as tests', (err, statement) => {
@@ -27,9 +30,9 @@ connection.prepare('select ? + ? as tests', (err, statement) => {
     // -> [ { tests: 3 } ]
   });
 
-  // do not use statement.close(), use connection.unprepare() to remove lru cache properly.
+  // don't use connection.unprepare(), it won't work!
   // note that there is no callback here. There is no statement close ack at protocol level.
-  connection.unprepare('select ? + ? as tests');
+  statement.close();
 });
 ```
 Note that you should not use statement after connection reset (`changeUser()` or disconnect). Statement scope is connection, you need to prepare statement for each new connection in order to use it.

--- a/documentation/Prepared-Statements.md
+++ b/documentation/Prepared-Statements.md
@@ -27,8 +27,9 @@ connection.prepare('select ? + ? as tests', (err, statement) => {
     // -> [ { tests: 3 } ]
   });
 
+  // do not use statement.close(), use connection.unprepare() to remove lru cache properly.
   // note that there is no callback here. There is no statement close ack at protocol level.
-  statement.close();
+  connection.unprepare('select ? + ? as tests');
 });
 ```
 Note that you should not use statement after connection reset (`changeUser()` or disconnect). Statement scope is connection, you need to prepare statement for each new connection in order to use it.

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -62,7 +62,8 @@ export interface Connection extends EventEmitter {
     values: any | any[] | { [param: string]: any }
   ): Promise<[T, FieldPacket[]]>;
 
-  unprepare(sql: string): void;
+  prepare(options: string | QueryOptions): Promise<PreparedStatementInfo>;
+  unprepare(sql: string | QueryOptions): void;
 
   end(options?: any): Promise<void>;
 
@@ -137,3 +138,11 @@ export function createConnection(
   config: ConnectionOptions
 ): Promise<Connection>;
 export function createPool(config: PoolOptions): Pool;
+
+export interface PreparedStatementInfo {
+  /**
+   * Close the prepared statement. This method DO NOT REMOVE the statement cache, and should only be used internally. Use {@link Connection.unprepare} instead when you've done with prepared statement.
+   */
+  close(): Promise<void>;
+  execute(parameters: any[]): Promise<[RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader, FieldPacket[]]>;
+}

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -140,9 +140,6 @@ export function createConnection(
 export function createPool(config: PoolOptions): Pool;
 
 export interface PreparedStatementInfo {
-  /**
-   * Close the prepared statement. This method DO NOT REMOVE the statement cache, and should only be used internally. Use {@link Connection.unprepare} instead when you've done with prepared statement.
-   */
   close(): Promise<void>;
   execute(parameters: any[]): Promise<[RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader, FieldPacket[]]>;
 }


### PR DESCRIPTION
## Issue
1. The prepared statement typings are missing
2. The documentation of prepare() usage are kinda wrong

Let's say that we have following code (assume we've fixed the typings):
```typescript
async function updateStuffs(updates: [string, string][]) {
    const statement = await conn.prepare('UPDATE Users SET A = ? WHERE B = ?');
    for (const update of updates) {
        await statement.execute(update);
    }
    statement.close(); // <-- Notice this line
}

await updateStuffs(...);
await updateStuffs(...); // Call multiple times
```

The first call to `updateStuffs` works fine, but later calls (assume the connection didn't get closed) produces the following error:
```
Error: Unknown prepared statement handler (#XXX) given to mysql_stmt_precheck
```

I've searched a bit and found this issue: https://github.com/sidorares/node-mysql2/issues/805, where @rallfo [found the exact cause of this](https://github.com/sidorares/node-mysql2/issues/805#issuecomment-447871245). And the fix is super simple:
```typescript
async function updateStuffs(updates: [string, string][]) {
    const statement = await conn.prepare('UPDATE Users SET A = ? WHERE B = ?');
    for (const update of updates) {
        await statement.execute(update);
    }
    conn.unprepare('UPDATE Users SET A = ? WHERE B = ?'); // <-- Fixed!
}

await updateStuffs(...);
await updateStuffs(...); // Works now
```

According to [current docs](https://github.com/sidorares/node-mysql2#using-prepared-statements), I believe there's a documentation error.

## Fix
1. Added typings of `Connection.prepare`, `Connection.unprepare` and `PreparedStatementInfo` to promised version, with a warning in `PreparedStatementInfo.close` jsdoc
2. Updated the documentation to use `unprepare` instead of `close`