### PR TITLE
Ability to use `createServer` in typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,8 @@ import {
 import * as mysql from './typings/mysql';
 export * from './typings/mysql';
 
+import Server from './lib/server.js';
+
 export interface Connection extends mysql.Connection {
   execute<
     T extends
@@ -199,3 +201,4 @@ export interface PoolOptions extends mysql.PoolOptions, ConnectionOptions {}
 export function createConnection(connectionUri: string): Connection;
 export function createConnection(config: ConnectionOptions): Connection;
 export function createPool(config: PoolOptions): Pool;
+export function createServer(handler: (conn: Connection) => any): Server;


### PR DESCRIPTION
When using typescript and/or ESM it's nice to be able to:
```js
import { createServer } from 'mysql2';
```

This PR hoists the `createServer` module.

Let me know if this is way is unacceptable and I can possibly define this within `typings/mysql/...`