### PR TITLE
Implement releaseConnection in promise-wrapped Pools

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -125,6 +125,8 @@ export interface Pool extends EventEmitter {
   ): Promise<[T, FieldPacket[]]>;
 
   getConnection(): Promise<PoolConnection>;
+  releaseConnection(connection: PoolConnection): void;
+
   on(event: 'connection', listener: (connection: PoolConnection) => any): this;
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
   on(event: 'release', listener: (connection: PoolConnection) => any): this;

--- a/promise.js
+++ b/promise.js
@@ -336,6 +336,11 @@ class PromisePool extends EventEmitter {
     });
   }
 
+  releaseConnection(poolConnection) {
+    const coreConnection = poolConnection.connection;
+    this.pool.releaseConnection(coreConnection);
+  }
+
   query(sql, args) {
     const corePool = this.pool;
     const localErr = new Error();


### PR DESCRIPTION
This fixes a missing member of the promise-wrapped Pool object to avoid leak connections whenever you manually call PromisePool.getConnection()