### PR TITLE
Types, tests, and commands Oh my! 🌪️ 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,13 +9,6 @@
     "es6": true
   },
   "rules": {
-    "@typescript-eslint/typedef": [
-      "error",
-      {
-        "arrowParameter": true,
-        "variableDeclaration": true
-      }
-    ],
     "template-curly-spacing": ["error", "never"],
     "prefer-template": "error",
     "no-useless-call": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,13 @@
     "es6": true
   },
   "rules": {
+    "@typescript-eslint/typedef": [
+      "error",
+      {
+        "arrowParameter": true,
+        "variableDeclaration": true
+      }
+    ],
     "template-curly-spacing": ["error", "never"],
     "prefer-template": "error",
     "no-useless-call": "error",

--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ export interface Connection extends mysql.Connection {
   sequenceId: number;
 }
 
-export interface PoolConnection extends Connection {
+export interface PoolConnection extends mysql.PoolConnection, Connection {
   promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {
   Connection as PromiseConnection,
   Pool as PromisePool,
-  PoolConnection as PromisePoolConnection
+  PoolConnection as PromisePoolConnection,
 } from './promise';
 
 import * as mysql from './typings/mysql';
@@ -74,9 +74,16 @@ export interface Connection extends mysql.Connection {
   promise(promiseImpl?: PromiseConstructor): PromiseConnection;
   unprepare(sql: string): mysql.PrepareStatementInfo;
   prepare(sql: string, callback?: (err: mysql.QueryError | null, statement: mysql.PrepareStatementInfo) => any): mysql.Prepare;
+  serverHandshake(args: any): any;
+  writeOk(args?: mysql.OkPacketParams): void;
+  writeError(args?: mysql.ErrorPacketParams): void;
+  writeEof(warnings?: number, statusFlags?: number): void;
+  writeTextResult(rows?: Array<any>, columns?: Array<any>): void;
+  writePacket(packet: any): void;
+  sequenceId: number;
 }
 
-export interface PoolConnection extends mysql.PoolConnection, Connection {
+export interface PoolConnection extends Connection {
   promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
 }
 
@@ -153,6 +160,8 @@ export interface Pool extends mysql.Connection {
   promise(promiseImpl?: PromiseConstructor): PromisePool;
   unprepare(sql: string): mysql.PrepareStatementInfo;
   prepare(sql: string, callback?: (err: mysql.QueryError | null, statement: mysql.PrepareStatementInfo) => any): mysql.Prepare;
+
+  config: mysql.PoolOptions;
 }
 
 type authPlugins = (pluginMetadata: {

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -55,7 +55,8 @@ class Prepare extends Command {
     }
     const cmdPacket = new Packets.PrepareStatement(
       this.query,
-      connection.config.charsetNumber
+      connection.config.charsetNumber,
+      this.options.values
     );
     connection.writePacket(cmdPacket.toPacket(1));
     return Prepare.prototype.prepareHeader;

--- a/lib/commands/server_handshake.js
+++ b/lib/commands/server_handshake.js
@@ -71,7 +71,7 @@ class ServerHandshake extends Command {
 
   _isStatement(query, name) {
     const firstWord = query.split(' ')[0].toUpperCase();
-    return firstWord == name;
+    return firstWord === name;
   }
 
   dispatchCommands(packet, connection) {

--- a/lib/commands/server_handshake.js
+++ b/lib/commands/server_handshake.js
@@ -122,7 +122,13 @@ class ServerHandshake extends Command {
       case CommandCode.QUERY:
         if (connection.listeners('query').length) {
           const query = packet.readString(undefined, encoding);
-          connection.emit('query', query);
+          if (this._isStatement(query, 'PREPARE') || this._isStatement(query, 'SET')) {
+            connection.emit('stmt_prepare', query);
+          }
+          else if (this._isStatement(query, 'EXECUTE')) {
+            connection.emit('stmt_execute', null, null, null, null, query);
+          }
+          else connection.emit('query', query);
         } else {
           connection.writeError({
             code: Errors.HA_ERR_INTERNAL_ERROR,

--- a/lib/commands/server_handshake.js
+++ b/lib/commands/server_handshake.js
@@ -5,6 +5,7 @@ const Errors = require('../constants/errors.js');
 
 const Command = require('./command.js');
 const Packets = require('../packets/index.js');
+const Types = require('../constants/types');
 
 class ServerHandshake extends Command {
   constructor(args) {
@@ -75,6 +76,90 @@ class ServerHandshake extends Command {
     const encoding = connection.clientHelloReply.encoding;
     const commandCode = packet.readInt8();
     switch (commandCode) {
+      case CommandCode.STMT_PREPARE:
+        if (connection.listeners('stmt_prepare').length) {
+          const query = packet.readString(undefined, encoding);
+          connection.emit('stmt_prepare', query);
+        } else {
+          connection.writeError({
+            code: Errors.HA_ERR_INTERNAL_ERROR,
+            message:
+              'No query handler for prepared statements.'
+          });
+        }
+        break;
+      case CommandCode.STMT_EXECUTE:
+        if (connection.listeners('stmt_execute').length) {
+          console.log(packet)
+          const stmtId = packet.readInt32();
+          const flags = packet.readInt8();
+          const iterationCount = packet.readInt32();
+
+          let nullBitmaps = 0;
+          let i = packet.offset;
+          while (i < packet.end - 1) {
+            if((packet.buffer[i+1] == Types.VAR_STRING 
+              || packet.buffer[i+1] == Types.NULL 
+              || packet.buffer[i+1] == Types.DOUBLE
+              || packet.buffer[i+1] == Types.TINY
+              || packet.buffer[i+1] == Types.DATETIME
+              || packet.buffer[i+1] == Types.JSON) && packet.buffer[i] == 1 && packet.buffer[i+2] == 0) {
+                break
+            }
+            else {
+              nullBitmaps += packet.readInt8();
+            }
+            i++;
+          }
+
+          const types = [];
+
+          for(let i = packet.offset + 1; i < packet.end - 1; i++) {
+            if((packet.buffer[i] == Types.VAR_STRING 
+              || packet.buffer[i] == Types.NULL 
+              || packet.buffer[i] == Types.DOUBLE
+              || packet.buffer[i] == Types.TINY
+              || packet.buffer[i] == Types.DATETIME
+              || packet.buffer[i] == Types.JSON) && packet.buffer[i + 1] == 0) {
+                types.push(packet.buffer[i]);
+                packet.skip(2);
+            }
+          }
+
+          packet.skip(1);
+
+          const values = [];
+          for(let i = 0; i < types.length; i++) {
+            if(types[i] == Types.VAR_STRING) {
+              values.push(packet.readLengthCodedString(encoding))
+            }
+            else if(types[i] == Types.DOUBLE) {
+              values.push(packet.readDouble())
+            }
+            else if(types[i] == Types.TINY) {
+              values.push(packet.readInt8())
+            }
+            else if(types[i] == Types.DATETIME) {
+              values.push(packet.readDateTime())
+            }
+            else if(types[i] == Types.JSON) {
+              values.push(JSON.parse(packet.readLengthCodedString(encoding)))
+            }
+            if(types[i] == Types.NULL) {
+              values.push(null)
+            }
+          }
+          console.log(values)
+
+          connection.emit('stmt_execute', stmtId, flags, iterationCount, values);
+        } else {
+          connection.writeError({
+            code: Errors.HA_ERR_INTERNAL_ERROR,
+            message:
+              'No query handler for execute statements.'
+          });
+        }
+        break;
       case CommandCode.QUIT:
         if (connection.listeners('quit').length) {
           connection.emit('quit');

--- a/lib/commands/server_handshake.js
+++ b/lib/commands/server_handshake.js
@@ -5,7 +5,6 @@ const Errors = require('../constants/errors.js');
 
 const Command = require('./command.js');
 const Packets = require('../packets/index.js');
-const Types = require('../constants/types');
 
 class ServerHandshake extends Command {
   constructor(args) {
@@ -70,6 +69,11 @@ class ServerHandshake extends Command {
     return ServerHandshake.prototype.dispatchCommands;
   }
 
+  _isStatement(query, name) {
+    const firstWord = query.split(' ')[0].toUpperCase();
+    return firstWord == name;
+  }
+
   dispatchCommands(packet, connection) {
     // command from client to server
     let knownCommand = true;
@@ -90,67 +94,7 @@ class ServerHandshake extends Command {
         break;
       case CommandCode.STMT_EXECUTE:
         if (connection.listeners('stmt_execute').length) {
-          console.log(packet)
-          const stmtId = packet.readInt32();
-          const flags = packet.readInt8();
-          const iterationCount = packet.readInt32();
-
-          let nullBitmaps = 0;
-          let i = packet.offset;
-          while (i < packet.end - 1) {
-            if((packet.buffer[i+1] == Types.VAR_STRING 
-              || packet.buffer[i+1] == Types.NULL 
-              || packet.buffer[i+1] == Types.DOUBLE
-              || packet.buffer[i+1] == Types.TINY
-              || packet.buffer[i+1] == Types.DATETIME
-              || packet.buffer[i+1] == Types.JSON) && packet.buffer[i] == 1 && packet.buffer[i+2] == 0) {
-                break
-            }
-            else {
-              nullBitmaps += packet.readInt8();
-            }
-            i++;
-          }
-
-          const types = [];
-
-          for(let i = packet.offset + 1; i < packet.end - 1; i++) {
-            if((packet.buffer[i] == Types.VAR_STRING 
-              || packet.buffer[i] == Types.NULL 
-              || packet.buffer[i] == Types.DOUBLE
-              || packet.buffer[i] == Types.TINY
-              || packet.buffer[i] == Types.DATETIME
-              || packet.buffer[i] == Types.JSON) && packet.buffer[i + 1] == 0) {
-                types.push(packet.buffer[i]);
-                packet.skip(2);
-            }
-          }
-
-          packet.skip(1);
-
-          const values = [];
-          for(let i = 0; i < types.length; i++) {
-            if(types[i] == Types.VAR_STRING) {
-              values.push(packet.readLengthCodedString(encoding))
-            }
-            else if(types[i] == Types.DOUBLE) {
-              values.push(packet.readDouble())
-            }
-            else if(types[i] == Types.TINY) {
-              values.push(packet.readInt8())
-            }
-            else if(types[i] == Types.DATETIME) {
-              values.push(packet.readDateTime())
-            }
-            else if(types[i] == Types.JSON) {
-              values.push(JSON.parse(packet.readLengthCodedString(encoding)))
-            }
-            if(types[i] == Types.NULL) {
-              values.push(null)
-            }
-          }
-          console.log(values)
-
+          const { stmtId, flags, iterationCount, values } = Packets.Execute.fromPacket(packet, encoding);
           connection.emit('stmt_execute', stmtId, flags, iterationCount, values);
         } else {
           connection.writeError({

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -81,6 +81,69 @@ class Execute {
     this.timezone = timezone;
   }
 
+  static fromPacket(packet, encoding) {
+    const stmtId = packet.readInt32();
+    const flags = packet.readInt8();
+    const iterationCount = packet.readInt32();
+
+    let nullBitmaps = 0;
+    let i = packet.offset;
+    while (i < packet.end - 1) {
+      if((packet.buffer[i+1] == Types.VAR_STRING 
+        || packet.buffer[i+1] == Types.NULL 
+        || packet.buffer[i+1] == Types.DOUBLE
+        || packet.buffer[i+1] == Types.TINY
+        || packet.buffer[i+1] == Types.DATETIME
+        || packet.buffer[i+1] == Types.JSON) && packet.buffer[i] == 1 && packet.buffer[i+2] == 0) {
+          break
+      }
+      else {
+        nullBitmaps += packet.readInt8();
+      }
+      i++;
+    }
+
+    const types = [];
+
+    for(let i = packet.offset + 1; i < packet.end - 1; i++) {
+      if((packet.buffer[i] == Types.VAR_STRING 
+        || packet.buffer[i] == Types.NULL 
+        || packet.buffer[i] == Types.DOUBLE
+        || packet.buffer[i] == Types.TINY
+        || packet.buffer[i] == Types.DATETIME
+        || packet.buffer[i] == Types.JSON) && packet.buffer[i + 1] == 0) {
+          types.push(packet.buffer[i]);
+          packet.skip(2);
+      }
+    }
+
+    packet.skip(1);
+
+    const values = [];
+    for(let i = 0; i < types.length; i++) {
+      if(types[i] == Types.VAR_STRING) {
+        values.push(packet.readLengthCodedString(encoding))
+      }
+      else if(types[i] == Types.DOUBLE) {
+        values.push(packet.readDouble())
+      }
+      else if(types[i] == Types.TINY) {
+        values.push(packet.readInt8())
+      }
+      else if(types[i] == Types.DATETIME) {
+        values.push(packet.readDateTime())
+      }
+      else if(types[i] == Types.JSON) {
+        values.push(JSON.parse(packet.readLengthCodedString(encoding)))
+      }
+      if(types[i] == Types.NULL) {
+        values.push(null)
+      }
+    }
+
+    return { stmtId, flags, iterationCount, values };
+  }
+
   toPacket() {
     // TODO: don't try to calculate packet length in advance, allocate some big buffer in advance (header + 256 bytes?)
     // and copy + reallocate if not enough

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -89,16 +89,16 @@ class Execute {
     let nullBitmaps = 0;
     let i = packet.offset;
     while (i < packet.end - 1) {
-      if((packet.buffer[i+1] == Types.VAR_STRING 
-        || packet.buffer[i+1] == Types.NULL 
-        || packet.buffer[i+1] == Types.DOUBLE
-        || packet.buffer[i+1] == Types.TINY
-        || packet.buffer[i+1] == Types.DATETIME
-        || packet.buffer[i+1] == Types.JSON) && packet.buffer[i] == 1 && packet.buffer[i+2] == 0) {
-          break
+      if((packet.buffer[i+1] === Types.VAR_STRING 
+        || packet.buffer[i+1] === Types.NULL 
+        || packet.buffer[i+1] === Types.DOUBLE
+        || packet.buffer[i+1] === Types.TINY
+        || packet.buffer[i+1] === Types.DATETIME
+        || packet.buffer[i+1] === Types.JSON) && packet.buffer[i] === 1 && packet.buffer[i+2] === 0) {
+        break;
       }
       else {
-        nullBitmaps += packet.readInt8();
+        packet.readInt8()
       }
       i++;
     }
@@ -106,14 +106,14 @@ class Execute {
     const types = [];
 
     for(let i = packet.offset + 1; i < packet.end - 1; i++) {
-      if((packet.buffer[i] == Types.VAR_STRING 
-        || packet.buffer[i] == Types.NULL 
-        || packet.buffer[i] == Types.DOUBLE
-        || packet.buffer[i] == Types.TINY
-        || packet.buffer[i] == Types.DATETIME
-        || packet.buffer[i] == Types.JSON) && packet.buffer[i + 1] == 0) {
-          types.push(packet.buffer[i]);
-          packet.skip(2);
+      if((packet.buffer[i] === Types.VAR_STRING 
+        || packet.buffer[i] === Types.NULL 
+        || packet.buffer[i] === Types.DOUBLE
+        || packet.buffer[i] === Types.TINY
+        || packet.buffer[i] === Types.DATETIME
+        || packet.buffer[i] === Types.JSON) && packet.buffer[i + 1] === 0) {
+        types.push(packet.buffer[i]);
+        packet.skip(2);
       }
     }
 
@@ -121,22 +121,22 @@ class Execute {
 
     const values = [];
     for(let i = 0; i < types.length; i++) {
-      if(types[i] == Types.VAR_STRING) {
+      if(types[i] === Types.VAR_STRING) {
         values.push(packet.readLengthCodedString(encoding))
       }
-      else if(types[i] == Types.DOUBLE) {
+      else if(types[i] === Types.DOUBLE) {
         values.push(packet.readDouble())
       }
-      else if(types[i] == Types.TINY) {
+      else if(types[i] === Types.TINY) {
         values.push(packet.readInt8())
       }
-      else if(types[i] == Types.DATETIME) {
+      else if(types[i] === Types.DATETIME) {
         values.push(packet.readDateTime())
       }
-      else if(types[i] == Types.JSON) {
+      else if(types[i] === Types.JSON) {
         values.push(JSON.parse(packet.readLengthCodedString(encoding)))
       }
-      if(types[i] == Types.NULL) {
+      if(types[i] === Types.NULL) {
         values.push(null)
       }
     }

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -86,7 +86,6 @@ class Execute {
     const flags = packet.readInt8();
     const iterationCount = packet.readInt32();
 
-    let nullBitmaps = 0;
     let i = packet.offset;
     while (i < packet.end - 1) {
       if((packet.buffer[i+1] === Types.VAR_STRING 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "precommit": "lint-staged",
     "eslint-check": "eslint --print-config .eslintrc | eslint-config-prettier-check",
     "wait-port": "wait-on",
-    "type-test": "node ./node_modules/typescript/bin/tsc -p tests.json && mocha typings/test"
+    "type-test": "node ./node_modules/typescript/bin/tsc -p tests.json && mocha typings/test --timeout 10000"
   },
   "lint-staged": {
     "*.js": [

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -5,7 +5,8 @@ import {
   FieldPacket,
   QueryOptions,
   ConnectionOptions,
-  PoolOptions
+  PoolOptions,
+  Pool as CorePool
 } from './index';
 
 import { EventEmitter } from 'events';
@@ -131,6 +132,13 @@ export interface Pool extends EventEmitter {
   on(event: 'release', listener: (connection: PoolConnection) => any): this;
   on(event: 'enqueue', listener: () => any): this;
   end(): Promise<void>;
+
+  escape(value: any): string;
+  escapeId(value: string): string;
+  escapeId(values: string[]): string;
+  format(sql: string, values?: any | any[] | { [param: string]: any }): string;
+
+  pool: CorePool;
 }
 
 export function createConnection(connectionUri: string): Promise<Connection>;
@@ -143,3 +151,7 @@ export interface PreparedStatementInfo {
   close(): Promise<void>;
   execute(parameters: any[]): Promise<[RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader, FieldPacket[]]>;
 }
+
+export interface PromisePoolConnection extends Connection {
+  destroy(): any;
+} 

--- a/tests.json
+++ b/tests.json
@@ -6,7 +6,9 @@
 		"listEmittedFiles": false
 	},
 	"files": [
-		"typings/test/server.ts"
+		"typings/test/server.ts",
+		"typings/test/connection.ts",
+		"typings/test/pool.ts"
 	],
 	"typeRoots": [
 		"./typings",

--- a/typings/mysql/index.d.ts
+++ b/typings/mysql/index.d.ts
@@ -24,6 +24,7 @@ export function format(sql: string, values: any, stringifyObjects?: boolean, tim
 export function raw(sql: string): {
     toSqlString: () => string
 };
+export function createServer(handler: (conn: BaseConnection) => any): Server;
 
 export {
     ConnectionOptions,
@@ -43,5 +44,3 @@ export interface Pool extends BasePool {}
 export interface PoolCluster extends BasePoolCluster {}
 export interface Query extends BaseQuery {}
 export interface Prepare extends BasePrepare {}
-
-export function createServer(handler: (conn: BaseConnection) => any): Server;

--- a/typings/mysql/index.d.ts
+++ b/typings/mysql/index.d.ts
@@ -14,7 +14,7 @@ import Server = require('./lib/Server');
 
 export function createConnection(connectionUri: string): Connection;
 export function createConnection(config: BaseConnection.ConnectionOptions): Connection;
-export function createPool(config: BasePool.PoolOptions): Pool;
+export function createPool(config: BasePool.PoolOptions): BasePool;
 export function createPoolCluster(config?: BasePoolCluster.PoolClusterOptions): PoolCluster;
 export function escape(value: any): string;
 export function escapeId(value: any): string;

--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -271,6 +271,12 @@ declare class Connection extends EventEmitter {
     on(event: string, listener: Function): this;
 
     rollback(callback: (err: Query.QueryError | null) => void): void;
+
+    execute(sql: string, values: Array<any>, cb: (err: any, rows: Array<any>, fields: Array<any>) => any): any;
+
+    unprepare(sql: string): any;
+
+    serverHandshake(args: any): any;
 }
 
 export = Connection;

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -61,7 +61,7 @@ declare class Pool extends EventEmitter {
     on(event: string, listener: Function): this;
     on(event: 'connection', listener: (connection: PoolConnection) => any): this;
 
-    promise(promiseImpl?: any): any
+    promise(promiseImpl?: any): any;
 }
 
 export = Pool;

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -60,6 +60,8 @@ declare class Pool extends EventEmitter {
 
     on(event: string, listener: Function): this;
     on(event: 'connection', listener: (connection: PoolConnection) => any): this;
+
+    promise(promiseImpl?: any): any
 }
 
 export = Pool;

--- a/typings/mysql/lib/protocol/packets/index.d.ts
+++ b/typings/mysql/lib/protocol/packets/index.d.ts
@@ -4,11 +4,15 @@ import RowDataPacket = require('./RowDataPacket');
 import FieldPacket = require('./FieldPacket');
 import Field = require('./Field');
 import ResultSetHeader = require('./ResultSetHeader');
+import OkPacketParams = require('./params/OkPacketParams');
+import ErrorPacketParams = require('./params/ErrorPacketParams');
 
 export {
     OkPacket,
     RowDataPacket,
     FieldPacket,
     Field,
-    ResultSetHeader
+    ResultSetHeader,
+    OkPacketParams,
+    ErrorPacketParams
 };

--- a/typings/mysql/lib/protocol/packets/params/ErrorPacketParams.d.ts
+++ b/typings/mysql/lib/protocol/packets/params/ErrorPacketParams.d.ts
@@ -1,0 +1,6 @@
+declare interface ErrorPacketParams {
+  message?: string;
+  code?: number | string;
+}
+
+export = ErrorPacketParams;

--- a/typings/mysql/lib/protocol/packets/params/OkPacketParams.d.ts
+++ b/typings/mysql/lib/protocol/packets/params/OkPacketParams.d.ts
@@ -1,0 +1,9 @@
+declare interface OkPacketParams {
+  affectedRows?: number;
+  insertId?: number;
+  serverStatus?: number;
+  warningCount?: number;
+  message?: string;
+}
+
+export = OkPacketParams;

--- a/typings/test/connection.ts
+++ b/typings/test/connection.ts
@@ -1,0 +1,45 @@
+'use strict';
+
+// get the client
+import * as mysql from 'mysql2';
+import ConnectionType = require('../mysql/lib/Connection');
+import { expect } from 'chai'
+
+// create the connection to database
+const connection: ConnectionType = mysql.createConnection({
+  host: 'localhost',
+  user: 'root',
+  database: 'test'
+});
+
+describe('Connection', () => {
+    it('execute', (done) => {
+        connection.execute(
+        'select ?+1 as qqq, ? as rrr, ? as yyy',
+        [1, null, 3],
+        (err, rows, fields) => {
+            expect(rows[0].qqq).to.equal(2);
+            expect(err).to.be.null;
+
+            connection.execute(
+            'select ?+1 as qqq, ? as rrr, ? as yyy',
+            [3, null, 3],
+            (err, rows, fields) => {
+                expect(rows[0].qqq).to.equal(4);
+                expect(err).to.be.null;
+                connection.unprepare('select ?+1 as qqq, ? as rrr, ? as yyy');
+                connection.execute(
+                'select ?+1 as qqq, ? as rrr, ? as yyy',
+                [3, null, 3],
+                (err, rows, fields) => {
+                    expect(rows[0].qqq).to.equal(4);
+                    expect(err).to.be.null;
+                    done();
+                }
+                );
+            }
+            );
+        }
+        );
+    })
+})

--- a/typings/test/pool.ts
+++ b/typings/test/pool.ts
@@ -1,0 +1,38 @@
+'use strict';
+
+const portfinder = require('portfinder');
+import { createPool } from '../../index';
+import { Pool, PoolOptions, PromisePoolConnection } from '../../promise';
+import { expect } from 'chai'
+
+portfinder.getPort(async (err: any, port: number) => {
+	const pool: Pool = createPool({
+		user: 'test_user',
+		password: 'test',
+		database: 'test_database',
+		port: port,
+	} as PoolOptions).promise();
+
+	describe('Pool.promise()', () => {
+
+		it('exposes escape', () => {
+			expect(pool.escape(123)).to.equal('123')
+		})
+
+		it('exposes escapeId', () => {
+			expect(pool.escapeId('table name')).to.equal('`table name`')
+		})
+
+		it('exposes format', () => {
+			const params = ['table name', 'thing'];
+			expect(pool.format('SELECT a FROM ?? WHERE b = ?', params)).to.equal("SELECT a FROM `table name` WHERE b = 'thing'")
+		})
+
+		it('promise connection config', (done) => {
+			pool.getConnection().then((connection: PromisePoolConnection) => {
+				expect(connection.config.user).to.equal('test_user');
+				done();
+			}).catch(done);
+		})
+	});
+});


### PR DESCRIPTION
This PR invalidates #1584 (based on whether or not this PR can be merged). It adds the missing typings and aims to simplify things a bit.

It also takes care of added tests for the common types, fixes a packet issue related to `prepare`, and adds additional listeners for both `prepare` and `execute` when using the module as a MySQL proxy.

These changes are necessary in order to build a more complete (batteries included) MySQL proxy (in typescript) with support for prepared statements (using mysql2 module as a client along with other common clients).