### PR TITLE
Enable TCP_NODELAY flag

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -55,6 +55,10 @@ class Connection extends EventEmitter {
         // Enable keep-alive on the socket.  It's disabled by default, but the
         // user can enable it and supply an initial delay.
         this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
+
+        // Enable TCP_NODELAY flag. This is needed so that the network packets
+        // are sent immediately to the server
+        this.stream.setNoDelay(true);
       }
       // if stream is a function, treat it as "stream agent / factory"
     } else if (typeof opts.config.stream === 'function')  {


### PR DESCRIPTION
This fixes the massive slowness I experienced on some machines (Amazon Linux 2 on AWS EC2), where each query was taking ~60ms. Running a script that executes 100 UPDATE queries in sequence takes ~6.5s before patch, and 0.3s after patch.

And somewhat less interestingly.. the setting doesn't make much difference if I execute the script on my local PC. I'm guessing there are settings at the OS level that can amplify this slowness.

I don't know much about the TCP_NODELAY flag, only that it should always be set for time sensitive network communications (like for a MySQL client). And forgetting to set this flag seems to be a common issue, for example this blog post has a nice explanation: https://vorner.github.io/2020/11/06/40-ms-bug.html

