### PR TITLE
ci: Adding TypeScript build test

### DIFF
--- a/.github/workflows/ci-tsc-build.yml
+++ b/.github/workflows/ci-tsc-build.yml
@@ -1,0 +1,38 @@
+name: CI - TypeScript Build
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  tests-tsc-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x]
+
+    name: Node.js ${{ matrix.node-version }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+          
+      - name: Install npm dependencies
+        run: npm ci
+          
+      - name: Testing TypeScript build
+        run: npm run test:tsc-build

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:code": "eslint index.js promise.js \"lib/**/*.js\" \"test/**/*.js\" \"benchmarks/**/*.js\"",
     "lint:docs": "eslint Contributing.md \"documentation/**/*.md\" \"examples/*.js\"",
     "test": "node ./test/run.js",
+    "test:tsc-build": "cd \"test/tsc-build\" && npx tsc -p \"tsconfig.json\"",
     "coverage-test": "c8 -r cobertura -r lcov -r text node ./test/run.js",
     "benchmark": "node ./benchmarks/benchmark.js",
     "prettier": "prettier --single-quote --trailing-comma none --write \"{lib,examples,test}/**/*.js\"",

--- a/test/tsc-build/index.ts
+++ b/test/tsc-build/index.ts
@@ -1,0 +1,4 @@
+import mysql from '../../index';
+import mysqlp from '../../promise';
+
+export { mysql, mysqlp };

--- a/test/tsc-build/tsconfig.json
+++ b/test/tsc-build/tsconfig.json
@@ -1,0 +1,18 @@
+{
+   "include": ["index.ts"],
+   "compilerOptions": {
+      "target": "ES2016",
+      "module": "CommonJS",
+      "moduleResolution": "Node",
+      "isolatedModules": true,
+      "esModuleInterop": true,
+      "allowSyntheticDefaultImports": true,
+      "strict": true,
+      "alwaysStrict": true,
+      "noImplicitAny": true,
+		"strictFunctionTypes": false,
+      "skipLibCheck": false,
+      "noEmitOnError": true,
+      "noEmit": true
+   }
+}


### PR DESCRIPTION
<!-- # ci: Adding TypeScript build test -->

### In this PR:

1. In `package.json`, add the script `test:tsc-build`, allowing local testing before committing new `PRs`:
   - ```sh
      npm run test:tsc-build
      ```

2. In `.github/workflows/ci-tsc-build.yml`, runs the command `npm run test:tsc-build` when new `PRs` are submitted
   - ✅ Successfully, it will exit with **`code 0`**
   - ❌ In case the `tsc` build command fails, it will print the build errors and exit with **`code 1`**
   - I reproduced the pattern from `.github/workflows/ci-linux.yml`
   - I didn't understand the `main` branch instead `master`, but I kept by default like all the other `CI` patterns 🥷🏻

3. In `test/tsc-build/index.ts`, only imports the `mysql`, `mysql/promise` and export them
   - It allows this CI to not need to be updated because of any future changes within them

4. In `test/tsc-build/tsconfig.json`, reproduces the almost options from original `tsconfig.json`, but:
   - Doesn't emit output files
   - Set `skipLibCheck` to `false`

<hr />

### Important

- This `CI` has a single purpose which is to test the **TypeScript** build like an external module
   - It will prevent future `typings` incompatibilities before `PRs` are merged
- The build test will not change any file


<hr />

### Tests

- To test it locally, I just ran the command `npm run test:tsc-build`
- To test the `CI`, I cloned (not forked) the `master` to a private repository and played between valid and invalids `PRs` 🥷🏻
- After concluding all the tests, I performed the `fork`
