### PR TITLE
Fix backpressure when using TLS

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -382,9 +382,7 @@ class Connection extends EventEmitter {
     secureSocket.on('data', data => {
       this.packetParser.execute(data);
     });
-    this.write = buffer => {
-      secureSocket.write(buffer);
-    };
+    this.stream = secureSocket;
     // start TLS communications
     secureSocket._start();
   }


### PR DESCRIPTION
Rebase of PR #1559 which GitHub automatically closed :(

This PR fixes two related issues when using TLS:

Using LOAD DATA LOCAL, backpressure is not respected, causing out of memory errors if the data stream supplied by infileStreamFactory is faster than the upload to the database server
Using connection.query().stream(), backpressure is not respected if data is returned by the server faster than the client is handling it
Both issues result from the fact that the backpressure mechanisms of pause(), resume(), emit('pause'), on('drain'), etc., were being applied to the original stream object, which have no effect after that stream has been wrapped inside a TLSSocket, according to my experiments. This can lead to an out of memory error if the buffer grows too large.

See: backpressure not handled https://github.com/sidorares/node-mysql2/issues/1134
Prior fix, which did not cover TLS, because the startTLS function was replacing the write method: handle backpressure when loading data from file https://github.com/sidorares/node-mysql2/pull/1167

Note: There is still the legacy TLS support at the bottom of connection.js which I did not touch. The docs state TLSSocket was added in Node.js v0.11.4 which was released in 2013. It is so old I did not feel like looking into it.