### PR TITLE
fix uri connection unavaliable

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -250,12 +250,31 @@ class ConnectionConfig {
 
   static parseUrl(url) {
     const parsedUrl = new URL(url);
+    // reference https://nodejs.org/dist/latest/docs/api/url.html#urlpassword
+    // reference https://nodejs.org/dist/latest/docs/api/url.html#percent-encoding-in-urls
+    const userInfoSet = [
+      '\u002F',
+      '\u003A',
+      '\u003B',
+      '\u003D',
+      '\u0040',
+      '\u005B',
+      '\u005C',
+      '\u005D',
+      '\u005E',
+      '\u007C'
+    ].map(char => [encodeURIComponent(char), char]);
+    let { username, password } = parsedUrl;
+    userInfoSet.forEach(([encoded, raw]) => {
+      username = username.replace(encoded, raw);
+      password = password.replace(encoded, raw);
+    });
     const options = {
       host: parsedUrl.hostname,
       port: parsedUrl.port,
       database: parsedUrl.pathname.slice(1),
-      user: parsedUrl.username,
-      password: parsedUrl.password
+      user: username,
+      password: password
     };
     parsedUrl.searchParams.forEach((value, key) => {
       try {

--- a/test/unit/connection/test-connection_config.js
+++ b/test/unit/connection/test-connection_config.js
@@ -47,5 +47,5 @@ assert.strictEqual(
   ConnectionConfig.parseUrl(
     String.raw`fml://test:pass!@$%^&*()\word:@www.example.com/database`
   ).password,
-  'pass!%40$%%5E&*()%5Cword%3A'
+  'pass!@$%^&*()\\word:'
 );


### PR DESCRIPTION
when password contains some characters

e.g. `mysql://root:pa%ss=wo%rd@localhost/test`

#1384
