### PR TITLE
fix: LRU constructor

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -22,7 +22,7 @@ const EventEmitter = require('events').EventEmitter;
 const Readable = require('stream').Readable;
 const Queue = require('denque');
 const SqlString = require('sqlstring');
-const LRU = require('lru-cache');
+const LRU = require('lru-cache').default;
 
 const PacketParser = require('./packet_parser.js');
 const Packets = require('./packets/index.js');

--- a/lib/parsers/parser_cache.js
+++ b/lib/parsers/parser_cache.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const LRU = require('lru-cache');
+const LRU = require('lru-cache').default;
 
 const parserCache = new LRU({
   max: 15000


### PR DESCRIPTION
@sidorares, this time, the fix is in **JavaScript** 🤹🏻‍♀️

<hr />

### This fixes the LRU Constructor:
 - #1885

The problem is a compatibility issue between CommonJS and ECMAScript Modules when importing the `lru-cache`.

<hr />

To fix it, I changed the import from `LRU` in `./lib/parser_cache.js` and `./lib/connection.js`:

- from
```js
  const LRU = require('lru-cache');
```
- to
```js
  const LRU = require('lru-cache').default;
```

Now, it's compatible with both **CJS** and **ESM**.

<hr />

### NextJS

I tested this fix in a latest **NextJS** project and it works perfectly without use the experimental: `serverComponentsExternalPackages: ["mysql2"]`.

- It may be necessary to delete the `./.next` cache folder before the first `npm run` `build` | `dev`.

<hr />

### Notes

- As I didn't tested in older versions of **Node.js**, the CI tests from this PR will be the "final test"
- ~~In case some CI fail, I will close this PR~~ *(not today)* 🥷🏻✨