### PR TITLE
fix: Missing types in "mysql" import

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -153,6 +153,4 @@ export interface PreparedStatementInfo {
   execute(parameters: any[]): Promise<[RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader, FieldPacket[]]>;
 }
 
-export interface PromisePoolConnection extends Connection {
-  destroy(): any;
-} 
+export interface PromisePoolConnection extends Pool {}

--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -289,9 +289,8 @@ declare class Connection extends EventEmitter {
 
     rollback(callback: (err: Query.QueryError | null) => void): void;
 
-    execute(sql: string, callback?: (err: any, rows: Array<any>, fields: Array<any>) => any): any;
-
-    execute(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: any, rows: Array<any>, fields: Array<any>) => any): any;
+    execute(sql: string, callback?: (err: any, rows: RowDataPacket[] | RowDataPacket[][] | OkPacket | OkPacket[] | ResultSetHeader, fields: FieldPacket[]) => void): void;
+    execute(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: any, rows: RowDataPacket[] | RowDataPacket[][] | OkPacket | OkPacket[] | ResultSetHeader, fields: FieldPacket[]) => void): void;
 
     unprepare(sql: string): any;
 

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -71,7 +71,7 @@ declare class Pool extends EventEmitter {
     on(event: string, listener: Function): this;
     on(event: 'connection', listener: (connection: PoolConnection) => any): this;
 
-    promise(promiseImpl?: any): any;
+    promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
 }
 
 export = Pool;

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -4,6 +4,7 @@ import {OkPacket, RowDataPacket, FieldPacket, ResultSetHeader} from './protocol/
 import Connection = require('./Connection');
 import PoolConnection = require('./PoolConnection');
 import {EventEmitter} from 'events';
+import { PromisePoolConnection } from '../../../promise';
 
 declare namespace Pool {
 
@@ -65,6 +66,9 @@ declare class Pool extends EventEmitter {
     query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
     query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(options: Query.QueryOptions, callback?: (err: Query.QueryError | null, result: T, fields?: FieldPacket[]) => any): Query;
     query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(options: Query.QueryOptions, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
+
+    execute(sql: string, callback?: (err: any, rows: RowDataPacket[] | RowDataPacket[][] | OkPacket | OkPacket[] | ResultSetHeader, fields: FieldPacket[]) => void): void;
+    execute(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: any, rows: RowDataPacket[] | RowDataPacket[][] | OkPacket | OkPacket[] | ResultSetHeader, fields: FieldPacket[]) => void): void;
 
     end(callback?: (err: NodeJS.ErrnoException | null, ...args: any[]) => any): void;
 


### PR DESCRIPTION
I performed a variety of tests to cover the most common options from `mysql` import among:

```ts
.promise();
/* callbacks */

.query(sql);
.query(sql, params);

.execute(sql);
.execute(sql, params);
```

Included in:

```ts
.createConnection();
.createPool();
.createPool().getConnection();
```

<hr />

### This fixes these problems:

1. In `Pool` the `execute` method didn't exists (#1966)
2. In `Connection` all the `execute` method params and returns were set as `any`
3. In `promise()` the most of options were missing, but they didn't report errors because it were implied as `any` [(as in this comment)](https://github.com/sidorares/node-mysql2/issues/1936#issuecomment-1506258067)
4. Fix type conflicts between `promise()` and `callback` use cases

<hr />

#### These changes don't affects the `mysql/promise`

<hr />

### Tests:

-  The changes are small, but tests are extensive, so I preferred to embed them in **details** tag.
-  All `.promise()` tests the `query` and `execute` methods with and without **Prepared Statements**
-  These fixes includes all variations of the following tests

<hr />

<details>
<summary>
   Base connection
</summary>

```ts
import mysql from 'mysql2';

const access: mysql.ConnectionOptions = {
   host: '127.0.0.1',
   user: 'root',
   password: '*',
   port: 3306,
   database: 'mydb',
};

const sqlQuery = 'SELECT * FROM `Users`;';
const sqlQueryWithParam = 'SELECT * FROM `Users` WHERE `id` = ?;';
const sqlParam = [1];
```

</details>

<hr />

<details>
<summary>
   <code>.createConnection()</code>, <code>.promise()</code> and <code>.query()</code>
</summary>

```ts
(async () => {
   const db = mysql.createConnection(access).promise();
   const [users] = await db.query(sqlQuery);
   const [usersWithParam] = await db.query(sqlQueryWithParam, sqlParam);

   console.log(users, usersWithParam);
   await db.end();
})();
```

</details>

<details>
<summary>
   <code>.createPool()</code>, <code>.promise()</code> and <code>.query()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access).promise();
   const [users] = await db.query(sqlQuery);
   const [usersWithParam] = await db.query(sqlQueryWithParam, sqlParam);

   console.log(users, usersWithParam);
   await db.end();
})();
```

</details>

<details>
<summary>
   <code>.createPool()</code>, <code>.promise()</code>, <code>.getConnection()</code> and <code>.query()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access).promise();
   const [users] = await db.query(sqlQuery);
   const [usersWithParam] = await db.query(sqlQueryWithParam, sqlParam);

   console.log(users, usersWithParam);
   await db.end();
})();
```

