### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -145,7 +145,7 @@ class ConnectionConfig {
       // "+" is a url encoded char for space so it
       // gets translated to space when giving a
       // connection string..
-      this.timezone = `+${this.timezone.substr(1)}`;
+      this.timezone = `+${this.timezone.slice(1)}`;
     }
     if (this.ssl) {
       if (typeof this.ssl !== 'object') {
@@ -253,7 +253,7 @@ class ConnectionConfig {
     const options = {
       host: parsedUrl.hostname,
       port: parsedUrl.port,
-      database: parsedUrl.pathname.substr(1),
+      database: parsedUrl.pathname.slice(1),
       user: parsedUrl.username,
       password: parsedUrl.password
     };


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.