### PR TITLE
Do not include typings/test in built package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "files": [
     "lib",
-    "typings",
+    "typings/mysql",
     "index.js",
     "index.d.ts",
     "promise.js",


### PR DESCRIPTION
PR makes it so the `typings/test` directory is not included in the built package that goes to NPM. Right now, they do, and contributes 3 files at ~2.7kb to the final output. See https://unpkg.com/browse/mysql2@3.0.0-rc.1/typings/test/ for example of it.