### PR TITLE
Simplify query and execute type definitions

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -26,41 +26,15 @@ export interface Connection extends EventEmitter {
   changeUser(options: ConnectionOptions): Promise<void>;
 
   query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any }
   ): Promise<[T, FieldPacket[]]>;
 
   execute<
     T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
   >(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any }
   ): Promise<[T, FieldPacket[]]>;
 
   prepare(options: string | QueryOptions): Promise<PreparedStatementInfo>;
@@ -89,41 +63,15 @@ export interface PoolConnection extends Connection {
 
 export interface Pool extends EventEmitter {
   query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any }
   ): Promise<[T, FieldPacket[]]>;
 
   execute<
     T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
   >(
-    sql: string
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    sql: string,
-    values: any | any[] | { [param: string]: any }
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions
-  ): Promise<[T, FieldPacket[]]>;
-  execute<
-    T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader
-  >(
-    options: QueryOptions,
-    values: any | any[] | { [param: string]: any }
+    sql_or_options: string | QueryOptions,
+    values?: any | any[] | { [param: string]: any }
   ): Promise<[T, FieldPacket[]]>;
 
   getConnection(): Promise<PoolConnection>;
@@ -155,4 +103,4 @@ export interface PreparedStatementInfo {
 
 export interface PromisePoolConnection extends Connection {
   destroy(): any;
-} 
+}

--- a/tests.json
+++ b/tests.json
@@ -8,7 +8,8 @@
 	"files": [
 		"typings/test/server.ts",
 		"typings/test/connection.ts",
-		"typings/test/pool.ts"
+		"typings/test/pool.ts",
+		"typings/test/promise.ts"
 	],
 	"typeRoots": [
 		"./typings",
@@ -18,4 +19,4 @@
 		"./node_modules",
 		"./typings"
 	]
-} 
+}

--- a/typings/test/promise.ts
+++ b/typings/test/promise.ts
@@ -1,0 +1,38 @@
+import type { Connection } from '../../promise'
+import * as mysql from '../../promise'
+import { expect } from 'chai'
+
+describe('promise Connection', () => {
+  it('execute', async(done) => {
+    // create the connection to database
+    const connection: Connection = await mysql.createConnection({
+      host: 'localhost',
+      user: 'root',
+      database: 'test'
+    });
+
+    const [ rows ] = await connection.execute('select 1 as qqq');
+
+    expect(
+      0 in rows
+      && 'qqq' in rows[0]
+      && rows[0].qqq
+    ).to.equal(1);
+
+
+    // Regression test for #1329
+    const myCustomExecute = (
+      ...args: Parameters<Connection['execute']>
+    ) => connection.execute(...args);
+
+    const [ rows2 ] = await myCustomExecute('select 1 as qqq');
+
+    expect(
+      0 in rows2
+      && 'qqq' in rows2[0]
+      && rows2[0].qqq
+    ).to.equal(1);
+
+    done();
+  })
+})


### PR DESCRIPTION
Fixes #1329.

Some type declarations were using overloading which was causing me problems.  The equivalent types can be declared using [Optional Parameters](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#use-optional-parameters) and [Union Types](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#use-union-types) which is the recommended method according to the TypeScript Do's and Don'ts (see links).