### PR TITLE
documentation: create pt-br README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 [![Windows Build][appveyor-image]][appveyor-url]
 [![License][license-image]][license-url]  
 
-English | [简体中文](./documentation/zh-cn/)
+English | [简体中文](./documentation/zh-cn/) | [Português (BR)](./documentation/pt-br/)
 
-> MySQL client for Node.js with focus on performance. Supports prepared statements, non-utf8 encodings, binary log protocol, compression, ssl [much more](./documentation/en)
+> MySQL client for Node.js with focus on performance. Supports prepared statements, non-utf8 encodings, binary log protocol, compression, ssl [much more](./documentation/en).
 
 __Table of contents__
 
@@ -20,6 +20,9 @@ __Table of contents__
   - [Using Prepared Statements](#using-prepared-statements)
   - [Using connection pools](#using-connection-pools)
   - [Using Promise Wrapper](#using-promise-wrapper)
+  - [Array Results](#array-results)
+    - [Connection Level](#connection-level)
+    - [Query Level](#query-level)
   - [API and Configuration](#api-and-configuration)
   - [Documentation](#documentation)
   - [Acknowledgements](#acknowledgements)
@@ -29,7 +32,7 @@ __Table of contents__
 
 MySQL2 project is a continuation of [MySQL-Native][mysql-native]. Protocol parser code was rewritten from scratch and api changed to match popular [mysqljs/mysql][node-mysql]. MySQL2 team is working together with [mysqljs/mysql][node-mysql] team to factor out shared code and move it under [mysqljs][node-mysql] organisation.
 
-MySQL2 is mostly API compatible with [mysqljs][node-mysql] and supports majority of features. MySQL2 also offers these additional features
+MySQL2 is mostly API compatible with [mysqljs][node-mysql] and supports majority of features. MySQL2 also offers these additional features:
 
  - Faster / Better Performance
  - [Prepared Statements](./documentation/en/Prepared-Statements.md)
@@ -51,7 +54,6 @@ npm install --save mysql2
 ```
 
 ## First Query
-
 ```js
 // get the client
 const mysql = require('mysql2');
@@ -84,11 +86,11 @@ connection.query(
 
 ## Using Prepared Statements
 
-With MySQL2 you also get the prepared statements. With prepared statements MySQL doesn't have to prepare plan for same query everytime, this results in better performance. If you don't know why they are important, please check these discussions
+With MySQL2 you also get the prepared statements. With prepared statements MySQL doesn't have to prepare plan for same query every time, this results in better performance. If you don't know why they are important, please check these discussions:
 
 - [How prepared statements can protect from SQL Injection attacks](http://stackoverflow.com/questions/8263371/how-can-prepared-statements-protect-from-sql-injection-attacks)
 
-MySQL provides `execute` helper which will prepare and query the statement. You can also manually prepare / unprepare statement with `prepare` / `unprepare` methods.
+MySQL2 provides `execute` helper which will prepare and query the statement. You can also manually prepare / unprepare statement with `prepare` / `unprepare` methods.
 
 ```js
 // get the client
@@ -144,9 +146,9 @@ The pool does not create all connections upfront but creates them on demand unti
 You can use the pool in the same way as connections (using `pool.query()` and `pool.execute()`):
 ```js
 // For pool initialization, see above
-pool.query("SELECT field FROM atable", function(err, rows, fields) {
+pool.query("SELECT `field` FROM `table`", function(err, rows, fields) {
   // Connection is automatically released when query resolves
-})
+});
 ```
 
 Alternatively, there is also the possibility of manually acquiring a connection from the pool and returning it later:
@@ -157,14 +159,12 @@ pool.getConnection(function(err, conn) {
   conn.query(/* ... */);
   // Don't forget to release the connection when finished!
   pool.releaseConnection(conn);
-})
+});
 ```
 
 ## Using Promise Wrapper
 
 MySQL2 also support Promise API. Which works very well with ES7 async await.
-
-<!--eslint-disable-next-block-->
 ```js
 async function main() {
   // get the client
@@ -176,9 +176,7 @@ async function main() {
 }
 ```
 
-MySQL2 use default `Promise` object available in scope. But you can choose which `Promise` implementation you want to use
-
-<!--eslint-disable-next-block-->
+MySQL2 use default `Promise` object available in scope. But you can choose which `Promise` implementation you want to use.
 ```js
 // get the client
 const mysql = require('mysql2/promise');
@@ -193,7 +191,7 @@ const connection = await mysql.createConnection({host:'localhost', user: 'root',
 const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
 ```
 
-MySQL2 also exposes a .promise() function on Pools, so you can create a promise/non-promise connections from the same pool
+MySQL2 also exposes a .promise() function on Pools, so you can create a promise/non-promise connections from the same pool.
 ```js
 async function main() {
   // get the client
@@ -207,7 +205,7 @@ async function main() {
 }
 ```
 
-MySQL2 exposes a .promise() function on Connections, to "upgrade" an existing non-promise connection to use promise
+MySQL2 exposes a .promise() function on Connections, to "upgrade" an existing non-promise connection to use promise.
 ```js
 // get the client
 const mysql = require('mysql2');
@@ -223,7 +221,7 @@ con.promise().query("SELECT 1")
   .then( () => con.end());
 ```
 
-## Array results
+## Array Results
 
 If you have two columns with the same name, you might want to get results as an array rather than an object to prevent them from clashing. This is a deviation from the [Node MySQL][node-mysql] library.
 
@@ -231,22 +229,19 @@ For example: `select 1 as foo, 2 as foo`.
 
 You can enable this setting at either the connection level (applies to all queries), or at the query level (applies only to that specific query).
 
-### Connection Option
+### Connection Level
 ```js
 const con = mysql.createConnection(
   { host: 'localhost', database: 'test', user: 'root', rowsAsArray: true }
 );
-
 ```
 
-### Query Option
-
+### Query Level
 ```js
 con.query({ sql: 'select 1 as foo, 2 as foo', rowsAsArray: true }, function(err, results, fields) {
-  console.log(results) // will be an array of arrays rather than an array of objects
-  console.log(fields) // these are unchanged
+  console.log(results); // in this query, results will be an array of arrays rather than an array of objects
+  console.log(fields); // fields are unchanged
 });
-
 ```
 
 ## API and Configuration

--- a/documentation/pt-br/README.md
+++ b/documentation/pt-br/README.md
@@ -1,0 +1,288 @@
+## Node MySQL 2
+
+[![Greenkeeper badge](https://badges.greenkeeper.io/sidorares/node-mysql2.svg)](https://greenkeeper.io/)
+[![NPM Version][npm-image]][npm-url]
+[![NPM Downloads][downloads-image]][downloads-url]
+[![Node.js Version][node-version-image]][node-version-url]
+[![Linux Build][travis-image]][travis-url]
+[![Windows Build][appveyor-image]][appveyor-url]
+[![License][license-image]][license-url]  
+
+[English](../..) | [简体中文](../zh-cn/) | Português (BR)
+
+> Cliente MySQL para Node.js com foco em performance. Suporta instruções preparadas (*prepared statements*), Codidificações *non-utf8*, protocolo de log binário (*binary log protocol*), compressão, SSL e [muito mais](../en).
+
+__Lista de Conteúdos__
+
+  - [História e por que MySQL2](#história-e-por-que-mysql2)
+  - [Instalação](#instalação)
+  - [Primeira Consulta (*Query*)](#primeira-consulta-query)
+  - [Usando Instruções Preparadas (*Prepared Statements*)](#usando-instruções-preparadas-prepared-statements)
+  - [Usando Conjuntos de Conexões (*Pool*)](#usando-conjunto-de-conexões-pools)
+  - [Usando o *Promise Wrapper*](#usando-o-promise-wrapper)
+  - [Resultados em *Array*](#resultados-em-array)
+    - [Nível de Conexão](#resultados-em-array)
+    - [Nível de Consulta (*Query*)](#resultados-em-array)
+  - [API e Configuração](#api-e-configuração)
+  - [Documentação](#documentação)
+  - [Agradecimentos](#agradecimentos)
+  - [Contribuições](#contribuições)
+
+## História e por que MySQL2
+
+O projeto MySQL2 é uma continuação do [MySQL-Native][mysql-native]. O código do analisador de protocolo (*protocol parser*) foi reescrito do zero e a API foi alterada para corresponder ao popular [mysqljs/mysql][node-mysql]. A equipe do MySQL2 está trabalhando em conjunto com a equipe do [mysqljs/mysql][node-mysql] para *fatorar* o código compartilhado e movê-lo para a organização [mysqljs][node-mysql].
+
+O MySQL2 é maioritariamente compatível com a API do [mysqljs][node-mysql] e suporta a maioria de suas funcionalidades. O MySQL2 também oferece essas funcionalidades adicionais:
+
+ - Desempenho mais rápido / melhor
+ - [Instruções Preparadas (*Prepared Statements*)](../en/Prepared-Statements.md)
+ - Protocolo de log binário MySQL (*MySQL Binary Log Protocol*)
+ - [Servidor MySQL](../en/MySQL-Server.md)
+ - Estende o suporte para *Encoding* and *Collation*
+ - [*Promise Wrapper*](../en/Promise-Wrapper.md)
+ - Compressão
+ - SSL e [*Authentication Switch*](../en/Authentication-Switch.md)
+ - [*Streams* Personalizados](../en/Extras.md)
+ - [Conjunto de Conexões (*Pooling*)](#using-connection-pools)
+
+## Instalação
+
+O MySQL2 não tem restrições nativas e pode ser instalado no Linux, Mac OS ou Windows sem qualquer problema.
+
+```bash
+npm install --save mysql2
+```
+
+## Primeira Consulta (*Query*)
+
+```js
+// obtém o cliente
+const mysql = require('mysql2');
+
+// Cria a conexão com o Banco de Dados
+const connection = mysql.createConnection({
+  host: 'localhost',
+  user: 'root',
+  database: 'test'
+});
+
+// Consulta simples
+connection.query(
+  'SELECT * FROM `table` WHERE `name` = "Page" AND `age` > 45',
+  function(err, results, fields) {
+    console.log(results); // "results" contêm as linhas retornadas pelo servidor
+    console.log(fields); // "fields" contêm metadados adicionais sobre os resultados, quando disponíveis
+  }
+);
+
+// Utilizando espaços reservados (placeholders)
+connection.query(
+  'SELECT * FROM `table` WHERE `name` = ? AND `age` > ?',
+  ['Page', 45],
+  function(err, results) {
+    console.log(results);
+  }
+);
+```
+
+## Usando Instruções Preparadas (*Prepared Statements*)
+
+Com o MySQL2 você também pode obter Instruções Preparadas (Prepared Statements). Dessa forma o MySQL não precisa preparar um plano para a mesma consulta todas as vezes, resultando em um melhor desempenho. Se você não sabe por que isso é importante, veja essa discussão:
+
+- [Como as instruções preparadas (*prepared statements*) podem proteger contra ataques de injeção SQL](http://stackoverflow.com/questions/8263371/how-can-prepared-statements-protect-from-sql-injection-attacks)
+
+
+O MySQL2 fornece o método auxiliar `execute` que irá preparar e consultar as declarações (*statements*) SQL. Além disso, você também pode usar os métodos `prepare` e `unprepare` para preparar ou desfazer a preparação de declarações (*statements*) manualmente, se necessário.
+
+```js
+// Obtém o cliente
+const mysql = require('mysql2');
+
+// Cria a conexão com o Banco de Dados
+const connection = mysql.createConnection({
+  host: 'localhost',
+  user: 'root',
+  database: 'test'
+});
+
+// "execute" irá chamar internamente a preparação e a consulta (query)
+connection.execute(
+  'SELECT * FROM `table` WHERE `name` = ? AND `age` > ?',
+  ['Rick C-137', 53],
+  function(err, results, fields) {
+    console.log(results); // "results" contêm as linhas retornadas pelo servidor
+    console.log(fields); // "fields" contêm metadados adicionais sobre os resultados, quando disponíveis
+
+    // Se você executar a mesma declaração novamente, ela será selecionada a partir do LRU Cache
+    // O que economizará tempo de preparação da consulta e proporcionará melhor desempenho.
+  }
+);
+```
+
+## Usando Conjunto de Conexões (*pools*)
+
+O conjunto de conexões (*pools*) ajuda a reduzir o tempo gasto na conexão com o servidor MySQL, reutilizando uma conexão anterior e deixando-as abertas ao invés de fechá-las quando você termina de usá-las.
+
+Isto melhora a latência das consultas (*queries*), pois evita toda a sobrecarga associada à criação de uma nova conexão.
+
+```js
+// Obtém o cliente
+const mysql = require('mysql2');
+
+// Cria a conexão (pool). As definições específicadas do "createPool" são as predefinições padrões
+const pool = mysql.createPool({
+  host: 'localhost',
+  user: 'root',
+  database: 'test',
+  waitForConnections: true,
+  connectionLimit: 10,
+  maxIdle: 10, // Máximo de conexões inativas; o valor padrão é o mesmo que "connectionLimit"
+  idleTimeout: 60000, // Tempo limite das conexões inativas em milissegundos; o valor padrão é "60000"
+  queueLimit: 0,
+  enableKeepAlive: true,
+  keepAliveInitialDelay: 0
+});
+```
+O *pool* não estabelece todas as conexões previamente, mas as cria sob demanda até que o limite de conexões seja atingido.
+
+Você pode usar o *pool* da mesma maneira como em uma conexão (usando `pool.query()` e `pool.execute()`):
+```js
+// Para a inicialização do "pool", veja acima
+pool.query("SELECT `field` FROM `table`", function(err, rows, fields) {
+  // A conexão é automaticamente liberada quando a consulta (query) é resolvida
+});
+```
+
+Alternativamente, também existe a possibilidade de adquirir manualmente uma conexão do pool e liberá-la posteriormente:
+```js
+// Para a inicialização do "pool", veja acima
+pool.getConnection(function(err, conn) {
+  // Fazer algo com a conexão
+  conn.query(/* ... */);
+  // Não se esqueça de liberar a conexão quando terminar!
+  pool.releaseConnection(conn);
+});
+```
+
+## Usando o *Promise Wrapper*
+
+O MySQL2 também suporta *Promise* API. O que funciona muito bem com o ES7 async await.
+
+```js
+async function main() {
+  // Obtém o cliente
+  const mysql = require('mysql2/promise');
+  // Cria a conexão com o Banco de Dados
+  const connection = await mysql.createConnection({host:'localhost', user: 'root', database: 'test'});
+  // Consulta no Banco de Dados
+  const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
+}
+```
+
+O MySQL2 usa o objeto *`Promise`* padrão disponível no escopo. Mas você pode escolher qual implementação de *`Promise`* deseja usar.
+```js
+// Obtém o cliente
+const mysql = require('mysql2/promise');
+
+// Obtém a implementação de "Promise" (nós usaremos o "bluebird")
+const bluebird = require('bluebird');
+
+// Cria a conexão, especificando o "bluebird" como "Promise"
+const connection = await mysql.createConnection({host:'localhost', user: 'root', database: 'test', Promise: bluebird});
+
+// Consulta no Banco de Dados
+const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
+```
+
+O MySQL2 também expõe o método .promise() em *Pools*, então você pode criar conexões "*promise/non-promise*" para o mesmo *pool*.
+```js
+async function main() {
+  // Obtém o cliente
+  const mysql = require('mysql2');
+  // Cria o "pool"
+  const pool = mysql.createPool({host:'localhost', user: 'root', database: 'test'});
+  // Agora obtém a instância "Promise wrapped" do "pool"
+  const promisePool = pool.promise();
+  // Consulta no Banco de Dados usando "Promises"
+  const [rows,fields] = await promisePool.query("SELECT 1");
+}
+```
+
+O MySQL2 também expõe o método .promise() em conexões, para "atualizar" a conexão *non-promise* existente e usá-la como *promise*.
+```js
+// Obtém o cliente
+const mysql = require('mysql2');
+// Cria a conexão
+const con = mysql.createConnection(
+  {host:'localhost', user: 'root', database: 'test'}
+);
+con.promise().query("SELECT 1")
+  .then( ([rows,fields]) => {
+    console.log(rows);
+  })
+  .catch(console.log)
+  .then( () => con.end());
+```
+
+## Resultados em *Array*
+
+Se você tiver duas colunas com o mesmo nome, pode preferir receber os resultados como um *array*, em vez de um objeto, para evitar conflitos. Isso é uma divergência da biblioteca [Node MySQL][node-mysql].
+
+Por exemplo: `select 1 as foo, 2 as foo`.
+
+Você pode habilitar essa configuração tanto no nível de conexão (aplica-se a todas as consultas), quanto no nível de consulta (aplica-se apenas a essa consulta específica).
+
+### Nível de Conexão
+```js
+const con = mysql.createConnection(
+  { host: 'localhost', database: 'test', user: 'root', rowsAsArray: true }
+);
+```
+
+### Nível de Consulta (*Query*)
+```js
+con.query({ sql: 'select 1 as foo, 2 as foo', rowsAsArray: true }, function(err, results, fields) {
+  console.log(results); // nessa consulta, "results" contêm um array de arrays ao invés de um array de objetos
+  console.log(fields); // "fields" mantêm-se inalterados
+});
+```
+
+## API e Configuração
+
+O MySQL2 é maioritariamente compatível com a API do [Node MySQL][node-mysql]. Você deve consultar a documentação da API para ver todas as opções disponíveis.
+
+Uma incompatibilidade conhecida é que os valores em `DECIMAL` são retornados como *strings*, enquanto no [Node MySQL][node-mysql] eles são retornados como números. Isso inclui o resultado das funções `SUM()` e `AVG()` quando aplicadas a argumentos `INTEGER`. Isso é feito deliberadamente para evitar a perda de precisão - veja https://github.com/sidorares/node-mysql2/issues/935.
+
+Se você encontrar qualquer outra incompatibilidade com o [Node MySQL][node-mysql], por favor, reporte através do acompanhamento de *Issues*. Nós corrigiremos a incompatibilidade relatada como uma prioridade.
+
+## Documentação
+
+Você pode encontrar a documentação detalhada [aqui](../en) e também pode consultar vários [exemplos](../../examples) de código para compreender conceitos avançados.
+
+## Agradecimentos
+
+  - O protocolo interno é escrito por @sidorares [MySQL-Native](https://github.com/sidorares/nodejs-mysql-native)
+  - *Constants*, interpolação de parâmetros SQL, *Pooling* e a classe `ConnectionConfig` foram retirados do [node-mysql](https://github.com/mysqljs/mysql)
+  - O Código de atualização SSL é baseado no [código](https://gist.github.com/TooTallNate/848444) feito por @TooTallNate
+  - *Flags* de API de conexão segura / comprimida compatíveis com o cliente [MariaSQL](https://github.com/mscdex/node-mariasql/).
+  - [Contribuidores](https://github.com/sidorares/node-mysql2/graphs/contributors)
+
+## Contribuições
+
+Quer melhorar algo no `node-mysql2`? Consulte o arquivo [Contributing.md](https://github.com/sidorares/node-mysql2/blob/master/Contributing.md) para instruções detalhadas sobre como começar.
+
+
+[npm-image]: https://img.shields.io/npm/v/mysql2.svg
+[npm-url]: https://npmjs.org/package/mysql2
+[node-version-image]: http://img.shields.io/node/v/mysql2.svg
+[node-version-url]: http://nodejs.org/download/
+[travis-image]: https://img.shields.io/travis/sidorares/node-mysql2/master.svg?label=linux
+[travis-url]: https://travis-ci.org/sidorares/node-mysql2
+[appveyor-image]: https://img.shields.io/appveyor/ci/sidorares/node-mysql2/master.svg?label=windows
+[appveyor-url]: https://ci.appveyor.com/project/sidorares/node-mysql2
+[downloads-image]: https://img.shields.io/npm/dm/mysql2.svg
+[downloads-url]: https://npmjs.org/package/mysql2
+[license-url]: https://github.com/sidorares/node-mysql2/blob/master/License
+[license-image]: https://img.shields.io/npm/l/mysql2.svg?maxAge=2592000
+[node-mysql]: https://github.com/mysqljs/mysql
+[mysql-native]: https://github.com/sidorares/nodejs-mysql-native

--- a/documentation/pt-br/README.md
+++ b/documentation/pt-br/README.md
@@ -10,7 +10,7 @@
 
 [English](../..) | [简体中文](../zh-cn/) | Português (BR)
 
-> Cliente MySQL para Node.js com foco em performance. Suporta instruções preparadas (*prepared statements*), Codidificações *non-utf8*, protocolo de log binário (*binary log protocol*), compressão, SSL e [muito mais](../en).
+> Cliente MySQL para Node.js com foco em performance. Suporta instruções preparadas (*prepared statements*), Codificações *non-utf8*, protocolo de log binário (*binary log protocol*), compressão, SSL e [muito mais](../en).
 
 __Lista de Conteúdos__
 
@@ -56,7 +56,7 @@ npm install --save mysql2
 ## Primeira Consulta (*Query*)
 
 ```js
-// obtém o cliente
+// Obtém o cliente
 const mysql = require('mysql2');
 
 // Cria a conexão com o Banco de Dados
@@ -166,7 +166,7 @@ pool.getConnection(function(err, conn) {
 
 ## Usando o *Promise Wrapper*
 
-O MySQL2 também suporta *Promise* API. O que funciona muito bem com o ES7 async await.
+O MySQL2 também suporta *Promise* API. O que funciona muito bem com o ES7 *async await*.
 
 ```js
 async function main() {

--- a/documentation/zh-cn/README.md
+++ b/documentation/zh-cn/README.md
@@ -8,9 +8,9 @@
 [![Windows Build][appveyor-image]][appveyor-url]
 [![License][license-image]][license-url]
 
-[English](../..) | 简体中文
+[English](../..) | 简体中文 | [Português (BR)](../pt-br/)
 
-> 适用于Node.js的MySQL客户端，专注于性能优化。支持SQL预处理、非UTF-8编码支持、二进制文件编码支持、压缩和SSL等等 [查看更多](../en)
+> 适用于Node.js的MySQL客户端，专注于性能优化。支持SQL预处理、非UTF-8编码支持、二进制文件编码支持、压缩和SSL等等 [查看更多](../en)。
 
 __目录__
 
@@ -20,6 +20,9 @@ __目录__
   - [SQL预处理的使用](#SQL预处理的使用)
   - [连接池的使用](#连接池的使用)
   - [Promise封装](#Promise封装)
+  - [结果返回](#结果返回)
+    - [连接级别](#连接级别)
+    - [查询级别](#查询级别)
   - [API配置项](#API配置项)
   - [文档](#文档)
   - [鸣谢](#鸣谢)
@@ -29,17 +32,17 @@ __目录__
 
 MySQL2 项目是 [MySQL-Native][mysql-native] 的延续。 协议解析器代码从头开始重写，api 更改为匹配流行的 [mysqljs/mysql][node-mysql]。 MySQL2 团队正在与 [mysqljs/mysql][node-mysql] 团队合作，将共享代码分解并移至 [mysqljs][node-mysql] 组织下。
 
-MySQL2 大部分 API 与 [mysqljs][node-mysql] 兼容，并支持大部分功能。 MySQL2 还提供了更多的附加功能
+MySQL2 大部分 API 与 [mysqljs][node-mysql] 兼容，并支持大部分功能。 MySQL2 还提供了更多的附加功能：
 
  - 更快、更好的性能
- - [支持预处理](../en/documentation/en/Prepared-Statements.md)
+ - [支持预处理](../en/Prepared-Statements.md)
  - MySQL二进制日志协议
- - [MySQL Server](../en/documentation/en/MySQL-Server.md)
+ - [MySQL Server](../en/MySQL-Server.md)
  -  对编码和排序规则有很好的支持
- - [Promise封装](../en/documentation/en/Promise-Wrapper.md)
+ - [Promise封装](../en/Promise-Wrapper.md)
  - 支持压缩
- - SSL 和 [Authentication Switch](../en/documentation/en/Authentication-Switch.md)
- - [自定义流](../en/documentation/en/Extras.md)
+ - SSL 和 [Authentication Switch](../en/Authentication-Switch.md)
+ - [自定义流](../en/Extras.md)
  - [连接池](#using-connection-pools)
 
 ## 安装
@@ -84,11 +87,11 @@ connection.query(
 
 ## SQL预处理的使用
 
-使用 MySQL2，您还可以提前准备好SQL预处理语句。 使用准备好的SQL预处理语句，MySQL 不必每次都为相同的查询做准备，这会带来更好的性能。 如果您不知道为什么它们很重要，请查看这些讨论
+使用 MySQL2，您还可以提前准备好SQL预处理语句。 使用准备好的SQL预处理语句，MySQL 不必每次都为相同的查询做准备，这会带来更好的性能。 如果您不知道为什么它们很重要，请查看这些讨论：
 
 - [如何防止预处理语句SQL注入攻击](http://stackoverflow.com/questions/8263371/how-can-prepared-statements-protect-from-sql-injection-attacks)
 
-MySQL 提供了 `execute` 辅助函数，它将准备和查询语句。 您还可以使用 `prepare` / `unprepare` 方法手动准备/取消准备。
+MySQL2 提供了 `execute` 辅助函数，它将准备和查询语句。 您还可以使用 `prepare` / `unprepare` 方法手动准备/取消准备。
 
 ```js
 // 导入模块
@@ -142,9 +145,9 @@ const pool = mysql.createPool({
 您可以像直接连接一样使用池（使用 `pool.query()` 和 `pool.execute()`）：
 ```js
 // For pool initialization, see above
-pool.query("SELECT field FROM atable", function(err, rows, fields) {
+pool.query("SELECT `field` FROM `table`", function(err, rows, fields) {
   // Connection is automatically released when query resolves
-})
+});
 ```
 
 或者，也可以手动从池中获取连接并稍后返回：
@@ -155,14 +158,12 @@ pool.getConnection(function(err, conn) {
   conn.query(/* ... */);
   // Don't forget to release the connection when finished!
   pool.releaseConnection(conn);
-})
+});
 ```
 
 ## Promise封装
 
 MySQL2 也支持 Promise API。 这与 ES7 异步等待非常有效。
-
-<!--eslint-disable-next-block-->
 ```js
 async function main() {
   // get the client
@@ -174,9 +175,7 @@ async function main() {
 }
 ```
 
-MySQL2 使用范围内可用的默认 `Promise` 对象。 但是你可以选择你想使用的 `Promise` 实现
-
-<!--eslint-disable-next-block-->
+MySQL2 使用范围内可用的默认 `Promise` 对象。 但是你可以选择你想使用的 `Promise` 实现。
 ```js
 // get the client
 const mysql = require('mysql2/promise');
@@ -191,7 +190,7 @@ const connection = await mysql.createConnection({host:'localhost', user: 'root',
 const [rows, fields] = await connection.execute('SELECT * FROM `table` WHERE `name` = ? AND `age` > ?', ['Morty', 14]);
 ```
 
-MySQL2 还在 Pools 上公开了一个 .promise()函数，因此您可以从同一个池创建一个 promise/non-promise 连接
+MySQL2 还在 Pools 上公开了一个 .promise()函数，因此您可以从同一个池创建一个 promise/non-promise 连接。
 ```js
 async function main() {
   // get the client
@@ -205,7 +204,7 @@ async function main() {
 }
 ```
 
-MySQL2 在 Connections 上公开了一个 .promise*()函数，以“升级”现有的 non-promise 连接以使用 Promise
+MySQL2 在 Connections 上公开了一个 .promise*()函数，以“升级”现有的 non-promise 连接以使用 Promise。
 ```js
 // get the client
 const mysql = require('mysql2');
@@ -229,33 +228,30 @@ con.promise().query("SELECT 1")
 
 您可以在连接级别（适用于所有查询）或查询级别（仅适用于该特定查询）启用此设置。
 
-### 连接参数
+### 连接级别
 ```js
 const con = mysql.createConnection(
   { host: 'localhost', database: 'test', user: 'root', rowsAsArray: true }
 );
-
 ```
 
-### 查询参数
-
+### 查询级别
 ```js
 con.query({ sql: 'select 1 as foo, 2 as foo', rowsAsArray: true }, function(err, results, fields) {
   console.log(results) // 返回数组而不是数组对象
   console.log(fields) // 无变化
 });
-
 ```
 
 ## API配置项
 
 MySQL2大部分的API与 [Node MySQL][node-mysql] 基本上相同，你应该查看他们的API文档来知道更多的API选项。
 
-如果您发现与 [Node MySQL][node-mysql] 的任何不兼容问题，请通过`isesue`报告。 我们将优先修复报告的不兼容问题。
+如果您发现与 [Node MySQL][node-mysql] 的任何不兼容问题，请通过`issue`报告。 我们将优先修复报告的不兼容问题。
 
 ## 文档
 
-你可以在[这里](../en/documentation/en)获得更多的详细文档，并且你应该查阅各种代码[示例](../en/examples)来获得更高级的概念。
+你可以在[这里](../en)获得更多的详细文档，并且你应该查阅各种代码[示例](../en/examples)来获得更高级的概念。
 
 ## 鸣谢
 


### PR DESCRIPTION
Pleased to translate the first part of the documentation into Portuguese (BR) 🎉

This **PR** contains the `README.md` in **portuguese (BR)**.

<hr />

In the translation process, some changes that affect all `README` (`en`, `zh-cn` and `pt-br`):

- I removed every `<!--eslint-disable-next-block-->` comment.

- Updated this line to "**MySQL2**":
  - https://github.com/sidorares/node-mysql2/blob/f930f6e0453f6ffb62f46dec40825f0bff2307a1/README.md#L91

- I have added punctuation to all sentences in the text:
  - `en`: `:`, `.`
  - `zh-cn`: `：`, `。`

- I have patterned the examples a bit by:
  - Including `;` in example variables that were missing it
  - Adding backticks to tables and columns that were missing it in query strings

- Noticed some simple errors and corrected them (like `isesue`, `everytime`, etc.).

- Added the `Array Results` to **Table of Contents** and changed in:
  - `en`
    - from `Connection Options` to `Connection Level`
    - from `Query Options` to `Query Level`
  - `zh-cn`
    - from `连接参数` to `连接级别`
    - from `查询参数` to `查询级别`
      - To update it in **Simplified Chinese** language, I just got this text from the description itself in:
        - https://github.com/sidorares/node-mysql2/blob/f930f6e0453f6ffb62f46dec40825f0bff2307a1/documentation/zh-cn/README.md#L230
        - As a precaution, I rechecked it in **DeepL Translator**, **Google Translator** and **GPT-4**
