### PR TITLE
fix: releaseConnection types and promise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import {
   Connection as PromiseConnection,
-  PoolConnection as PromisePoolConnection,
+  Pool as PromisePool,
+  PoolConnection as PromisePoolConnection2,
 } from './promise';
 
 import * as mysql from './typings/mysql';
@@ -83,7 +84,7 @@ export interface Connection extends mysql.Connection {
 }
 
 export interface PoolConnection extends mysql.PoolConnection {
-  promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
+  promise(promiseImpl?: PromiseConstructor): PromisePool;
 }
 
 export interface Pool extends mysql.Connection {
@@ -152,13 +153,14 @@ export interface Pool extends mysql.Connection {
   getConnection(
     callback: (err: NodeJS.ErrnoException, connection: PoolConnection) => any
   ): void;
+  releaseConnection(connection: PoolConnection | PromisePoolConnection2): void;
   on(event: 'connection', listener: (connection: PoolConnection) => any): this;
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
   on(event: 'release', listener: (connection: PoolConnection) => any): this;
   on(event: 'enqueue', listener: () => any): this;
   unprepare(sql: string): mysql.PrepareStatementInfo;
   prepare(sql: string, callback?: (err: mysql.QueryError | null, statement: mysql.PrepareStatementInfo) => any): mysql.Prepare;
-  promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
+  promise(promiseImpl?: PromiseConstructor): PromisePool;
   config: mysql.PoolOptions;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import {
   Connection as PromiseConnection,
   Pool as PromisePool,
-  PoolConnection as PromisePoolConnection2,
+  PoolConnection as PromisePoolConnection,
 } from './promise';
 
 import * as mysql from './typings/mysql';
@@ -153,7 +153,7 @@ export interface Pool extends mysql.Connection {
   getConnection(
     callback: (err: NodeJS.ErrnoException, connection: PoolConnection) => any
   ): void;
-  releaseConnection(connection: PoolConnection | PromisePoolConnection2): void;
+  releaseConnection(connection: PoolConnection | PromisePoolConnection): void;
   on(event: 'connection', listener: (connection: PoolConnection) => any): this;
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
   on(event: 'release', listener: (connection: PoolConnection) => any): this;

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -83,12 +83,11 @@ export interface Connection extends EventEmitter {
 }
 
 export interface PoolConnection extends Connection {
-  connection: Connection;
-  getConnection(): Promise<PoolConnection>;
   release(): void;
+  connection: Connection;
 }
 
-export interface Pool extends EventEmitter {
+export interface Pool extends EventEmitter, Connection {
   query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(
     sql: string
   ): Promise<[T, FieldPacket[]]>;
@@ -128,6 +127,7 @@ export interface Pool extends EventEmitter {
   ): Promise<[T, FieldPacket[]]>;
 
   getConnection(): Promise<PoolConnection>;
+  releaseConnection(connection: PoolConnection): void;
   on(event: 'connection', listener: (connection: PoolConnection) => any): this;
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
   on(event: 'release', listener: (connection: PoolConnection) => any): this;
@@ -138,7 +138,7 @@ export interface Pool extends EventEmitter {
   escapeId(value: string): string;
   escapeId(values: string[]): string;
   format(sql: string, values?: any | any[] | { [param: string]: any }): string;
-
+  
   pool: CorePool;
 }
 
@@ -153,4 +153,3 @@ export interface PreparedStatementInfo {
   close(): Promise<void>;
   execute(parameters: any[]): Promise<[RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader, FieldPacket[]]>;
 }
-

--- a/promise.js
+++ b/promise.js
@@ -346,6 +346,10 @@ class PromisePool extends EventEmitter {
     });
   }
 
+  releaseConnection(connection) {
+    if (connection instanceof PromisePoolConnection) connection.release();
+  }
+
   query(sql, args) {
     const corePool = this.pool;
     const localErr = new Error();

--- a/test/integration/promise-wrappers/test-promise-wrappers.js
+++ b/test/integration/promise-wrappers/test-promise-wrappers.js
@@ -207,6 +207,16 @@ function testEventsConnect() {
 
 function testBasicPool() {
   const pool = createPool(config);
+  const promiseConn = pool.getConnection();
+
+  promiseConn
+    .then(connResolved => {
+      pool.releaseConnection(connResolved);
+    })
+    .catch(err => {
+      throw err;
+    });
+
   pool
     .query('select 1+2 as ttt')
     .then(result1 => {

--- a/test/tsc-build/mysql/createPool/callbacks/connection.ts
+++ b/test/tsc-build/mysql/createPool/callbacks/connection.ts
@@ -1,0 +1,15 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+const pool = mysql.createPool(access);
+
+pool.getConnection((err, conn) => {
+	conn.connection;
+   
+   try {
+      // @ts-expect-error: The pool can't be a connection itself
+      pool.connection;
+   } catch (err) {
+      console.log('This error is expected', err);
+   }
+});

--- a/test/tsc-build/mysql/createPool/callbacks/getConnection.ts
+++ b/test/tsc-build/mysql/createPool/callbacks/getConnection.ts
@@ -1,0 +1,13 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+const pool = mysql.createPool(access);
+
+pool.getConnection((err, conn) => {
+  try {
+    // @ts-expect-error: The connection can't get another connection
+    conn.getConnection();
+  } catch (err) {
+    console.log('This error is expected', err);
+  }
+});

--- a/test/tsc-build/mysql/createPool/callbacks/release.ts
+++ b/test/tsc-build/mysql/createPool/callbacks/release.ts
@@ -1,0 +1,15 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+const pool = mysql.createPool(access);
+
+pool.getConnection((err, conn) => {
+	conn.release();
+	
+	try {
+		// @ts-expect-error: The pool isn't a connection itself, so it doesn't have the connection methods
+		pool.release();
+   } catch (err) {
+      console.log('This error is expected', err);
+   }
+});

--- a/test/tsc-build/mysql/createPool/callbacks/releaseConnection.ts
+++ b/test/tsc-build/mysql/createPool/callbacks/releaseConnection.ts
@@ -1,0 +1,8 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+const pool = mysql.createPool(access);
+
+pool.getConnection((err, conn) => {
+  pool.releaseConnection(conn);
+});

--- a/test/tsc-build/mysql/createPool/promise/connection.ts
+++ b/test/tsc-build/mysql/createPool/promise/connection.ts
@@ -1,0 +1,16 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+(async () => {
+  const pool = mysql.createPool(access);
+  const conn = await pool.promise().getConnection();
+
+  conn.connection;
+  
+  try {
+    // @ts-expect-error: The pool can't be a connection itself
+    pool.connection;
+  } catch (err) {
+    console.log('This error is expected', err);
+  }
+})();

--- a/test/tsc-build/mysql/createPool/promise/getConnection.ts
+++ b/test/tsc-build/mysql/createPool/promise/getConnection.ts
@@ -1,0 +1,14 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+(async () => {
+  const pool = mysql.createPool(access);
+  const conn = await pool.promise().getConnection();
+  
+  try {
+    // @ts-expect-error: The connection can't get another connection
+    conn.getConnection();
+  } catch (err) {
+    console.log('This error is expected', err);
+  }
+})();

--- a/test/tsc-build/mysql/createPool/promise/release.ts
+++ b/test/tsc-build/mysql/createPool/promise/release.ts
@@ -1,0 +1,16 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+(async () => {
+   const pool = mysql.createPool(access);
+   const conn = await pool.promise().getConnection();
+
+   conn.release();
+
+   try {
+		// @ts-expect-error: The pool isn't a connection itself, so it doesn't have the connection methods
+		pool.release();
+   } catch (err) {
+      console.log('This error is expected', err);
+   }
+})();

--- a/test/tsc-build/mysql/createPool/promise/releaseConnection.ts
+++ b/test/tsc-build/mysql/createPool/promise/releaseConnection.ts
@@ -1,0 +1,9 @@
+import { mysql } from '../../../index';
+import { access } from '../../baseConnection';
+
+(async () => {
+   const pool = mysql.createPool(access);
+   const conn = await pool.promise().getConnection();
+
+   pool.releaseConnection(conn);
+})();

--- a/test/tsc-build/promise/createPool/connection.ts
+++ b/test/tsc-build/promise/createPool/connection.ts
@@ -1,0 +1,16 @@
+import { mysqlp as mysql } from '../../index';
+import { access } from '../baseConnection';
+
+(async () => {
+  const pool = mysql.createPool(access);
+  const conn = await pool.getConnection();
+
+  conn.connection;
+
+  try {
+    // @ts-expect-error: The pool can't be a connection itself
+    pool.connection;
+  } catch (err) {
+    console.log('This error is expected', err);
+  }
+})();

--- a/test/tsc-build/promise/createPool/getConnection.ts
+++ b/test/tsc-build/promise/createPool/getConnection.ts
@@ -1,0 +1,16 @@
+import { mysqlp as mysql } from '../../index';
+import { access } from '../baseConnection';
+
+(async () => {
+  const pool = mysql.createPool(access);
+  const conn = await pool.getConnection();
+
+  conn.connection;
+
+  try {
+    // @ts-expect-error: The connection can't get another connection
+    conn.getConnection();
+  } catch (err) {
+    console.log('This error is expected', err);
+  }
+})();

--- a/test/tsc-build/promise/createPool/release.ts
+++ b/test/tsc-build/promise/createPool/release.ts
@@ -1,0 +1,16 @@
+import { mysqlp as mysql } from '../../index';
+import { access } from '../baseConnection';
+
+(async () => {
+  const pool = mysql.createPool(access);
+  const conn = await pool.getConnection();
+
+  conn.release();
+
+  try {
+		// @ts-expect-error: The pool isn't a connection itself, so it doesn't have the connection methods
+		pool.release();
+   } catch (err) {
+      console.log('This error is expected', err);
+   }
+})();

--- a/test/tsc-build/promise/createPool/releaseConnection.ts
+++ b/test/tsc-build/promise/createPool/releaseConnection.ts
@@ -1,0 +1,9 @@
+import { mysqlp as mysql } from '../../index';
+import { access } from '../baseConnection';
+
+(async () => {
+  const pool = mysql.createPool(access);
+  const conn = await pool.getConnection();
+
+  pool.releaseConnection(conn);
+})();

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -61,6 +61,8 @@ declare class Pool extends EventEmitter {
 
     getConnection(callback: (err: NodeJS.ErrnoException | null, connection: PoolConnection) => any): void;
 
+    releaseConnection(connection: PoolConnection): void;
+
     query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
     query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(sql: string, values: any | any[] | { [param: string]: any }, callback?: (err: Query.QueryError | null, result: T, fields: FieldPacket[]) => any): Query;
     query<T extends RowDataPacket[][] | RowDataPacket[] | OkPacket | OkPacket[] | ResultSetHeader>(options: Query.QueryOptions, callback?: (err: Query.QueryError | null, result: T, fields?: FieldPacket[]) => any): Query;


### PR DESCRIPTION
This fixes the #1761 and #1563.

<hr />

### JS

The [promise.js](https://github.com/sidorares/node-mysql2/blob/f930f6e0453f6ffb62f46dec40825f0bff2307a1/promise.js) didn't have the method `releaseConnection`.

Instead of creating from scratch, I just "extended" it from the `release` method:

```js
releaseConnection(connection) {
  if (connection instanceof PromisePoolConnection) connection.release();
}
```

Then, I added the test to [test/integration/promise-wrappers/test-promise-wrappers.js](https://github.com/sidorares/node-mysql2/compare/master...wellwelwel:node-mysql2:release-connection#diff-5b7f569fa112eba31069c6d57e2a1958dd38979a02880434a4f0b02057dac748).

<hr />

### TS

I had to fix a few wrong types before to fix the `releaseConnection`.

Before this **PR**, according by typings, this should be possible:

```js
await (await (await pool.getConnection()).getConnection()).getConnection();
// To infinity and beyond... 😵‍💫
```

So, I fixed it to only `Pool` have the method `getConnection`.

- At this time, I added "negative" tests in `tsc-build` to ensure that the above code doesn't occur again.

<hr />

Lastly, I added some tests for each method that I changed something in types:

- `releaseConnection`
- `release`
- `getConnection`
- `connection`