### PR TITLE
Fix Simplified Chinese document button parsing error in Github Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Windows Build][appveyor-image]][appveyor-url]
 [![License][license-image]][license-url]  
 
-[简体中文 | Simplified Chinese](./documentation_zh-cn/)
+[简体中文 Simplified Chinese](./documentation_zh-cn/)
 
 > MySQL client for Node.js with focus on performance. Supports prepared statements, non-utf8 encodings, binary log protocol, compression, ssl [much more](https://github.com/sidorares/node-mysql2/tree/master/documentation)
 


### PR DESCRIPTION
I found an issue with the Simplified Chinese documentation hyperlinks on Github Pages. It was originally a hyperlink, but was parsed into a table. It is caused by `|`, so i removed it.