### PR TITLE
fix: PoolConnection redundancy when extending Connection interface in TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -83,7 +83,7 @@ export interface Connection extends mysql.Connection {
   sequenceId: number;
 }
 
-export interface PoolConnection extends mysql.PoolConnection, Connection {
+export interface PoolConnection extends mysql.PoolConnection {
   promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
 }
 


### PR DESCRIPTION
As I mentioned in [#1722](https://github.com/sidorares/node-mysql2/issues/1722#issuecomment-1500928005) issue:

Once the [`PoolConnection.d.ts`](https://github.com/sidorares/node-mysql2/blob/master/typings/mysql/lib/PoolConnection.d.ts#L4) has already declared extending the `Connection` interface:

```ts
declare class PoolConnection extends Connection {
    connection: Connection;
    release(): void;
}
```

Then it doesn't needs to re extend the `Connection` in [`index.d.ts` `#86`](https://github.com/sidorares/node-mysql2/blob/master/index.d.ts#L86) like:
```ts
export interface PoolConnection extends mysql.PoolConnection, Connection {
  promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
}
```

> Causing the error:
> ```
> [...] Interface 'PoolConnection' cannot simultaneously extend types 'PoolConnection' and 'Connection'.
>   Named property 'execute' of types 'PoolConnection' and 'Connection' are not identical.
> 
> 86 export interface PoolConnection extends mysql.PoolConnection, Connection {
>                     ~~~~~~~~~~~~~~
> ```

<hr />

So, I just removed the `Connection` from extends in [`index.d.ts` `#86`](https://github.com/sidorares/node-mysql2/blob/master/index.d.ts#L86) and it will work:
```ts
export interface PoolConnection extends mysql.PoolConnection {
  promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
}
```

<hr />

As you recommended in [#1722](https://github.com/sidorares/node-mysql2/issues/1722#issuecomment-1433942315):
For this `PR`, I cloned the `master` and tested it again in a real use (locally), it works perfectly.

<hr />

Extra tests:

- ```json
  "skipLibCheck": false,
  ```

- ```json
  "skipLibCheck": true,
  ```

- Also, without `skipLibCheck`.