### PR TITLE
Reference SecureContextOptions.

### DIFF
--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -6,6 +6,7 @@
 import Query = require('./protocol/sequences/Query');
 import {OkPacket, FieldPacket, RowDataPacket, ResultSetHeader} from './protocol/packets/index';
 import {EventEmitter} from 'events';
+import { SecureContextOptions } from 'tls';
 
 declare namespace Connection {
 
@@ -170,7 +171,7 @@ declare namespace Connection {
         /**
          * object with ssl parameters or a string containing name of ssl profile
          */
-        ssl?: string | SslOptions;
+        ssl?: string | SslOptions | SecureContextOptions;
 
 
         /**


### PR DESCRIPTION
Hi, this module defines the SSL Option, but I think a better way is to directly refer to the SecureContextOptions of the node tls module, because now this option is incomplete, for example, it does not support ca files in the form of buffers.
![image](https://user-images.githubusercontent.com/27798227/154198103-cfed09e1-df37-4404-91c0-36dec4aa4b02.png)
![image](https://user-images.githubusercontent.com/27798227/154198281-5b86564f-6814-4834-8afc-03abc78684cc.png)
