### PR TITLE
fix: webpack projects no longer show warning for cardinal dependency

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,7 +25,9 @@ exports.srcEscape = srcEscape;
 let highlightFn;
 let cardinalRecommended = false;
 try {
-  highlightFn = require('cardinal').highlight;
+  // the purpose of this is to prevent projects using Webpack from displaying a warning during runtime if cardinal is not a dependency
+  const REQUIRE_TERMINATOR = '';
+  highlightFn = require(`cardinal${REQUIRE_TERMINATOR}`).highlight;
 } catch (err) {
   highlightFn = text => {
     if (!cardinalRecommended) {


### PR DESCRIPTION
I made a [comment here on a fix](https://github.com/sidorares/node-mysql2/issues/846#issuecomment-1172958633) for the cardinal optional dependency issue with Webpack.  I decided to go ahead with the PR as I won't have the configuration set up for too long on my end.

This fixes the issue for at least Webpack, I haven't checked with other bundlers.

I've added a video below to show how my project running Next12/Webpack5 would show the warning, and how after the fix the warning would be gone.  On the right is the node-mysql2 project, and the top left console is my project which has it npm linked so I can test changes.

https://user-images.githubusercontent.com/5728044/177018917-d3ff624a-37c8-4651-8de8-61316c762098.mov