</details>

<hr />

<details>
<summary>
   <code>.createConnection()</code>, <code>.promise()</code> and <code>.execute()</code>
</summary>

```ts
(async () => {
   const db = mysql.createConnection(access).promise();

   const [users] = await db.execute(sqlQuery);
   const [usersWithParam] = await db.execute(sqlQueryWithParam, sqlParam);

   console.log(users, usersWithParam);
   await db.end();
})();
```

</details>

<details>
<summary>
   <code>.createPool()</code>, <code>.promise()</code> and <code>.execute()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access).promise();
   const [users] = await db.execute(sqlQuery);
   const [usersWithParam] = await db.execute(sqlQueryWithParam, sqlParam);

   console.log(users, usersWithParam);
   await db.end();
})();
})();
```

</details>

<details>
<summary>
   <code>.createPool()</code>, <code>.promise()</code>, <code>.getConnection()</code> and <code>.execute()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access).promise();
   const conn = await db.getConnection();
   const [users] = await conn.execute(sqlQuery);
   const [usersWithParam] = await conn.query(sqlQueryWithParam, sqlParam);

   console.log(users, usersWithParam);
   await db.end();
})();
```

</details>

<hr />

<details>
<summary>
   <strong>callback:</strong> <code>.createConnection()</code> and <code>.query()</code>
</summary>

```ts
(async () => {
   const db = mysql.createConnection(access);

   db.query(sqlQuery, (error, users) => {
      console.log(users);
      db.end();
   });
})();
```

</details>

<details>
<summary>
   <strong>callback:</strong> <code>.createConnection()</code> and <code>.query()</code> with Prepared Statements
</summary>

```ts
(async () => {
   const db = mysql.createConnection(access);

   db.query(sqlQueryWithParam, sqlParam, (error, usersWithParam) => {
      console.log(usersWithParam);
      db.end();
   });
})();
```

</details>

<hr />

<details>
<summary>
   <strong>callback:</strong> <code>.createConnection()</code> and <code>.execute()</code>
</summary>

```ts
(async () => {
   const db = mysql.createConnection(access);

   db.execute(sqlQuery, (error, users) => {
      console.log(users);
      db.end();
   });
})();
```

</details>

<details>
<summary>
   <strong>callback:</strong> <code>.createConnection()</code> and <code>.execute()</code> with Prepared Statements
</summary>

```ts
(async () => {
   const db = mysql.createConnection(access);

   db.execute(sqlQueryWithParam, sqlParam, (error, usersWithParam) => {
      console.log(usersWithParam);
      db.end();
   });
})();
```

</details>

<hr />

<details>
<summary>
   <strong>callback:</strong> <code>.createPool()</code> and <code>.query()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.query(sqlQuery, (error, users) => {
      console.log(users);
      db.end();
   });
})();
```

</details>

<details>
<summary>
   <strong>callback:</strong> <code>.createPool()</code> and <code>.query()</code> with Prepared Statements
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.query(sqlQueryWithParam, sqlParam, (error, usersWithParam) => {
      console.log(usersWithParam);
      db.end();
   });
})();
```

</details>

<hr />

<details>
<summary>
   <strong>callback:</strong> <code>.createPool()</code>, <code>.getConnection()</code> and <code>.query()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.getConnection((err, conn) => {
      conn.query(sqlQuery, (error, users) => {
         console.log(users);
         db.end();
      });
   });
})();
```

</details>

<details>
<summary>
  <strong>callback:</strong> <code>.createPool()</code>, <code>.getConnection()</code> and <code>.query()</code> with Prepared Statements
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.getConnection((err, conn) => {
      conn.query(sqlQueryWithParam, sqlParam, (error, usersWithParam) => {
         console.log(usersWithParam);
         db.end();
      });
   });
})();
```

</details>

<hr />

<details>
<summary>
   <strong>callback:</strong> <code>.createPool()</code> and <code>.execute()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.execute(sqlQuery, (error, users) => {
      console.log(users);
      db.end();
   });
})();
```

</details>

<details>
<summary>
   <strong>callback:</strong> <code>.createPool()</code> and <code>.execute()</code> with Prepared Statements
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.execute(sqlQueryWithParam, sqlParam, (error, usersWithParam) => {
      console.log(usersWithParam);
      db.end();
   });
})();
```

</details>

<hr />

<details>
<summary>
   <strong>callback:</strong> <code>.createPool()</code>, <code>.getConnection()</code> and <code>.execute()</code>
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.getConnection((err, conn) => {
      conn.execute(sqlQuery, (error, users) => {
         console.log(users);
         db.end();
      });
   });
})();
```

</details>

<details>
<summary>
  <strong>callback:</strong> <code>.createPool()</code>, <code>.getConnection()</code> and <code>.execute()</code> with Prepared Statements
</summary>

```ts
(async () => {
   const db = mysql.createPool(access);

   db.getConnection((err, conn) => {
      conn.execute(sqlQueryWithParam, sqlParam, (error, usersWithParam) => {
         console.log(usersWithParam);
         db.end();
      });
   });
})();
```

</details>
