### PR TITLE
Update events that are propegated from pool cluster to include remove

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -117,7 +117,7 @@ export interface PoolCluster extends EventEmitter {
 
   on(event: string, listener: (args: any[]) => void): this;
   on(event: 'remove', listener: (nodeId: number) => void): this;
-  on(event: 'connection', listener: (connection: PoolConnection) => void): this;
+  on(event: 'warn', listener: (err: Error) => void): this;
 }
 
 export function createConnection(connectionUri: string): Promise<Connection>;

--- a/promise.js
+++ b/promise.js
@@ -448,7 +448,7 @@ class PromisePoolCluster extends EventEmitter {
     super();
     this.poolCluster = poolCluster;
     this.Promise = thePromise || Promise;
-    inheritEvents(poolCluster, this, ['acquire', 'connection', 'enqueue', 'release']);
+    inheritEvents(poolCluster, this, ['warn', 'remove']);
   }
 
   getConnection() {

--- a/test/builtin-runner/integration/pool-cluster/test-promise-wrapper.mjs
+++ b/test/builtin-runner/integration/pool-cluster/test-promise-wrapper.mjs
@@ -1,0 +1,33 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import common from '../../../common.js';
+import { createPoolCluster } from "../../../../promise.js"
+
+describe('Test pool cluster', { timeout: 1000 }, () => {
+
+  it('should propagate warn event to promise wrapper', (t, done) => {
+
+    const poolCluster = createPoolCluster();
+    /* eslint-disable no-invalid-this */
+    poolCluster
+      .once('warn', function () {
+        assert.equal(this, poolCluster);
+        done();
+      })
+    /* eslint-enable no-invalid-this */
+    poolCluster.poolCluster.emit('warn', new Error());
+  });
+
+  it('should propagate remove event to promise wrapper', (t, done) => {
+
+    const poolCluster = createPoolCluster();
+    /* eslint-disable no-invalid-this */
+    poolCluster
+      .once('remove', function () {
+        assert.equal(this, poolCluster);
+        done();
+      });
+    /* eslint-enable no-invalid-this */
+    poolCluster.poolCluster.emit('remove');
+  });
+});

--- a/test/integration/promise-wrappers/test-promise-wrappers.js
+++ b/test/integration/promise-wrappers/test-promise-wrappers.js
@@ -11,7 +11,6 @@ const assert = require('assert');
 
 const createConnection = require('../../../promise.js').createConnection;
 const createPool = require('../../../promise.js').createPool;
-const createPoolCluster = require('../../../promise.js').createPoolCluster;
 
 // it's lazy exported from main index.js as well. Test that it's same function
 const mainExport = require('../../../index.js').createConnectionPromise;
@@ -20,7 +19,6 @@ assert.equal(mainExport, createConnection);
 let doneCalled = false;
 let exceptionCaught = false;
 let doneEventsConnect = false;
-let eventsPoolCluster = false;
 
 let doneCalledPool = false;
 let exceptionCaughtPool = false;
@@ -205,26 +203,6 @@ function testEventsConnect() {
         );
       }
     });
-}
-
-function testEventsConnectPoolCluster() {
-  const poolCluster = createPoolCluster();
-  let events = 0;
-  /* eslint-disable no-invalid-this */
-  poolCluster
-    .once('warn', function () {
-      assert.equal(this, poolCluster);
-      ++events;
-    })
-    .once('remove', function () {
-      assert.equal(this, poolCluster);
-      ++events;
-      eventsPoolCluster = events === 2;
-    });
-  /* eslint-enable no-invalid-this */
-  poolCluster.poolCluster.emit('warn', new Error());
-  poolCluster.poolCluster.emit("remove");
-
 }
 
 function testBasicPool() {
@@ -491,7 +469,6 @@ testBasicPool();
 testErrorsPool();
 testObjParamsPool();
 testEventsPool();
-testEventsConnectPoolCluster();
 testChangeUser();
 testConnectionProperties();
 testPoolConnectionDestroy();
@@ -501,7 +478,6 @@ process.on('exit', () => {
   assert.equal(doneCalled, true, 'done not called');
   assert.equal(exceptionCaught, true, 'exception not caught');
   assert.equal(doneEventsConnect, true, 'wrong number of connection events');
-  assert.equal(eventsPoolCluster, true, 'wrong number of pool cluster events');
   assert.equal(doneCalledPool, true, 'pool done not called');
   assert.equal(exceptionCaughtPool, true, 'pool exception not caught');
   assert.equal(doneEventsPool, true, 'wrong number of pool connection events');

--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -80,7 +80,7 @@ declare class PoolCluster extends EventEmitter {
 
   on(event: string, listener: (args: any[]) => void): this;
   on(event: 'remove', listener: (nodeId: number) => void): this;
-  on(event: 'connection', listener: (connection: PoolConnection) => void): this;
+  on(event: 'warn', listener: (err: Error) => void): this;
 }
 
 export { PoolCluster };


### PR DESCRIPTION
Removed events from promise wrapper that aren't fired by pool cluster.
I've seperated this into 2 commits. The first adds a failing test the second fixes that test