### PR TITLE
ci: add node 20.x to the build matrix

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -45,10 +45,6 @@ jobs:
             mysql-version: "mysql:8.0.18"
             use-compression: 0
             use-tls: 1
-          - node-version: "20.x"
-            mysql-version: "mysql:8.0.18"
-            use-compression: 1
-            use-tls: 1
 
           # 18.x
           # - node-version: "18.x"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -36,6 +36,40 @@ jobs:
         mysql_connection_url_key: [""]
         # TODO - add mariadb to the matrix. currently few tests are broken due to mariadb incompatibilities
         include:
+          # 20.x 
+          - node-version: "20.x"
+            mysql-version: "mysql:8.0.18"
+            use-compression: 1
+            use-tls: 0
+          - node-version: "20.x"
+            mysql-version: "mysql:8.0.18"
+            use-compression: 0
+            use-tls: 1
+          - node-version: "20.x"
+            mysql-version: "mysql:8.0.18"
+            use-compression: 1
+            use-tls: 1
+
+          # 18.x
+          - node-version: "18.x"
+            mysql-version: "mysql:8.0.18"
+            use-compression: 1
+            use-tls: 0
+          - node-version: "18.x"
+            mysql-version: "mysql:8.0.18"
+            use-compression: 0
+            use-tls: 1
+          - node-version: "18.x"
+            mysql-version: "mysql:8.0.18"
+            use-compression: 1
+            use-tls: 1
+          # - node-version: "18.x"
+          #   mysql_connection_url_key: "PS_MYSQL_URL"
+          #   filter: "test-select"
+          #   use-compression: 0
+          #   use-tls: 0
+
+          # 16.x 
           - node-version: "16.x"
             mysql-version: "mysql:8.0.18"
             use-compression: 1
@@ -48,20 +82,19 @@ jobs:
             mysql-version: "mysql:8.0.18"
             use-compression: 1
             use-tls: 1
+
+          # 14.x 
           - node-version: "14.x"
             mysql-version: "mysql:5.7"
             use-compression: 0
             use-tls: 0
+
+          # filter
           - filter: "test-select-1" # a number of tests does not work with mysql 5.1 due to old sql syntax, just testing basic connection
             node-version: "16.x"
             mysql-version: "datagrip/mysql:5.1"
             use-compression: 0
             use-tls: 0
-#           - node-version: "18.x"
-#             mysql_connection_url_key: "PS_MYSQL_URL"
-#             filter: "test-select"
-#             use-compression: 0
-#             use-tls: 0
     env:
       MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}
 

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -51,18 +51,6 @@ jobs:
             use-tls: 1
 
           # 18.x
-          - node-version: "18.x"
-            mysql-version: "mysql:8.0.18"
-            use-compression: 1
-            use-tls: 0
-          - node-version: "18.x"
-            mysql-version: "mysql:8.0.18"
-            use-compression: 0
-            use-tls: 1
-          - node-version: "18.x"
-            mysql-version: "mysql:8.0.18"
-            use-compression: 1
-            use-tls: 1
           # - node-version: "18.x"
           #   mysql_connection_url_key: "PS_MYSQL_URL"
           #   filter: "test-select"

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         mysql-version: ["mysql:8.0.18", "mysql:8.0.22", "mysql:5.7"]
         use-compression: [0]
         use-tls: [0]

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         mysql-version: ['8.0']
         use-compression: [0, 1]
         use-tls: [0, 1]

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [18.x, 20.x]
         mysql-version: ['8.0']
         use-compression: [0, 1]
         use-tls: [0, 1]

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ logs
 node_modules
 npm-debug.log
 benchmarks/results.json
+!test/fixtures/data.csv


### PR DESCRIPTION
### Steps:

- [x] Fix **Linux and Windows CI** to work in base (forked) repositories:
  - [x] Fix the missing `test/fixtures/data.csv` in cloned/forked repositories
- [x] Add **Node 20.x** to:
  - [x] **Linux** build matrix
  - [x] **Windows** build matrix
- [x] Check variations for **SSL** and **Compression**:
    - [x] 20.x
    - [x] 18.x *(removed after checking)*
    - [x] 16.x
- [x] Remove (as in #2003):
  - [x] Linux
    - [x] **`SSL=1`** and **`Compression=1`** variation from **node 20.x**
  - [x] Windows
    - [x] 16.x from matrix