### PR TITLE
fix(connection): ensure pooled connections get released

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -96,6 +96,10 @@ class Connection extends EventEmitter {
       }
       this.packetParser.execute(data);
     });
+    this.stream.on('end', () => {
+      // emit the end event so that the pooled connection can close the connection
+      this.emit('end');
+    });
     this.stream.on('close', () => {
       // we need to set this flag everywhere where we want connection to close
       if (this._closing) {

--- a/test/integration/test-pool-end.js
+++ b/test/integration/test-pool-end.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { createPool } = require('../common.js');
+const assert = require('assert');
+
+const pool = createPool();
+
+pool.getConnection((err, conn) => {
+  assert.ifError(err);
+
+  assert(pool._allConnections.length === 1);
+  assert(pool._freeConnections.length === 0);
+
+  // emit the end event, so the connection gets removed from the pool
+  conn.stream.emit('end');
+
+  assert(pool._allConnections.length === 0);
+  assert(pool._freeConnections.length === 0);
+
+  // As the connection has not really ended we need to do this ourselves
+  conn.destroy();
+});


### PR DESCRIPTION
The PoolConnection is listening for the end event to be emitted to close the connection, but the connection is not listening to the underlying end event emitted by the net.Socket.

fixes #1664