### PR TITLE
Fix issue #1334: warning "packets out of order" when handling ER_CLIENT_INTERACTION_TIMEOUT

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -407,19 +407,6 @@ class Connection extends EventEmitter {
       this._paused_packets.push(packet);
       return;
     }
-    if (packet) {
-      if (this.sequenceId !== packet.sequenceId) {
-        const err = new Error(
-          `Warning: got packets out of order. Expected ${this.sequenceId} but received ${packet.sequenceId}`
-        );
-        err.expected = this.sequenceId;
-        err.received = packet.sequenceId;
-        this.emit('warn', err); // REVIEW
-        // eslint-disable-next-line no-console
-        console.error(err.message);
-      }
-      this._bumpSequenceId(packet.numPackets);
-    }
     if (this.config.debug) {
       if (packet) {
         // eslint-disable-next-line no-console
@@ -457,6 +444,20 @@ class Connection extends EventEmitter {
       }
       this.close();
       return;
+    }
+    if (packet) {
+      // Note: when server closes connection due to inactivity, Err packet ER_CLIENT_INTERACTION_TIMEOUT from MySQL 8.0.24, sequenceId will be 0
+      if (this.sequenceId !== packet.sequenceId) {
+        const err = new Error(
+          `Warning: got packets out of order. Expected ${this.sequenceId} but received ${packet.sequenceId}`
+        );
+        err.expected = this.sequenceId;
+        err.received = packet.sequenceId;
+        this.emit('warn', err); // REVIEW
+        // eslint-disable-next-line no-console
+        console.error(err.message);
+      }
+      this._bumpSequenceId(packet.numPackets);
     }
     const done = this._command.execute(packet, this);
     if (done) {


### PR DESCRIPTION
To fix issue #1334

From MySQL 8.0.24, an [error packet with code 4031](https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_client_interaction_timeout) is sent to client before connection is closed. This packet has sequenceId == 0, thus the connection will issue a warning "packets out of order", which is not correct.

The changes here is just move the block checking & increasing sequence id to go after check for protocol error, since in case of error, we close the connection and return right away.