### PR TITLE
fix: handle prepare response when number of fields in the prepare header does not match the actual number in the response

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -38,12 +38,12 @@ jobs:
         include:
           # 20.x 
           - node-version: "20.x"
-            mysql-version: "mysql:8.0.18"
+            mysql-version: "mysql:8.0.33"
             use-compression: 1
             use-tls: 0
             use-builtin-test-runner: 1
           - node-version: "20.x"
-            mysql-version: "mysql:8.0.18"
+            mysql-version: "mysql:8.0.33"
             use-compression: 0
             use-tls: 1
             use-builtin-test-runner: 1

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -41,10 +41,12 @@ jobs:
             mysql-version: "mysql:8.0.18"
             use-compression: 1
             use-tls: 0
+            use-builtin-test-runner: 1
           - node-version: "20.x"
             mysql-version: "mysql:8.0.18"
             use-compression: 0
             use-tls: 1
+            use-builtin-test-runner: 1
 
           # 18.x
           # - node-version: "18.x"
@@ -112,6 +114,10 @@ jobs:
 
       - name: Run tests
         run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run coverage-test
+
+      - name: Run tests with built-in node test runner
+        if: ${{ matrix.use-builtin-test-runner }}
+        run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run test:builtin-node-runner
 
       - run: echo "coverage-artifact-name=`echo -n "${{github.run_id}}-${{ matrix.node-version }}-${{ matrix.mysql-version }}-{${{ matrix.mysql_connection_url_key }}-${{matrix.use-tls}}-${{matrix.use-compression}}" | shasum | cut -d " " -f 1`"  >> $GITHUB_ENV   
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        mysql-version: ["mysql:8.0.18", "mysql:8.0.22", "mysql:5.7"]
+        mysql-version: ["mysql:8.0.18", "mysql:8.0.22", "mysql:8.0.33", "mysql:5.7"]
         use-compression: [0]
         use-tls: [0]
         mysql_connection_url_key: [""]

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -159,9 +159,8 @@ class Connection extends EventEmitter {
   }
 
   _addCommandClosedState(cmd) {
-    console.trace();
     const err = new Error(
-      "Can't add new command when connection is in closed state", cmd
+      "Can't add new command when connection is in closed state"
     );
     err.fatal = true;
     if (cmd.onResult) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -159,8 +159,9 @@ class Connection extends EventEmitter {
   }
 
   _addCommandClosedState(cmd) {
+    console.trace();
     const err = new Error(
-      "Can't add new command when connection is in closed state"
+      "Can't add new command when connection is in closed state", cmd
     );
     err.fatal = true;
     if (cmd.onResult) {
@@ -487,14 +488,23 @@ class Connection extends EventEmitter {
       }
       this._bumpSequenceId(packet.numPackets);
     }
-    const done = this._command.execute(packet, this);
-    if (done) {
-      this._command = this._commands.shift();
-      if (this._command) {
-        this.sequenceId = 0;
-        this.compressedSequenceId = 0;
-        this.handlePacket();
+    try {
+      if (this._fatalError) {
+        // skip remaining packets after client is in the error state
+        return;
       }
+      const done = this._command.execute(packet, this);
+      if (done) {
+        this._command = this._commands.shift();
+        if (this._command) {
+          this.sequenceId = 0;
+          this.compressedSequenceId = 0;
+          this.handlePacket();
+        }
+      }
+    } catch (err) {
+      this._handleFatalError(err);
+      this.stream.destroy();
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:code": "eslint index.js promise.js \"lib/**/*.js\" \"test/**/*.js\" \"benchmarks/**/*.js\"",
     "lint:docs": "eslint Contributing.md README.md \"documentation/**/*.md\" \"examples/*.js\"",
     "test": "node ./test/run.js",
-    "test-node-runner": "node --test test/builtin-runner",
+    "test:builtin-node-runner": "node --test test/builtin-runner",
     "test:tsc-build": "cd \"test/tsc-build\" && npx tsc -p \"tsconfig.json\"",
     "coverage-test": "c8 -r cobertura -r lcov -r text node ./test/run.js",
     "benchmark": "node ./benchmarks/benchmark.js",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint:code": "eslint index.js promise.js \"lib/**/*.js\" \"test/**/*.js\" \"benchmarks/**/*.js\"",
     "lint:docs": "eslint Contributing.md README.md \"documentation/**/*.md\" \"examples/*.js\"",
     "test": "node ./test/run.js",
+    "test-node-runner": "node --test test/builtin-runner",
     "test:tsc-build": "cd \"test/tsc-build\" && npx tsc -p \"tsconfig.json\"",
     "coverage-test": "c8 -r cobertura -r lcov -r text node ./test/run.js",
     "benchmark": "node ./benchmarks/benchmark.js",

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import common from '../../../test/common.js';
 
-describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metadata_follows is unset', () => {
+describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metadata_follows is unset', { timeout: 1000 }, () => {
   it('should not throw an exception', (t, done) => {
     const connection = common.createConnection({
       database: 'mysql',

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -4,6 +4,7 @@ import common from '../../../test/common.js';
 
 describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metadata_follows is unset', () => {
   it('should not throw an exception', (t, done) => {
+    /*
     const connection = common.createConnection({
       database: 'mysql',
     });
@@ -19,7 +20,15 @@ describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metad
           connection.end();
         }
         done(err);
+      } else {
+        done(null);
       }
     });
+    */
+    console.log('test1')
+    setTimeout(() => {
+      console.log('test2')
+      done(null);
+    }, 1000);
   });
 });

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import common from '../../../test/common.js';
+
+describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metadata_follows is unset', () =>  {
+  it('should not throw an exception', (t, done) => {
+    assert(true);
+    done(null);
+    /*
+    const connection = common.createConnection({
+      database: 'mysql',
+    });
+
+    connection.on('error', (err) => {
+      done(err);
+    });
+
+    connection.prepare('select * from user order by ?', (err, stmt) => {
+      console.log(err);
+      if (err) {
+        if (!err.fatal) {
+          connection.end();
+        }
+        done(err);
+      }
+    });
+    */
+  });
+});

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -25,9 +25,7 @@ describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metad
       }
     });
     */
-    const connection = common.createConnection({
-      database: 'mysql',
-    });
+    const connection = common.createConnection();
     connection.on('error', (err) => {
       console.log('Error connecting to mysql', err);
       done(err);

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -25,10 +25,17 @@ describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metad
       }
     });
     */
-    console.log('test1')
-    setTimeout(() => {
-      console.log('test2')
+    const connection = common.createConnection({
+      database: 'mysql',
+    });
+    connection.on('error', (err) => {
+      console.log('Error connecting to mysql', err);
+      done(err);
+    });
+    connection.on('connect', () => {
+      console.log('Connected!')
       done(null);
-    }, 1000);
+    });
+
   });
 });

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -4,7 +4,6 @@ import common from '../../../test/common.js';
 
 describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metadata_follows is unset', () => {
   it('should not throw an exception', (t, done) => {
-    /*
     const connection = common.createConnection({
       database: 'mysql',
     });
@@ -21,19 +20,8 @@ describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metad
         }
         done(err);
       } else {
-        done(null);
+        connection.end(done);
       }
     });
-    */
-    const connection = common.createConnection();
-    connection.on('error', (err) => {
-      console.log('Error connecting to mysql', err);
-      done(err);
-    });
-    connection.on('connect', () => {
-      console.log('Connected!')
-      done(null);
-    });
-
   });
 });

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -2,11 +2,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert';
 import common from '../../../test/common.js';
 
-describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metadata_follows is unset', () =>  {
+describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metadata_follows is unset', () => {
   it('should not throw an exception', (t, done) => {
-    assert(true);
-    done(null);
-    /*
     const connection = common.createConnection({
       database: 'mysql',
     });
@@ -24,6 +21,5 @@ describe('Prepare result when CLIENT_OPTIONAL_RESULTSET_METADATA is set or metad
         done(err);
       }
     });
-    */
   });
 });


### PR DESCRIPTION
ref: #2052 

*Update*: main reason for the #2052 is not the medatdata_follows flag and/or missing parameters. The issue is caused by prepare header returning number of placeholders in the query ( 1 for `select * from user order by ?` ) but the actual number of parameters following the header is 0 - see https://github.com/sidorares/node-mysql2/issues/2052#issuecomment-1620318928. Changing the scope of this PR to handle "ignored" parameters / columns

------

Context: we currently expect that prepare response has exactly num fields + num parameters ColumnnDefinition packets in the response. However ether of them could be skipped by the server even when num fields is > 0 and/or num parameters > 0.

See https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html

> if num_params > 0 and CLIENT_OPTIONAL_RESULTSET_METADATA is not set or if medatdata_follows is RESULTSET_METADATA_FULL num_params packets will follow. Then a [EOF_Packet](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_eof_packet.html) will be transmitted, provided that CLIENT_DEPRECATE_EOF is not set.

 - [x] allow to handle exception from test example in #2043
 - [x] I plan to gradually switch to a built in node test runner. Add a setup to run new tests in node v20 using [built in runner](https://nodejs.org/api/test.html)
 - [ ] add a unit test (initially failing)

Descoping:
 - [ ] parse `metadata_follows` in COM_STMT_PREPARE_OK packet deserealisation
 - [ ] expect possible EOF packet where we currently read ColumnDefinition based on `OPTIONAL_RESULTSET_METADATA ` / `DEPRECATE_EOF` connection flags and metadata_follows COM_STMT_PREPARE_OK packet
 - [ ] verify that empty parameters / fields array does not break rest of the "execute PS" logic. For example, we currently might fail `.execute()` call if expected and actual number of parameters do not match. In that case 2 options: store them separately ( reported number of parameters and array of deserialised parameter metadata ( could be empty ) OR fill array with default / unknown metadata.