### PR TITLE
fix: create ProcedureCallPacket typings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -46,6 +46,7 @@
       "rules": {
         "@typescript-eslint/no-empty-interface": "off",
         "@typescript-eslint/no-explicit-any": "off",
+        "arrow-parens": "off",
         "no-restricted-syntax": [
           "error",
           {

--- a/test/tsc-build/helpers.ts
+++ b/test/tsc-build/helpers.ts
@@ -1,0 +1,37 @@
+import { mysql, mysqlp } from './index.js';
+
+export const isResultSetHeader = (
+  data: unknown
+): data is mysql.ResultSetHeader | mysqlp.ResultSetHeader => {
+  if (!data || typeof data !== 'object') return false;
+
+  const keys = [
+    'fieldCount',
+    'affectedRows',
+    'insertId',
+    'info',
+    'serverStatus',
+    'warningStatus',
+  ];
+
+  return keys.every((key) => key in data);
+};
+
+export const isOkPacket = (
+  data: unknown
+): data is mysql.OkPacket | mysqlp.OkPacket => {
+  if (!data || typeof data !== 'object') return false;
+
+  const keys = [
+    'fieldCount',
+    'affectedRows',
+    'changedRows',
+    'insertId',
+    'serverStatus',
+    'warningCount',
+    'message',
+    'procotol41',
+  ];
+
+  return keys.every((key) => key in data);
+};

--- a/test/tsc-build/strict-checks/ProcedureCallPacket.ts
+++ b/test/tsc-build/strict-checks/ProcedureCallPacket.ts
@@ -173,14 +173,14 @@ const procedureCall = {
 
   // Checking `ResultSetHeader | OkPacket | OkPacket[]` Procedure Calls
   {
-    await conn.query(dropProcedure.select);
-    await conn.query(createProcedure.select);
+    await conn.query(dropProcedure.update);
+    await conn.query(createProcedure.update);
 
     const [procedureResult] = await conn.query<
       mysqlp.ProcedureCallPacket<
         mysqlp.ResultSetHeader | mysqlp.OkPacket | mysqlp.OkPacket[]
       >
-    >(procedureCall.select, []);
+    >(procedureCall.update, []);
 
     // Strict checking the `ResultSetHeader`
     const resultSetHeader: mysqlp.ResultSetHeader = procedureResult;

--- a/test/tsc-build/strict-checks/ProcedureCallPacket.ts
+++ b/test/tsc-build/strict-checks/ProcedureCallPacket.ts
@@ -1,0 +1,189 @@
+import { mysql, mysqlp } from '../index.js';
+import { access } from '../mysql/baseConnection.js';
+import { isResultSetHeader } from '../helpers.js';
+
+const dropProcedure = {
+  select: 'DROP PROCEDURE IF EXISTS selectProcedure',
+  update: 'DROP PROCEDURE IF EXISTS updateProcedure',
+};
+
+const createProcedure = {
+  select: `
+    CREATE PROCEDURE selectProcedure()
+    BEGIN
+      SELECT 1 as id;
+    END
+  `,
+  update: `
+    CREATE PROCEDURE updateProcedure()
+    BEGIN
+      SET @a = 1;
+    END
+  `,
+};
+
+const procedureCall = {
+  select: 'CALL selectProcedure()',
+  update: 'CALL updateProcedure()',
+};
+
+// Callback
+(() => {
+  interface User extends mysql.RowDataPacket {
+    id: number;
+  }
+
+  const conn = mysql.createConnection(access);
+  const connAsRow = mysql.createConnection({ ...access, rowsAsArray: true });
+
+  // Checking `RowDataPacket[]` Procedure Calls
+  conn.query(dropProcedure.select, () => {
+    conn.query(createProcedure.select, () => {
+      conn.query<mysql.ProcedureCallPacket<User[]>>(
+        procedureCall.select,
+        [],
+        (_err, procedureResult) => {
+          procedureResult.forEach((results) => {
+            if (isResultSetHeader(results)) {
+              console.log(results);
+
+              return;
+            }
+
+            // Strict checking the `RowDataPacket[]`
+            const user: User = results;
+            const id: number = user.id;
+
+            console.log(id);
+          });
+        }
+      );
+    });
+  });
+
+  // Checking `RowDataPacket[][]` Procedure Calls
+  connAsRow.query(dropProcedure.select, () => {
+    connAsRow.query(createProcedure.select, () => {
+      connAsRow.query<mysql.ProcedureCallPacket<User[][]>>(
+        procedureCall.select,
+        [],
+        (_err, procedureResult) => {
+          procedureResult.forEach((results) => {
+            if (isResultSetHeader(results)) {
+              console.log(results);
+
+              return;
+            }
+
+            // Strict checking the `RowDataPacket[][]`
+            const users: User[] = results;
+
+            users.forEach((user) => {
+              const id: number = user.id;
+
+              console.log(id);
+            });
+          });
+        }
+      );
+    });
+  });
+
+  // Checking `ResultSetHeader | OkPacket | OkPacket[]` Procedure Calls
+  conn.query(dropProcedure.update, () => {
+    conn.query(createProcedure.update, () => {
+      conn.query<
+        mysql.ProcedureCallPacket<
+          mysql.ResultSetHeader | mysql.OkPacket | mysql.OkPacket[]
+        >
+      >(
+        procedureCall.update,
+        [],
+        // Strict checking the `ResultSetHeader`
+        (_err, procedureResult: mysql.ResultSetHeader) => {
+          console.log(procedureResult);
+        }
+      );
+    });
+  });
+})();
+
+// Promise
+(async () => {
+  interface User extends mysqlp.RowDataPacket {
+    id: number;
+  }
+
+  const conn = await mysqlp.createConnection(access);
+  const connAsRow = await mysqlp.createConnection({
+    ...access,
+    rowsAsArray: true,
+  });
+
+  // Checking `RowDataPacket[]` Procedure Calls
+  {
+    await conn.query(dropProcedure.select);
+    await conn.query(createProcedure.select);
+
+    const [procedureResult] = await conn.query<
+      mysqlp.ProcedureCallPacket<User[]>
+    >(procedureCall.select, []);
+
+    procedureResult.forEach((results) => {
+      if (isResultSetHeader(results)) {
+        console.log(results);
+
+        return;
+      }
+
+      // Strict checking the `RowDataPacket[]`
+      const user: User = results;
+      const id: number = user.id;
+
+      console.log(id);
+    });
+  }
+
+  // Checking `RowDataPacket[][]` Procedure Calls
+  {
+    await connAsRow.query(dropProcedure.select);
+    await connAsRow.query(createProcedure.select);
+
+    const [procedureResult] = await connAsRow.query<
+      mysqlp.ProcedureCallPacket<User[][]>
+    >(procedureCall.select, []);
+
+    procedureResult.forEach((results) => {
+      if (isResultSetHeader(results)) {
+        console.log(results);
+
+        return;
+      }
+
+      // Strict checking the `RowDataPacket[][]`
+      const users: User[] = results;
+
+      users.forEach((user) => {
+        const id: number = user.id;
+
+        console.log(id);
+      });
+    });
+  }
+
+  // Checking `ResultSetHeader | OkPacket | OkPacket[]` Procedure Calls
+  {
+    await conn.query(dropProcedure.select);
+    await conn.query(createProcedure.select);
+
+    const [procedureResult] = await conn.query<
+      mysqlp.ProcedureCallPacket<
+        mysqlp.ResultSetHeader | mysqlp.OkPacket | mysqlp.OkPacket[]
+      >
+    >(procedureCall.select, []);
+
+    // Strict checking the `ResultSetHeader`
+    const resultSetHeader: mysqlp.ResultSetHeader = procedureResult;
+    console.log(resultSetHeader);
+  }
+})();

--- a/test/tsc-build/strict-checks/execute.ts
+++ b/test/tsc-build/strict-checks/execute.ts
@@ -49,6 +49,48 @@ import { access, sql } from '../promise/baseConnection.js';
 
     console.log(err, result, fields);
   });
+
+  conn.execute<mysql.ProcedureCallPacket>(sql, (_e, _r, _f) => {
+    const err: mysql.QueryError | null = _e;
+    const result: mysql.ProcedureCallPacket = _r;
+    const fields: mysql.FieldPacket[] = _f;
+
+    console.log(err, result, fields);
+  });
+
+  conn.execute<mysql.ProcedureCallPacket<mysql.RowDataPacket[]>>(
+    sql,
+    (_e, _r, _f) => {
+      const err: mysql.QueryError | null = _e;
+      const result: [...mysqlp.RowDataPacket[], mysql.ResultSetHeader] = _r;
+      const fields: mysql.FieldPacket[] = _f;
+
+      console.log(err, result, fields);
+    }
+  );
+
+  conn.execute<mysql.ProcedureCallPacket<mysql.RowDataPacket[][]>>(
+    sql,
+    (_e, _r, _f) => {
+      const err: mysql.QueryError | null = _e;
+      const result: [...mysqlp.RowDataPacket[][], mysql.ResultSetHeader] = _r;
+      const fields: mysql.FieldPacket[] = _f;
+
+      console.log(err, result, fields);
+    }
+  );
+
+  conn.execute<
+    mysql.ProcedureCallPacket<
+      mysql.OkPacket | mysql.OkPacket[] | mysql.ResultSetHeader
+    >
+  >(sql, (_e, _r, _f) => {
+    const err: mysql.QueryError | null = _e;
+    const result: mysql.ResultSetHeader = _r;
+    const fields: mysql.FieldPacket[] = _f;
+
+    console.log(err, result, fields);
+  });
 }
 
 // Promise
@@ -89,4 +131,42 @@ import { access, sql } from '../promise/baseConnection.js';
 
     console.log(result, fields);
   });
