### PR TITLE
Fix wrong execute method definition.

### DIFF
--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -272,7 +272,9 @@ declare class Connection extends EventEmitter {
 
     rollback(callback: (err: Query.QueryError | null) => void): void;
 
-    execute(sql: string, values: Array<any>, cb: (err: any, rows: Array<any>, fields: Array<any>) => any): any;
+    execute(sql: string, callback?: (err: any, rows: Array<any>, fields: Array<any>) => any): any;
+
+    execute(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: any, rows: Array<any>, fields: Array<any>) => any): any;
 
     unprepare(sql: string): any;
 


### PR DESCRIPTION
Hi, I updated to 3.0.0-rc.1, now the definition of execute parameter has become required, which is wrong.