### PR TITLE
Fix precision bug in parseFloat affecting select(DOUBLE) in prepared statements

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -645,44 +645,17 @@ class Packet {
     return new Date(`${str}${timezone}`);
   }
 
-  parseFloat(len) {
-    if (len === null) {
-      return null;
-    }
-    let result = 0;
+  parseFloat(len)
+  {
+    const start = this.offset;
     const end = this.offset + len;
-    let factor = 1;
-    let pastDot = false;
-    let charCode = 0;
+    this.offset += len;
+
     if (len === 0) {
       return 0; // TODO: assert? exception?
     }
-    if (this.buffer[this.offset] === minus) {
-      this.offset++;
-      factor = -1;
-    }
-    if (this.buffer[this.offset] === plus) {
-      this.offset++; // just ignore
-    }
-    while (this.offset < end) {
-      charCode = this.buffer[this.offset];
-      if (charCode === dot) {
-        pastDot = true;
-        this.offset++;
-      } else if (charCode === exponent || charCode === exponentCapital) {
-        this.offset++;
-        const exponentValue = this.parseInt(end - this.offset);
-        return (result / factor) * Math.pow(10, exponentValue);
-      } else {
-        result *= 10;
-        result += this.buffer[this.offset] - 48;
-        this.offset++;
-        if (pastDot) {
-          factor = factor * 10;
-        }
-      }
-    }
-    return result / factor;
+    
+    return parseFloat(this.buffer.slice(start, end).toString('ascii'));
   }
 
   parseLengthCodedIntNoBigCheck() {

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -645,8 +645,7 @@ class Packet {
     return new Date(`${str}${timezone}`);
   }
 
-  parseFloat(len)
-  {
+  parseFloat(len) {
     const start = this.offset;
     const end = this.offset + len;
     this.offset += len;


### PR DESCRIPTION
This corrects Issue 1525 by falling back to the JS engine's own implementation of parseFloat.