### PR TITLE
Add minVersion for ssl option.

### DIFF
--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -221,6 +221,11 @@ declare namespace Connection {
          * You can also connect to a MySQL server without properly providing the appropriate CA to trust. You should not do this.
          */
         rejectUnauthorized?: boolean;
+      
+        /**
+         * Configure the minimum supported version of SSL, the default is TLSv1.2.
+         */
+        minVersion?: string;
     }
 }
 


### PR DESCRIPTION
I need to configure minVersion option, there is currently no option for this, I can only configure it via `as SslOptions as any` in  typescript, it's bad. so I created it.