### PR TITLE
ci: added workflow to integrate release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches:
+      - master
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: mysql2
+          changelog-path: 'Changelog.md'
+
+      - uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
+
+      - uses: actions/setup-node@v3
+        if: ${{ steps.release.outputs.release_created }}
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+        if: ${{ steps.release.outputs.release_created }}
+
+      - run: npm publish
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
refs https://github.com/sidorares/node-mysql2/issues/1631

- this workflow integrates Google's `release-please-action`, which seems like the best option for using release-please and GHA
- if a release was created, it'll also automatically publish to npm

---

@sidorares There is a [lot of configuration](https://github.com/google-github-actions/release-please-action#configuration) available for the Action. Might be worth giving that list a check before merging to ensure it is set up how you would like