### PR TITLE
Fix a TypeScript test

### DIFF
--- a/typings/test/connection.ts
+++ b/typings/test/connection.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 // get the client
-import * as mysql from 'mysql2';
+import * as mysql from '../../index';
 import ConnectionType = require('../mysql/lib/Connection');
 import { expect } from 'chai'
 


### PR DESCRIPTION
When I ran `npm run type-test`, I got a few error messages.  One of the messages was:

> Cannot find module 'mysql2' or its corresponding type declarations.

This PR fixes that error.


<details>
<summary>There are a few more typescript errors, but I don't know the right way to fix those.</summary>


```sh
npm run type-test
> mysql2@3.0.1 type-test
> node ./node_modules/typescript/bin/tsc -p tests.json && mocha typings/test --timeout 10000

index.d.ts:86:18 - error TS2320: Interface 'PoolConnection' cannot simultaneously extend types 'PoolConnection' and 'Connection'.
  Named property 'execute' of types 'PoolConnection' and 'Connection' are not identical.

86 export interface PoolConnection extends mysql.PoolConnection, Connection {
                    ~~~~~~~~~~~~~~

index.d.ts:86:18 - error TS2320: Interface 'PoolConnection' cannot simultaneously extend types 'PoolConnection' and 'Connection'.
  Named property 'unprepare' of types 'PoolConnection' and 'Connection' are not identical.

86 export interface PoolConnection extends mysql.PoolConnection, Connection {
                    ~~~~~~~~~~~~~~

Found 2 errors in the same file, starting at: index.d.ts:86
```

</details>