### PR TITLE
fix: createPool promise as PromisePool

### DIFF
--- a/test/tsc-build/mysql/createPool/promise/promise.ts
+++ b/test/tsc-build/mysql/createPool/promise/promise.ts
@@ -1,0 +1,16 @@
+import { mysql, mysqlp } from '../../../index';
+import { access } from '../../baseConnection';
+
+(async () => {
+   let pool: mysql.Pool | null = null;
+   let promisePool: mysqlp.Pool | null = null;
+   let conn: mysqlp.PoolConnection | null = null;
+
+   if (pool === null) return;
+
+   pool = mysql.createPool(access);
+   promisePool = pool.promise();
+   conn = await promisePool.getConnection();
+
+   conn.release();
+})();

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -4,7 +4,7 @@ import {OkPacket, RowDataPacket, FieldPacket, ResultSetHeader} from './protocol/
 import Connection = require('./Connection');
 import PoolConnection = require('./PoolConnection');
 import {EventEmitter} from 'events';
-import {PoolConnection as PromisePoolConnection} from '../../../promise';
+import {Pool as PromisePool} from '../../../promise';
 
 declare namespace Pool {
 
@@ -78,7 +78,7 @@ declare class Pool extends EventEmitter {
     on(event: string, listener: Function): this;
     on(event: 'connection', listener: (connection: PoolConnection) => any): this;
 
-    promise(promiseImpl?: PromiseConstructor): PromisePoolConnection;
+    promise(promiseImpl?: PromiseConstructor): PromisePool;
 }
 
 export = Pool;


### PR DESCRIPTION
Fixes the issue #2059.

<hr />

Before this **PR**, the `.promise()` typing tests started from `.promise()['any_tested_method']`, but the `.promise()` itself was not tested.

#### Credit:
- This test was based on the the code from https://github.com/sidorares/node-mysql2/issues/2059#issuecomment-1587924922 by @matvejs16.