### PR TITLE
fix: ConnectionOptions conflict between mysql and mysql/promise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 import {
   Connection as PromiseConnection,
-  Pool as PromisePool,
   PoolConnection as PromisePoolConnection,
 } from './promise';
 
@@ -71,7 +70,6 @@ export interface Connection extends mysql.Connection {
     ) => any
   ): mysql.Query;
   ping(callback?: (err: mysql.QueryError | null) => any): void;
-  promise(promiseImpl?: PromiseConstructor): PromiseConnection;
   unprepare(sql: string): mysql.PrepareStatementInfo;
   prepare(sql: string, callback?: (err: mysql.QueryError | null, statement: mysql.PrepareStatementInfo) => any): mysql.Prepare;
   serverHandshake(args: any): any;
@@ -157,7 +155,6 @@ export interface Pool extends mysql.Connection {
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
   on(event: 'release', listener: (connection: PoolConnection) => any): this;
   on(event: 'enqueue', listener: () => any): this;
-  promise(promiseImpl?: PromiseConstructor): PromisePool;
   unprepare(sql: string): mysql.PrepareStatementInfo;
   prepare(sql: string, callback?: (err: mysql.QueryError | null, statement: mysql.PrepareStatementInfo) => any): mysql.Prepare;
 

--- a/typings/mysql/index.d.ts
+++ b/typings/mysql/index.d.ts
@@ -12,6 +12,7 @@ import BasePrepare = require('./lib/protocol/sequences/Prepare');
 import {QueryOptions, StreamOptions, QueryError} from './lib/protocol/sequences/Query';
 import {PrepareStatementInfo} from './lib/protocol/sequences/Prepare';
 import Server = require('./lib/Server');
+import { Pool as PromisePool } from '../../promise';
 
 export function createConnection(connectionUri: string): Connection;
 export function createConnection(config: BaseConnection.ConnectionOptions): Connection;
@@ -39,7 +40,9 @@ export {
 export * from './lib/protocol/packets/index';
 
 // Expose class interfaces
-export interface Connection extends BaseConnection {}
+export interface Connection extends BaseConnection {
+  promise(promiseImpl?: PromiseConstructor): PromisePool;
+}
 export interface PoolConnection extends BasePoolConnection {}
 export interface Pool extends BasePool {}
 export interface PoolCluster extends BasePoolCluster {}

--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -290,8 +290,6 @@ declare class Connection extends EventEmitter {
     unprepare(sql: string): any;
 
     serverHandshake(args: any): any;
-
-    promise(): Promise<Connection>;
 }
 
 export = Connection;


### PR DESCRIPTION
@sidorares, this fix is about the `.promise()` option in issue #1936.

I see that in `3.2.1` release you merged the `PR` #1949, but in this `PR` the `Connection` is changed "globally", however in `mysql/promise` types it's causing 3 conflicts because it don't needs the `promise` option, so I rollbacked it before this fix.

<hr />

### In this fix:

1. Removed all the `PR` #1949 changes (sorry @bluefeet).
2. Removed all the `promise` options from "global" `Connection` Interface
3. Imported and added the `promise` option only in `mysql` ([typings/mysql/index.d.ts](https://github.com/sidorares/node-mysql2/blob/master/typings/mysql/index.d.ts))
   - I don't created a new `promise` method, I just imported the original from:
      ```ts
      import { Pool as PromisePool } from '../../promise';
      ```

<hr />

### Then:
- ✅ In `mysql/promise` import, the option `promise` will not appears
- ✅ In `mysql` import, both the `createConnection` and `createPool` has the `promise` option and show all the options within them
- ✅ As mentioned by @newtoncodes, in `mysql` import, the `.promise()` method returns a `Connection` instance and not a promise

<hr />

### A `mysql` test example:
```ts
// non-promise.ts
import mysql from 'mysql2';

const access: mysql.ConnectionOptions = {
   host: '127.0.0.1',
   user: 'root',
   password: '*',
   port: 3306,
   database: 'mydb',
};

(async () => {
   const db = mysql.createConnection(access).promise();
   
   const [pokemons] = await db.execute('SELECT * FROM pokemons');
   
   await db.end();
   
   console.log(pokemons);
})();
```

<hr />

### A `mysql/promise` test example:
```ts
// promise.ts
import mysql from 'mysql2/promise';

const access: mysql.ConnectionOptions = {
   host: '127.0.0.1',
   user: 'root',
   password: '*',
   port: 3306,
   database: 'mydb',
};

(async () => {
   const db = await mysql.createConnection(access);
   
   const [pokemons] = await db.execute('SELECT * FROM pokemons');
   
   await db.end();
   
   console.log(pokemons);
})();
```

<hr />

I cloned the latest `master` after `3.2.1` release and tested it in a real use (locally), it works and build the **TypeScript** perfectly in both `mysql` and `mysql/promise`.

<hr />

### Extra tests:

- ```json
  "skipLibCheck": false,
  ```

- ```json
  "skipLibCheck": true,
  ```

- Also, without `skipLibCheck`.

<hr />

I hope this helps 🙋🏻‍♂️