+
+  conn.execute<mysqlp.ProcedureCallPacket>(sql).then(([_r, _f]) => {
+    const result: mysqlp.ProcedureCallPacket = _r;
+    const fields: mysqlp.FieldPacket[] = _f;
+
+    console.log(result, fields);
+  });
+
+  conn
+    .execute<mysqlp.ProcedureCallPacket<mysqlp.RowDataPacket[]>>(sql)
+    .then(([_r, _f]) => {
+      const result: [...mysqlp.RowDataPacket[], mysql.ResultSetHeader] = _r;
+      const fields: mysqlp.FieldPacket[] = _f;
+
+      console.log(result, fields);
+    });
+
+  conn
+    .execute<mysqlp.ProcedureCallPacket<mysqlp.RowDataPacket[][]>>(sql)
+    .then(([_r, _f]) => {
+      const result: [...mysqlp.RowDataPacket[][], mysql.ResultSetHeader] = _r;
+      const fields: mysqlp.FieldPacket[] = _f;
+
+      console.log(result, fields);
+    });
+
+  conn
+    .execute<
+      mysqlp.ProcedureCallPacket<
+        mysqlp.OkPacket | mysqlp.OkPacket[] | mysqlp.ResultSetHeader
+      >
+    >(sql)
+    .then(([_r, _f]) => {
+      const result: mysqlp.ResultSetHeader = _r;
+      const fields: mysqlp.FieldPacket[] = _f;
+
+      console.log(result, fields);
+    });
 })();

