### PR TITLE
fix: keepAliveInitialDelay not taking effect

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -54,7 +54,9 @@ class Connection extends EventEmitter {
 
         // Optionally enable keep-alive on the socket.
         if (this.config.enableKeepAlive) {
-          this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
+          this.stream.on('connect', () => {
+            this.stream.setKeepAlive(true, this.config.keepAliveInitialDelay);
+          });
         }
 
         // Enable TCP_NODELAY flag. This is needed so that the network packets


### PR DESCRIPTION
TCP keepalive interval time will only take effect if setKeepAlive() is called after the socket object is created.