### PR TITLE
Adds decodeURIComponent in ConnectionConfig#parseUrl

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -7,9 +7,9 @@
 
 'use strict';
 
-const { URL } = require('url');
 const ClientConstants = require('./constants/client');
 const Charsets = require('./constants/charsets');
+const { URL } = require('url');
 let SSLProfiles = null;
 
 const validOptions = {
@@ -249,13 +249,31 @@ class ConnectionConfig {
   }
 
   static parseUrl(url) {
-    const parsedUrl = new URL(url);
+    // First, split the url. Take the mysql:// part. The username is after that.
+    // Then, split at the : - usernames cannot contain a :
+    let user = url.split("mysql://")[1];
+    if (user) user = user.split(":")[0];
+    else throw new Error("Invalid connection string");
+
+    // Now, get the password. Remove the mysql://<USER>: part from the connection string,
+    // Continue until the last @ - that indicates the host is after it.
+    let password = url.substring(8 + user.length + 1);
+    if (password) {
+      const passwordParts = password.split("@");
+      password = passwordParts.splice(0, passwordParts.length-1).join("@");
+    } else throw new Error("Invalid connection string");
+
+    // Now, let node handle the rest of the url parsing (for the host, port and database)
+    // Also, remove the username and password and replace them with placeholders.
+    // This way, we do not get an error when the username or password contains special characters. 
+    const parsedUrl = new URL(url.replace(user, "_PLACEHOLDER_").replace(password, "_PLACEHOLDER_"));
+
     const options = {
       host: parsedUrl.hostname,
       port: parsedUrl.port,
       database: parsedUrl.pathname.slice(1),
-      user: decodeURIComponent(parsedUrl.username),
-      password: decodeURIComponent(parsedUrl.password)
+      user,
+      password
     };
     parsedUrl.searchParams.forEach((value, key) => {
       try {

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -254,8 +254,8 @@ class ConnectionConfig {
       host: parsedUrl.hostname,
       port: parsedUrl.port,
       database: parsedUrl.pathname.slice(1),
-      user: parsedUrl.username,
-      password: parsedUrl.password
+      user: decodeURIComponent(parsedUrl.username),
+      password: decodeURIComponent(parsedUrl.password)
     };
     parsedUrl.searchParams.forEach((value, key) => {
       try {


### PR DESCRIPTION
Currently, you cannot use special characters like `@` in usernames or passwords. This is because those characters are getting uri encoded by the URL nodejs package.

This PR adds `decodeURIComponent()` to `ConnectionConfig#parseUrl`, for `options.user` and `options.password`. This way, users can use special characters like `@` in usernames and passwords!

This also resolves #1384.
It also makes sure mysql2 can be used in nodejs apps hosted by pterodactyl with databases. When creating a database in pterodactyl, it generates a password automatically. That password also contains special characters, which make them useless when using mysql2.