--- a/test/tsc-build/strict-checks/query.ts
+++ b/test/tsc-build/strict-checks/query.ts
@@ -49,6 +49,48 @@ import { access, sql } from '../promise/baseConnection.js';
 
     console.log(err, result, fields);
   });
+
+  conn.query<mysql.ProcedureCallPacket>(sql, (_e, _r, _f) => {
+    const err: mysql.QueryError | null = _e;
+    const result: mysql.ProcedureCallPacket = _r;
+    const fields: mysql.FieldPacket[] = _f;
+
+    console.log(err, result, fields);
+  });
+
+  conn.query<mysql.ProcedureCallPacket<mysql.RowDataPacket[]>>(
+    sql,
+    (_e, _r, _f) => {
+      const err: mysql.QueryError | null = _e;
+      const result: [...mysqlp.RowDataPacket[], mysql.ResultSetHeader] = _r;
+      const fields: mysql.FieldPacket[] = _f;
+
+      console.log(err, result, fields);
+    }
+  );
+
+  conn.query<mysql.ProcedureCallPacket<mysql.RowDataPacket[][]>>(
+    sql,
+    (_e, _r, _f) => {
+      const err: mysql.QueryError | null = _e;
+      const result: [...mysqlp.RowDataPacket[][], mysql.ResultSetHeader] = _r;
+      const fields: mysql.FieldPacket[] = _f;
+
+      console.log(err, result, fields);
+    }
+  );
+
+  conn.query<
+    mysql.ProcedureCallPacket<
+      mysql.OkPacket | mysql.OkPacket[] | mysql.ResultSetHeader
+    >
+  >(sql, (_e, _r, _f) => {
+    const err: mysql.QueryError | null = _e;
+    const result: mysql.ResultSetHeader = _r;
+    const fields: mysql.FieldPacket[] = _f;
+
+    console.log(err, result, fields);
+  });
 }
 
 // Promise
