### PR TITLE
feat: maxVersion ssl option to tls.createSecureContext

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -347,7 +347,8 @@ class Connection extends EventEmitter {
       ciphers: this.config.ssl.ciphers,
       key: this.config.ssl.key,
       passphrase: this.config.ssl.passphrase,
-      minVersion: this.config.ssl.minVersion
+      minVersion: this.config.ssl.minVersion,
+      maxVersion: this.config.ssl.maxVersion
     });
     const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
     const verifyIdentity = this.config.ssl.verifyIdentity;

--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -229,6 +229,11 @@ declare namespace Connection {
         minVersion?: string;
 
         /**
+	 * Configure the maximum supported version of SSL, the default is TLSv1.3.
+         */
+        maxVersion?: string; 
+
+        /**
          * You can verify the server name identity presented on the server certificate when connecting to a MySQL server.
          * You should enable this but it is disabled by default right now for backwards compatibility.
          */


### PR DESCRIPTION
As discussed here: https://github.com/sidorares/node-mysql2/issues/1870