### PR TITLE
fix: add package.json to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   ],
   "exports": {
     ".": "./index.js",
+    "./package.json": "./package.json",
     "./promise": "./promise.js",
     "./promise.js": "./promise.js"
   },


### PR DESCRIPTION
Hello, 

Proposal to keep mysql2 compatible to many external APIs, that need the package.json. My usage is for example esbuild plugins, that allow instrumentation through datadog APM.

```
✘ [ERROR] Package subpath './package.json' is not defined by "exports" in /Users/**/node_modules/mysql2/package.json [plugin datadog-esbuild]

    node_modules/dd-trace/packages/datadog-esbuild/index.js:45:40:
      45 │       const pathToPackageJson = require.resolve(`${packageName}/package.json`, { paths: [ args.resolveDir ] })

```

Don't hesitate to reach out for any complementary information