@@ -89,4 +131,42 @@ import { access, sql } from '../promise/baseConnection.js';
 
     console.log(result, fields);
   });
+
+  conn.query<mysqlp.ProcedureCallPacket>(sql).then(([_r, _f]) => {
+    const result: mysqlp.ProcedureCallPacket = _r;
+    const fields: mysqlp.FieldPacket[] = _f;
+
+    console.log(result, fields);
+  });
+
+  conn
+    .query<mysqlp.ProcedureCallPacket<mysqlp.RowDataPacket[]>>(sql)
+    .then(([_r, _f]) => {
+      const result: [...mysqlp.RowDataPacket[], mysql.ResultSetHeader] = _r;
+      const fields: mysqlp.FieldPacket[] = _f;
+
+      console.log(result, fields);
+    });
+
+  conn
+    .query<mysqlp.ProcedureCallPacket<mysqlp.RowDataPacket[][]>>(sql)
+    .then(([_r, _f]) => {
+      const result: [...mysqlp.RowDataPacket[][], mysql.ResultSetHeader] = _r;
+      const fields: mysqlp.FieldPacket[] = _f;
+
+      console.log(result, fields);
+    });
+
+  conn
+    .query<
+      mysqlp.ProcedureCallPacket<
+        mysqlp.OkPacket | mysqlp.OkPacket[] | mysqlp.ResultSetHeader
+      >
+    >(sql)
+    .then(([_r, _f]) => {
+      const result: mysqlp.ResultSetHeader = _r;
+      const fields: mysqlp.FieldPacket[] = _f;
+
+      console.log(result, fields);
+    });
 })();

--- a/test/tsc-build/tsconfig.json
+++ b/test/tsc-build/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["index.ts", "mysql", "promise"],
+  "include": ["index.ts", "helpers.ts", "mysql", "promise"],
   "compilerOptions": {
     "target": "ES2016",
     "module": "CommonJS",

--- a/typings/mysql/lib/protocol/packets/ProcedurePacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/ProcedurePacket.d.ts
@@ -3,17 +3,16 @@ import { ResultSetHeader } from './ResultSetHeader.js';
 import { RowDataPacket } from './RowDataPacket.js';
 
 declare type ProcedureCallPacket<
-  T extends
-    | OkPacket
-    | ResultSetHeader
-    | RowDataPacket[]
-    | RowDataPacket[][]
-    | OkPacket[] =
-    | OkPacket
-    | ResultSetHeader
-    | RowDataPacket[]
-    | RowDataPacket[][]
-    | OkPacket[]
-> = [T, ResultSetHeader];
+  T = RowDataPacket[] | RowDataPacket[][] | ResultSetHeader
+> = T extends RowDataPacket[]
+  ? [...T, ResultSetHeader]
+  : T extends RowDataPacket[][]
+  ? [...T, ResultSetHeader]
+  : T extends ResultSetHeader | OkPacket | OkPacket[]
+  ? ResultSetHeader
+  :
+      | [...RowDataPacket[], ResultSetHeader]
+      | [...RowDataPacket[][], ResultSetHeader]
+      | ResultSetHeader;
 
 export { ProcedureCallPacket };

--- a/typings/mysql/lib/protocol/packets/ProcedurePacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/ProcedurePacket.d.ts
@@ -1,0 +1,19 @@
+import { OkPacket } from './OkPacket.js';
+import { ResultSetHeader } from './ResultSetHeader.js';
+import { RowDataPacket } from './RowDataPacket.js';
+
+declare type ProcedureCallPacket<
+  T extends
+    | OkPacket
+    | ResultSetHeader
+    | RowDataPacket[]
+    | RowDataPacket[][]
+    | OkPacket[] =
+    | OkPacket
+    | ResultSetHeader
+    | RowDataPacket[]
+    | RowDataPacket[][]
+    | OkPacket[]
+> = [T, ResultSetHeader];
+
+export { ProcedureCallPacket };

--- a/typings/mysql/lib/protocol/packets/index.d.ts
+++ b/typings/mysql/lib/protocol/packets/index.d.ts
@@ -2,6 +2,7 @@ import { OkPacket } from './OkPacket.js';
 import { RowDataPacket } from './RowDataPacket.js';
 import { FieldPacket } from './FieldPacket.js';
 import { Field } from './Field.js';
+import { ProcedureCallPacket } from './ProcedurePacket.js';
 import { ResultSetHeader } from './ResultSetHeader.js';
 import { OkPacketParams } from './params/OkPacketParams.js';
 import { ErrorPacketParams } from './params/ErrorPacketParams.js';
@@ -11,6 +12,7 @@ export {
   RowDataPacket,
   FieldPacket,
   Field,
+  ProcedureCallPacket,
   ResultSetHeader,
   OkPacketParams,
   ErrorPacketParams,

--- a/typings/mysql/lib/protocol/sequences/ExecutableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/ExecutableBase.d.ts
@@ -3,6 +3,7 @@ import {
   FieldPacket,
   RowDataPacket,
   ResultSetHeader,
+  ProcedureCallPacket,
 } from '../packets/index.js';
 import {
   Query,
@@ -10,6 +11,7 @@ import {
   QueryOptions,
   QueryableConstructor,
 } from './Query.js';
+
 export declare function ExecutableBase<T extends QueryableConstructor>(
   Base?: T
 ): {
@@ -21,6 +23,7 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       sql: string,
       callback?:
@@ -28,44 +31,47 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
         | undefined
     ): Query;
     execute<
-      T_1 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       sql: string,
       values: any,
       callback?:
-        | ((err: QueryError | null, result: T_1, fields: FieldPacket[]) => any)
+        | ((err: QueryError | null, result: T, fields: FieldPacket[]) => any)
         | undefined
     ): Query;
     execute<
-      T_2 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       options: QueryOptions,
       callback?:
-        | ((err: QueryError | null, result: T_2, fields?: FieldPacket[]) => any)
+        | ((err: QueryError | null, result: T, fields?: FieldPacket[]) => any)
         | undefined
     ): Query;
     execute<
-      T_3 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       options: QueryOptions,
       values: any,
       callback?:
-        | ((err: QueryError | null, result: T_3, fields: FieldPacket[]) => any)
+        | ((err: QueryError | null, result: T, fields: FieldPacket[]) => any)
         | undefined
     ): Query;
   };

