### PR TITLE
Expose authPlugins to enable example from docs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -164,13 +164,6 @@ export interface Pool extends mysql.Connection {
   config: mysql.PoolOptions;
 }
 
-type authPlugins = (pluginMetadata: {
-  connection: Connection;
-  command: string;
-}) => (
-  pluginData: Buffer
-) => Promise<string> | string | Buffer | Promise<Buffer> | null;
-
 export interface ConnectionOptions extends mysql.ConnectionOptions {
   charsetNumber?: number;
   compress?: boolean;
@@ -191,7 +184,7 @@ export interface ConnectionOptions extends mysql.ConnectionOptions {
   queueLimit?: number;
   waitForConnections?: boolean;
   authPlugins?: {
-    [key: string]: authPlugins;
+    [key: string]: mysql.AuthPlugin;
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ exports.createServer = function(handler) {
 };
 
 exports.PoolConnection = require('./lib/pool_connection');
+exports.authPlugins = require('./lib/auth_plugins');
 exports.escape = SqlString.escape;
 exports.escapeId = SqlString.escapeId;
 exports.format = SqlString.format;

--- a/lib/auth_plugins/index.js
+++ b/lib/auth_plugins/index.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  caching_sha2_password: require('./caching_sha2_password'),
+  mysql_clear_password: require('./mysql_clear_password'),
+  mysql_native_password: require('./mysql_native_password'),
+  sha256_password: require('./sha256_password'),
+};

--- a/typings/mysql/index.d.ts
+++ b/typings/mysql/index.d.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 
 import BaseConnection = require('./lib/Connection');
 import {ConnectionOptions, SslOptions} from './lib/Connection';
@@ -44,3 +45,31 @@ export interface Pool extends BasePool {}
 export interface PoolCluster extends BasePoolCluster {}
 export interface Query extends BaseQuery {}
 export interface Prepare extends BasePrepare {}
+
+export type AuthPlugin = (pluginMetadata: {
+  connection: Connection;
+  command: string;
+}) => (
+  pluginData: Buffer
+) => Promise<string> | string | Buffer | Promise<Buffer> | null;
+
+type AuthPluginDefinition<T> = (pluginOptions?: T) => AuthPlugin
+
+export const authPlugins: {
+  caching_sha2_password: AuthPluginDefinition<{
+    overrideIsSecure?: boolean,
+    serverPublicKey?: crypto.RsaPublicKey | crypto.RsaPrivateKey | crypto.KeyLike,
+    jonServerPublicKey?: (data: Buffer) => void;
+  }>,
+  mysql_clear_password: AuthPluginDefinition<{
+    password?: string;
+  }>,
+  mysql_native_password: AuthPluginDefinition<{
+    password?: string;
+    passwordSha1?: string;
+  }>,
+  sha256_password: AuthPluginDefinition<{
+    serverPublicKey?: crypto.RsaPublicKey | crypto.RsaPrivateKey | crypto.KeyLike,
+    joinServerPublicKey?: (data: Buffer) => void;
+  }>,
+}


### PR DESCRIPTION
The example of using `authPlugins` given in https://github.com/sidorares/node-mysql2/blob/master/lib/auth_plugins/caching_sha2_password.md is not possible, as this module does not expose a top level `authPlugin` object. This PR adds that top-level object, as well as fully typing for the existing plugins.