### PR TITLE
Global crash repair

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -174,7 +174,7 @@ class Pool extends EventEmitter {
         });
       } catch (e) {
         conn.release();
-        throw e;
+        return cb(e);
       }
     });
   }


### PR DESCRIPTION
Without this fix node creates an uncatchable exception like

```
TypeError: Bind parameters must not contain undefined. To pass SQL NULL specify JS null
  at /var/repo/aerworx/api/node_modules/mysql2/lib/connection.js:592:17
  at Array.forEach (<anonymous>)
  at PoolConnection.execute (/var/repo/aerworx/api/node_modules/mysql2/lib/connection.js:584:22)
  at /var/repo/aerworx/api/node_modules/mysql2/lib/pool.js:172:14
  at /var/repo/aerworx/api/node_modules/mysql2/lib/pool.js:45:37
  at processTicksAndRejections (internal/process/task_queues.js:75:11)
```

Instead of allowing the calling function to handle this properly.
