### PR TITLE
fix:  typings

### DIFF
--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -11,12 +11,6 @@ import { ExecutableBase } from './protocol/sequences/ExecutableBase.js';
 
 export interface PoolOptions extends ConnectionOptions {
   /**
-   * The milliseconds before a timeout occurs during the connection acquisition. This is slightly different from connectTimeout,
-   * because acquiring a pool connection does not always involve making a connection. (Default: 10 seconds)
-   */
-  acquireTimeout?: number;
-
-  /**
    * Determines the pool's action when no connections are available and the limit has been reached. If true, the pool will queue
    * the connection request and call it when one becomes available. If false, the pool will immediately call back with an error.
    * (Default: true)


### PR DESCRIPTION
`acquireTimeout` exists only on this one place in repo and when I tried to use it, it was only complaining with deprecation warning that such parameter does not exist and in future versions it will be an error.

As it's not being used anywhere else in the actual code I think it can be safely removed from the TS types as well.