### PR TITLE
Update link to JS number object specification

### DIFF
--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -130,7 +130,7 @@ declare namespace Connection {
          * Enabling both supportBigNumbers and bigNumberStrings forces big numbers (BIGINT and DECIMAL columns) to be
          * always returned as JavaScript String objects (Default: false). Enabling supportBigNumbers but leaving
          * bigNumberStrings disabled will return big numbers as String objects only when they cannot be accurately
-         * represented with [JavaScript Number objects] (http://ecma262-5.com/ELS5_HTML.htm#Section_8.5)
+         * represented with [JavaScript Number objects](https://262.ecma-international.org/5.1/#sec-8.5)
          * (which happens when they exceed the [-2^53, +2^53] range), otherwise they will be returned as Number objects.
          * This option is ignored if supportBigNumbers is disabled.
          */


### PR DESCRIPTION
Closes #1765

Thought about linking to a newer ECMAScript spec, but this part of the spec hasn't really change to my knowledge so fine I think to link to an old one.

In case want to use the latest, the link would be https://262.ecma-international.org/13.0/#sec-ecmascript-language-types-number-type.