### PR TITLE
Updated `lru-cache` reset method to clear

### DIFF
--- a/lib/commands/change_user.js
+++ b/lib/commands/change_user.js
@@ -44,8 +44,8 @@ class ChangeUser extends Command {
     this.currentConfig.database = this.database;
     this.currentConfig.charsetNumber = this.charsetNumber;
     connection.clientEncoding = CharsetToEncoding[this.charsetNumber];
-    // reset prepared statements cache as all statements become invalid after changeUser
-    connection._statements.reset();
+    // clear prepared statements cache as all statements become invalid after changeUser
+    connection._statements.clear();
     connection.writePacket(newPacket.toPacket());
     // check if the server supports multi-factor authentication
     const multiFactorAuthentication = connection.serverCapabilityFlags & ClientConstants.MULTI_FACTOR_AUTHENTICATION;


### PR DESCRIPTION
refs https://github.com/isaacs/node-lru-cache/blob/main/CHANGELOG.md#v7---2022-02

- the `.reset` method became `.clear` in `lru-cache` v7 but the old method was maintained for backward compatibility and given a deprecation warning
- without this change, changing user in `node-mysql2` gives the
  following warning: `(node:27579) [LRU_CACHE_METHOD_reset] DeprecationWarning: The reset method is deprecated. Please use cache.clear() instead.`