### PR TITLE
Respect enableKeepAlive option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ const pool = mysql.createPool({
   connectionLimit: 10,
   maxIdle: 10, // max idle connections, the default value is the same as `connectionLimit`
   idleTimeout: 60000, // idle connections timeout, in milliseconds, the default value 60000
-  queueLimit: 0
+  queueLimit: 0,
+  enableKeepAlive: true
 });
 ```
 The pool does not create all connections upfront but creates them on demand until the connection limit is reached.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ const pool = mysql.createPool({
   maxIdle: 10, // max idle connections, the default value is the same as `connectionLimit`
   idleTimeout: 60000, // idle connections timeout, in milliseconds, the default value 60000
   queueLimit: 0,
-  enableKeepAlive: true
+  enableKeepAlive: true,
+  keepAliveInitialDelay: 0
 });
 ```
 The pool does not create all connections upfront but creates them on demand until the connection limit is reached.

--- a/documentation_zh-cn/README.md
+++ b/documentation_zh-cn/README.md
@@ -132,7 +132,8 @@ const pool = mysql.createPool({
   database: 'test',
   waitForConnections: true,
   connectionLimit: 10,
-  queueLimit: 0
+  queueLimit: 0,
+  enableKeepAlive: true
 });
 ```
 该池不会预先创建所有连接，而是根据需要创建它们，直到达到连接限制。

--- a/documentation_zh-cn/README.md
+++ b/documentation_zh-cn/README.md
@@ -133,7 +133,8 @@ const pool = mysql.createPool({
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0,
-  enableKeepAlive: true
+  enableKeepAlive: true,
+  keepAliveInitialDelay: 0
 });
 ```
 该池不会预先创建所有连接，而是根据需要创建它们，直到达到连接限制。

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -52,7 +52,7 @@ class Connection extends EventEmitter {
           opts.config.host
         );
 
-        // Enable keep-alive on the socket. It's enabled by default.
+        // Optionally enable keep-alive on the socket.
         if (this.config.enableKeepAlive) {
           this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
         }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -52,9 +52,10 @@ class Connection extends EventEmitter {
           opts.config.host
         );
 
-        // Enable keep-alive on the socket.  It's disabled by default, but the
-        // user can enable it and supply an initial delay.
-        this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
+        // Enable keep-alive on the socket. It's enabled by default.
+        if (this.config.enableKeepAlive) {
+          this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
+        }
 
         // Enable TCP_NODELAY flag. This is needed so that the network packets
         // are sent immediately to the server

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -115,7 +115,7 @@ class ConnectionConfig {
     this.debug = options.debug;
     this.trace = options.trace !== false;
     this.stringifyObjects = options.stringifyObjects || false;
-    this.enableKeepAlive = !!options.enableKeepAlive;
+    this.enableKeepAlive = options.enableKeepAlive !== false;
     this.keepAliveInitialDelay = options.keepAliveInitialDelay || 0;
     if (
       options.timezone &&

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -44,8 +44,7 @@ declare namespace Pool {
         queueLimit?: number;
 
         /**
-         * Enable keep-alive on the socket.  It's disabled by default, but the
-         * user can enable it and supply an initial delay.
+         * Enable keep-alive on the socket. (Default: true)
          */
         enableKeepAlive?: boolean;
 

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -49,7 +49,7 @@ declare namespace Pool {
         enableKeepAlive?: boolean;
 
         /**
-         * If keep-alive is enabled users can supply an initial delay.
+         * If keep-alive is enabled users can supply an initial delay. (Default: 0)
          */
         keepAliveInitialDelay?: number;
     }


### PR DESCRIPTION
This should make sure that the `enableKeepAlive` option is actually taken into account so that it's possible to disable keepalive. This is related to #1081 and #1586.

Before this change keepalive was always enabled, so I opted to let `enableKeepAlive` default to `true`. If enabled by default is not what we should do I'm happy to change it again.