--- a/typings/mysql/lib/protocol/sequences/QueryableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/QueryableBase.d.ts
@@ -3,6 +3,7 @@ import {
   FieldPacket,
   RowDataPacket,
   ResultSetHeader,
+  ProcedureCallPacket,
 } from '../packets/index.js';
 import {
   Query,
@@ -10,6 +11,7 @@ import {
   QueryOptions,
   QueryableConstructor,
 } from './Query.js';
+
 export declare function QueryableBase<T extends QueryableConstructor>(
   Base?: T
 ): {
@@ -21,6 +23,7 @@ export declare function QueryableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       sql: string,
       callback?:
@@ -28,44 +31,47 @@ export declare function QueryableBase<T extends QueryableConstructor>(
         | undefined
     ): Query;
     query<
-      T_1 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       sql: string,
       values: any,
       callback?:
-        | ((err: QueryError | null, result: T_1, fields: FieldPacket[]) => any)
+        | ((err: QueryError | null, result: T, fields: FieldPacket[]) => any)
         | undefined
     ): Query;
     query<
-      T_2 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       options: QueryOptions,
       callback?:
-        | ((err: QueryError | null, result: T_2, fields?: FieldPacket[]) => any)
+        | ((err: QueryError | null, result: T, fields?: FieldPacket[]) => any)
         | undefined
     ): Query;
     query<
-      T_3 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       options: QueryOptions,
       values: any,
       callback?:
-        | ((err: QueryError | null, result: T_3, fields: FieldPacket[]) => any)
+        | ((err: QueryError | null, result: T, fields: FieldPacket[]) => any)
         | undefined
     ): Query;
   };

--- a/typings/mysql/lib/protocol/sequences/promise/ExecutableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/promise/ExecutableBase.d.ts
@@ -3,6 +3,7 @@ import {
   FieldPacket,
   RowDataPacket,
   ResultSetHeader,
+  ProcedureCallPacket,
 } from '../../packets/index.js';
 import { QueryOptions, QueryableConstructor } from '../Query.js';
 
@@ -17,6 +18,7 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       sql: string
     ): Promise<[T, FieldPacket[]]>;
