### PR TITLE
Add node 18 to the build matrix

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
         mysql-version: ["mysql:8.0.18", "mysql:8.0.22", "mysql:5.7"]
         use-compression: [0]
         use-tls: [0]

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x]
         mysql-version: ['8.0']
         use-compression: [0, 1]
         use-tls: [0, 1]


### PR DESCRIPTION
Investigating issue in https://github.com/sidorares/node-mysql2/issues/1668 ( also node 18 been around for more than 6 months now and in LTS )