### PR TITLE
Fix wrong field type definition.

### DIFF
--- a/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
@@ -15,7 +15,8 @@ declare interface FieldPacket {
     orgTable: string;
     protocol41: boolean;
     table: string;
-    type: number;
+    columnType: number;
+    columnLength: number;
     zerofill: boolean;
 }
 


### PR DESCRIPTION
Hi, in the callback function of query, field does not have a type field, only columnType and columnLength.

![image](https://user-images.githubusercontent.com/27798227/200257933-f0a0663d-65ca-4ae7-9c01-1dfd9ee3b093.png)