### PR TITLE
Add default connection attributes

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -10,6 +10,7 @@
 const { URL } = require('url');
 const ClientConstants = require('./constants/client');
 const Charsets = require('./constants/charsets');
+const { version } = require('../package.json')
 let SSLProfiles = null;
 
 const validOptions = {
@@ -169,7 +170,13 @@ class ConnectionConfig {
       ConnectionConfig.getDefaultFlags(options),
       options.flags || ''
     );
-    this.connectAttributes = options.connectAttributes;
+    // Default connection attributes
+    // https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html
+    const defaultConnectAttributes =  {
+      _client_name: 'Node-MySQL-2',
+      _client_version: version
+    };
+    this.connectAttributes = { ...defaultConnectAttributes, ...(options.connectAttributes || {})};
     this.maxPreparedStatements = options.maxPreparedStatements || 16000;
   }
 

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -224,7 +224,8 @@ class ConnectionConfig {
       'SECURE_CONNECTION',
       'MULTI_RESULTS',
       'TRANSACTIONS',
-      'SESSION_TRACK'
+      'SESSION_TRACK',
+      'CONNECT_ATTRS'
     ];
     if (options && options.multipleStatements) {
       defaultFlags.push('MULTI_STATEMENTS');
@@ -232,9 +233,6 @@ class ConnectionConfig {
     defaultFlags.push('PLUGIN_AUTH');
     defaultFlags.push('PLUGIN_AUTH_LENENC_CLIENT_DATA');
 
-    if (options && options.connectAttributes) {
-      defaultFlags.push('CONNECT_ATTRS');
-    }
     return defaultFlags;
   }
 

--- a/lib/packets/handshake_response.js
+++ b/lib/packets/handshake_response.js
@@ -3,6 +3,7 @@
 const ClientConstants = require('../constants/client.js');
 const CharsetToEncoding = require('../constants/charset_encodings.js');
 const Packet = require('../packets/packet.js');
+const { version } = require('../../package.json')
 
 const auth41 = require('../auth_41.js');
 
@@ -66,7 +67,14 @@ class HandshakeResponse {
       packet.writeNullTerminatedString('mysql_native_password', 'latin1');
     }
     if (isSet('CONNECT_ATTRS')) {
+      // User-defined attributes
       const connectAttributes = this.connectAttributes || {};
+
+      // https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html
+      // Default attributes
+      connectAttributes['_client_name'] = 'Node-MySQL-2';
+      connectAttributes['_client_version'] = version;
+
       const attrNames = Object.keys(connectAttributes);
       let keysLength = 0;
       for (k = 0; k < attrNames.length; ++k) {

--- a/lib/packets/handshake_response.js
+++ b/lib/packets/handshake_response.js
@@ -3,7 +3,6 @@
 const ClientConstants = require('../constants/client.js');
 const CharsetToEncoding = require('../constants/charset_encodings.js');
 const Packet = require('../packets/packet.js');
-const { version } = require('../../package.json')
 
 const auth41 = require('../auth_41.js');
 
@@ -67,14 +66,7 @@ class HandshakeResponse {
       packet.writeNullTerminatedString('mysql_native_password', 'latin1');
     }
     if (isSet('CONNECT_ATTRS')) {
-      // User-defined attributes
       const connectAttributes = this.connectAttributes || {};
-
-      // https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html
-      // Default attributes
-      connectAttributes['_client_name'] = 'Node-MySQL-2';
-      connectAttributes['_client_version'] = version;
-
       const attrNames = Object.keys(connectAttributes);
       let keysLength = 0;
       for (k = 0; k < attrNames.length; ++k) {

--- a/test/integration/test-auth-switch.js
+++ b/test/integration/test-auth-switch.js
@@ -3,10 +3,17 @@
 const mysql = require('../../index.js');
 const Command = require('../../lib/commands/command.js');
 const Packets = require('../../lib/packets/index.js');
+const {version} = require('../../package.json')
 
 const assert = require('assert');
 
-const connectAttributes = { foo: 'bar', baz: 'foo' };
+const connectAttributes = {foo: 'bar', baz: 'foo'};
+
+const defaultConnectAttributes = {
+  _client_name: 'Node-MySQL-2',
+  _client_version: version
+};
+
 let count = 0;
 
 class TestAuthSwitchHandshake extends Command {
@@ -36,7 +43,8 @@ class TestAuthSwitchHandshake extends Command {
     assert.equal(clientHelloReply.user, 'test_user');
     assert.equal(clientHelloReply.database, 'test_database');
     assert.equal(clientHelloReply.authPluginName, 'mysql_native_password');
-    assert.deepEqual(clientHelloReply.connectAttributes, connectAttributes);
+    assert.deepEqual(clientHelloReply.connectAttributes,
+      {...connectAttributes, ...defaultConnectAttributes});
     const asr = new Packets.AuthSwitchRequest(this.args);
     connection.writePacket(asr.toPacket());
     return TestAuthSwitchHandshake.prototype.readClientAuthSwitchResponse;


### PR DESCRIPTION
MySQL connectors have some [Available Connection Attributes](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-connection-attribute-tables.html).

I add the following built-in connection attributes to Node-MySQL-2.
```
{
  '_client_name': 'Node-MySQL-2',
  '_client_version': version
}
```

These attributes will help users distinguish which driver the connection comes from.