@@ -27,6 +29,7 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       sql: string,
       values: any
@@ -38,6 +41,7 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       options: QueryOptions
     ): Promise<[T_2, FieldPacket[]]>;
@@ -48,6 +52,7 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket
     >(
       options: QueryOptions,
       values: any

--- a/typings/mysql/lib/protocol/sequences/promise/ExecutableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/promise/ExecutableBase.d.ts
@@ -23,7 +23,7 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
       sql: string
     ): Promise<[T, FieldPacket[]]>;
     execute<
-      T_1 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
@@ -33,9 +33,9 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
     >(
       sql: string,
       values: any
-    ): Promise<[T_1, FieldPacket[]]>;
+    ): Promise<[T, FieldPacket[]]>;
     execute<
-      T_2 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
@@ -44,9 +44,9 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
         | ProcedureCallPacket
     >(
       options: QueryOptions
-    ): Promise<[T_2, FieldPacket[]]>;
+    ): Promise<[T, FieldPacket[]]>;
     execute<
-      T_3 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
@@ -56,6 +56,6 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
     >(
       options: QueryOptions,
       values: any
-    ): Promise<[T_3, FieldPacket[]]>;
+    ): Promise<[T, FieldPacket[]]>;
   };
 } & T;

--- a/typings/mysql/lib/protocol/sequences/promise/QueryableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/promise/QueryableBase.d.ts
@@ -18,13 +18,7 @@ export declare function QueryableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
-        | ProcedureCallPacket<
-            | OkPacket
-            | ResultSetHeader
-            | RowDataPacket[]
-            | RowDataPacket[][]
-            | OkPacket[]
-          >
+        | ProcedureCallPacket
     >(
       sql: string
     ): Promise<[T, FieldPacket[]]>;
@@ -35,13 +29,7 @@ export declare function QueryableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
-        | ProcedureCallPacket<
-            | OkPacket
-            | ResultSetHeader
-            | RowDataPacket[]
-            | RowDataPacket[][]
-            | OkPacket[]
-          >
+        | ProcedureCallPacket
     >(
       sql: string,
       values: any
@@ -53,13 +41,7 @@ export declare function QueryableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
-        | ProcedureCallPacket<
-            | OkPacket
-            | ResultSetHeader
-            | RowDataPacket[]
-            | RowDataPacket[][]
-            | OkPacket[]
-          >
+        | ProcedureCallPacket
     >(
       options: QueryOptions
     ): Promise<[T, FieldPacket[]]>;
@@ -70,13 +52,7 @@ export declare function QueryableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
-        | ProcedureCallPacket<
-            | OkPacket
-            | ResultSetHeader
-            | RowDataPacket[]
-            | RowDataPacket[][]
-            | OkPacket[]
-          >
+        | ProcedureCallPacket
     >(
       options: QueryOptions,
       values: any

--- a/typings/mysql/lib/protocol/sequences/promise/QueryableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/promise/QueryableBase.d.ts
@@ -3,6 +3,7 @@ import {
   FieldPacket,
   RowDataPacket,
   ResultSetHeader,
+  ProcedureCallPacket,
 } from '../../packets/index.js';
 import { QueryOptions, QueryableConstructor } from '../Query.js';
 
@@ -17,40 +18,68 @@ export declare function QueryableBase<T extends QueryableConstructor>(
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket<
+            | OkPacket
+            | ResultSetHeader
+            | RowDataPacket[]
+            | RowDataPacket[][]
+            | OkPacket[]
+          >
     >(
       sql: string
     ): Promise<[T, FieldPacket[]]>;
     query<
-      T_1 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket<
+            | OkPacket
+            | ResultSetHeader
+            | RowDataPacket[]
+            | RowDataPacket[][]
+            | OkPacket[]
+          >
     >(
       sql: string,
       values: any
-    ): Promise<[T_1, FieldPacket[]]>;
+    ): Promise<[T, FieldPacket[]]>;
     query<
-      T_2 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket<
+            | OkPacket
+            | ResultSetHeader
+            | RowDataPacket[]
+            | RowDataPacket[][]
+            | OkPacket[]
+          >
     >(
       options: QueryOptions
-    ): Promise<[T_2, FieldPacket[]]>;
+    ): Promise<[T, FieldPacket[]]>;
     query<
-      T_3 extends
+      T extends
         | OkPacket
         | ResultSetHeader
         | RowDataPacket[]
         | RowDataPacket[][]
         | OkPacket[]
+        | ProcedureCallPacket<
+            | OkPacket
+            | ResultSetHeader
+            | RowDataPacket[]
+            | RowDataPacket[][]
+            | OkPacket[]
+          >
     >(
       options: QueryOptions,
       values: any
-    ): Promise<[T_3, FieldPacket[]]>;
+    ): Promise<[T, FieldPacket[]]>;
   };
 } & T;


