### PR TITLE
renamed done to onResult

### DIFF
--- a/lib/commands/quit.js
+++ b/lib/commands/quit.js
@@ -7,7 +7,7 @@ const Packet = require('../packets/packet.js');
 class Quit extends Command {
   constructor(callback) {
     super();
-    this.done = callback;
+    this.onResult = callback;
   }
 
   start(packet, connection) {
@@ -18,8 +18,8 @@ class Quit extends Command {
       0,
       5
     );
-    if (this.done) {
-      this.done();
+    if (this.onResult) {
+      this.onResult();
     }
     connection.writePacket(quit);
     return null;

--- a/test/unit/commands/test-quit.js
+++ b/test/unit/commands/test-quit.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const assert = require('assert');
+const Quit = require('../../../lib/commands/quit');
+
+const testCallback = err => console.info( err.message );
+const testQuit = new Quit( testCallback );
+
+assert.strictEqual( testQuit.onResult, testCallback );


### PR DESCRIPTION
Resolves #1638 to the extent that it invokes callback, although the mysql2 error message is "Can't add new command when connection is in closed state" instead of the more specific mysqljs/mysql error message "Cannot enqueue Quit after invoking quit.".