### PR TITLE
Add taggedExecute helper

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -124,6 +124,13 @@ class PromiseConnection extends EventEmitter {
     });
   }
 
+  taggedExecute() {
+    return (strings, ...keys) => {
+      const statementQuery = strings.join('?');
+      return this.execute(statementQuery, keys).then(result => result[0])
+    }
+  }
+
   end() {
     return new this.Promise(resolve => {
       this.connection.end(resolve);
@@ -370,6 +377,13 @@ class PromisePool extends EventEmitter {
         corePool.execute(sql, done);
       }
     });
+  }
+
+  taggedExecute() {
+    return (strings, ...keys) => {
+      const statementQuery = strings.join('?');
+      return this.execute(statementQuery, keys).then(result => result[0]);
+    }
   }
 
   end() {


### PR DESCRIPTION
RFC at this stage, but I thing the feature was mentioned / requested few times in the past and looks like a safe and useful addition

At this stage I intentionally adding this to "real" prepared statements only ( AKA `.execute()` ) and also to promise wrapper only

examples:

```js
import mysql from 'mysql2/promise';
const pool = mysql.createPool({ user: 'root', password: 'test' });
const $ = pool.taggedExecute();
const input = 'test\" --';
const rows = await $`select ${input} as solution`;
```

```js
import mysql from 'mysql2/promise';
const connection = await mysql.createConnection({ user: 'root', password: 'test' });
const $ =connection.taggedExecute();
const input = 'test\" --';
const rows = await $`select ${input} as solution`;
```