### PR DESCRIPTION
This **PR** looks to fix the Issue #1934.

---

<details>
<summary>
<b>Debugging Process</b>
</summary>

- [x] **RowDataPacket[]**
`[ ...RowDataPacket, ResultSetHeader ]`
- [x] **RowDataPacket[][]**
`[ ...[ ...RowDataPacket ], ResultSetHeader ]`
- [x] **OkPacket**
`ResultSetHeader`
- [x] **OkPacket[]**
`ResultSetHeader`
- [x] **ResultSetHeader**
`ResultSetHeader`
- [x] *Executing an empty Procedure*
`ResultSetHeader`
- [x] *an empty result of* **RowDataPacket[]**
`[ [], ResultSetHeader ]`
- [x] *an empty result of* **RowDataPacket[][]**
`[ [], ResultSetHeader ]`
- [x] **Multiple Statements**
  - [x] As the same
    - [x] OkPacket, ResultSetHeader
    `ResultSetHeader`
    - [x] RowDataPacket (two or more queries)
    `[ ...[ ...RowDataPacket ], ...[ ...RowDataPacket ], ResultSetHeader ]` 
  - [x] By combining
    - [x] **INSERT**, **UPDATE** and **DELETE**
    `ResultSetHeader`
    - [x] **INSERT**, **UPDATE**, **SELECT** and **DELETE**
    `[ ...[ ...RowDataPacket ], ResultSetHeader ]`
    - [x] **INSERT**, **SELECT**, **UPDATE**, **SELECT** and **DELETE**
    `[ ...[ ...RowDataPacket ], ...[ ...RowDataPacket ], ResultSetHeader ]` 

</details>

---

### Debugging Conclusion
- Always when a **SELECT** is executed (by itself, multiple queries, with or without results and including together with **INSERT**, **UPDATE**, etc.), the result will be an array with the returned rows (or `rowsAsArray`) and the last item from this array always be a `ResultSetHeader`.
- For **INSERT**, **UPDATE**, **DELETE**, **TRUNCATE**, **DROP**, empty Procedures, etc., the result always be a `ResultSetHeader` object (not an array).
- In any case, the `ResultSetHeader` (as a direct object or as the last array item) calculates the affected rows of all queries and it don't returns the `insertId` (even if it's a single INSERT query inside the Procedure).

---

#### About #1934
> can you help me understanding "Typing for stored procedure results wrong" problem?

In case no **SELECT** query is used, it's more convenient to just perform `query<ResultSetHeader>`.

But when it has one or more **SELECT** queries (even with empty results), after debugging, it's safe to say that the **Procedure Calls** have different behaviors. These behaviors aren't included in the current typings.

> The way I see it currently there is nothing wrong and added `ProcedureCallPacket` is just a convenience for when you know returned shape is `[Resultset, OkPacket]`

When using **TypeScript**, it's has some rules that can be bypassed by using `as`.

For example, I can use the `as` to "force" a type, but I can't do that:
```ts
const n = 'a' as number; // ❌
```

But, I can perform a redundant `as` by using it together with `unknown`
```ts
const number = 'a' as unknown as number; // ✅ (maybe?)
```

Going by this approach, we would need to do this:
```ts
(await conn.query(sql)) as unknown as [[...RowDataPacket[], ResultSetHeader], FieldPacket];
```

But that is not the only problem.

The current types can be misleading by believing that every Procedure Call will be a direct `ResultSetHeader` object.

It can also be confusing when using as `RowDataPacket[]` or `RowDataPacket[][]`, especially since the `ResultSetHeader` isn't detached, but the last item in the array (together with the rows).

By explicitly indicating these possibilities, it ensure that the Procedure Call return can be handled properly.

---

### Conclusion
Defining the proper types for Procedure Calls is not only a practical solution, but also a safer one.

That said, this **PR** proposes to make possible catch the proper typings returned from **Procedure Calls**.