### PR TITLE
highlighted known incompatibility with node-mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,9 @@ con.query({ sql: 'select 1 as foo, 2 as foo', rowsAsArray: true }, function(err,
 
 MySQL2 is mostly API compatible with [Node MySQL][node-mysql]. You should check their API documentation to see all available API options.
 
-If you find any incompatibility with [Node MySQL][node-mysql], Please report via Issue tracker. We will fix reported incompatibility on priority basis.
+One known incompatibility is that `sum` and `avg` results are returned as strings rather than numbers. This is deliberate to avoid loss of precision - see https://github.com/sidorares/node-mysql2/issues/935.
+
+If you find any other incompatibility with [Node MySQL][node-mysql], Please report via Issue tracker. We will fix reported incompatibility on priority basis.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ con.query({ sql: 'select 1 as foo, 2 as foo', rowsAsArray: true }, function(err,
 
 MySQL2 is mostly API compatible with [Node MySQL][node-mysql]. You should check their API documentation to see all available API options.
 
-One known incompatibility is that `sum` and `avg` results are returned as strings rather than numbers. This is deliberate to avoid loss of precision - see https://github.com/sidorares/node-mysql2/issues/935.
+One known incompatibility is that `DECIMAL` values are returned as strings whereas in [Node MySQL][node-mysql] they are returned as numbers. This includes the result of `SUM()` and `AVG()` functions when applied to `INTEGER` arguments. This is done deliberately to avoid loss of precision - see https://github.com/sidorares/node-mysql2/issues/935.
 
 If you find any other incompatibility with [Node MySQL][node-mysql], Please report via Issue tracker. We will fix reported incompatibility on priority basis.
 


### PR DESCRIPTION
I was caught by a quite subtle bug after upgrading from node-mysql to mysql2:

I was retrieving some `sum` values from the DB and then sorting by that field in JS code. because of the way I was processing the data after the sort, the sums were automatically converted from string to number. however, the sort itself was being done on the raw values.

In most of my tests the sum values were all 4 digits long so the output was identical when using mysql and mysql2. It was only when I happened to have a test where some of them where 3 digits long and some were 4 that the bug became apparent (999 would be sorted before 1000 when using mysql but "999" would be sorted after "1000" when using mysql2.

for this reason I think it warrants a warning on the main documentation page where it says it's "mostly compatible" to point out this potentially serious incompatibility.
