### PR TITLE
fix: make startTls code compatible with Bun

### DIFF
--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Wait mysql server is ready
         run: node tools/wait-up.js
 
-      - name: Run tests
-        # todo: run full test suite once test createServer is implemented using Bun.listen
-        run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun run test
+      # todo: run full test suite once test createServer is implemented using Bun.listen
+      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-ssl.js
+      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-select-1.js

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bun-version: [canary]
+        bun-version: [0.6.13, canary]
         mysql-version: ["mysql:5.7", "mysql:8.0.18", "mysql:8.0.22"]
-        use-compression: [0]
+        use-compression: [0, 1]
         use-tls: [0,1]
 
     name: Bun ${{ matrix.bun-version }} - DB ${{ matrix.mysql-version }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
@@ -58,5 +58,13 @@ jobs:
         run: node tools/wait-up.js
 
       # todo: run full test suite once test createServer is implemented using Bun.listen
-      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-1.js
-      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-ssl.js
+      - name: run tests
+        env:
+          MYSQL_USER: ${{ env.MYSQL_USER }}
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+          MYSQL_PORT: ${{ env.MYSQL_PORT }}
+          MYSQL_USE_COMPRESSION: ${{ matrix.use-compression }}
+          MYSQL_USE_TLS: ${{ matrix.use-tls }}
+        run: |
+          bun test/integration/connection/test-select-1.js
+          bun test/integration/connection/test-select-ssl.js

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bun-version: [0.6.13]
+        bun-version: [canary]
         mysql-version: ["mysql:5.7", "mysql:8.0.18", "mysql:8.0.22"]
         use-compression: [0]
         use-tls: [0,1]
@@ -33,7 +33,7 @@ jobs:
         run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/examples/custom-conf:/etc/mysql/conf.d -v $PWD/examples/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}
 
       - name: Set up Bun ${{ matrix.bun-version }}
-        uses: oven-sh/setup-bun@v0.1.8
+        uses: oven-sh/setup-bun@v1
         with:
           bun-version: ${{ matrix.bun-version }}
 
@@ -58,5 +58,5 @@ jobs:
         run: node tools/wait-up.js
 
       # todo: run full test suite once test createServer is implemented using Bun.listen
-      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-ssl.js
       - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-1.js
+      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-ssl.js

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -59,4 +59,4 @@ jobs:
 
       # todo: run full test suite once test createServer is implemented using Bun.listen
       - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-ssl.js
-      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-select-1.js
+      - run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun test/integration/connection/test-select-1.js

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -20,10 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bun-version: [0.5.1]
+        bun-version: [0.6.13]
         mysql-version: ["mysql:5.7", "mysql:8.0.18", "mysql:8.0.22"]
         use-compression: [0]
-        use-tls: [0]
+        use-tls: [0,1]
 
     name: Bun ${{ matrix.bun-version }} - DB ${{ matrix.mysql-version }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
 

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -59,4 +59,4 @@ jobs:
 
       - name: Run tests
         # todo: run full test suite once test createServer is implemented using Bun.listen
-        run: FILTER=test-select MYSQL_PORT=3306 bun run test
+        run: MYSQL_USE_TLS=${{ matrix.use-tls }} FILTER=test-select MYSQL_PORT=3306 bun run test

--- a/.github/workflows/ci-bun.yml
+++ b/.github/workflows/ci-bun.yml
@@ -20,10 +20,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bun-version: [0.6.13, canary]
+        bun-version: [canary]
         mysql-version: ["mysql:5.7", "mysql:8.0.18", "mysql:8.0.22"]
         use-compression: [0, 1]
         use-tls: [0,1]
+        include:
+          - bun-version: "0.6.13"
+            use-compression: 1
+            use-tls: 0
+            mysql-version: "mysql:8.0.18"
+          - bun-version: "0.6.13"
+            use-compression: 1
+            use-tls: 0
+            mysql-version: "mysql:8.0.22"
 
     name: Bun ${{ matrix.bun-version }} - DB ${{ matrix.mysql-version }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
 

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -49,7 +49,7 @@ jobs:
     
       - name: Set up MySQL
         if: ${{ matrix.mysql-version }}
-        run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/examples/custom-conf:/etc/mysql/conf.d -v $PWD/examples/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}
+        run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}
 
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -44,6 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up docker
+        uses: docker-practice/actions-setup-docker@v1
+
       - name: Set up MySQL
         if: ${{ matrix.mysql-version }}
         run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/examples/custom-conf:/etc/mysql/conf.d -v $PWD/examples/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -44,15 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up docker
-        run: |
-          brew install docker
-          brew install docker-compose
-          brew install docker-machine
-          docker-machine create --driver virtualbox default
-          docker-machine env default
-          eval $(docker-machine env default)
-
+      - name: Setup Docker on macOS
+        uses: douglascamata/setup-docker-macos-action@v1-alpha
+    
       - name: Set up MySQL
         if: ${{ matrix.mysql-version }}
         run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/examples/custom-conf:/etc/mysql/conf.d -v $PWD/examples/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -1,0 +1,75 @@
+name: CI - OSX
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+env:
+  MYSQL_PORT: 3306
+  MYSQL_USER: root
+  MYSQL_DATABASE: test
+
+jobs:
+  tests-osx:
+    runs-on: macos-13
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18.x, 20.x]
+        mysql-version: ["mysql:8.0.22", "mysql:8.0.33"]
+        use-compression: [0, 1]
+        use-tls: [0]
+        mysql_connection_url_key: [""]
+        # TODO - add mariadb to the matrix. currently few tests are broken due to mariadb incompatibilities
+        include:
+          # 20.x 
+          - node-version: "20.x"
+            mysql-version: "mysql:8.0.33"
+            use-compression: 1
+            use-tls: 0
+            use-builtin-test-runner: 1
+          - node-version: "20.x"
+            mysql-version: "mysql:8.0.33"
+            use-compression: 0
+            use-tls: 1
+            use-builtin-test-runner: 1
+    env:
+      MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}
+
+    name: Node.js ${{ matrix.node-version }} - DB ${{ matrix.mysql-version }}${{ matrix.mysql_connection_url_key }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up MySQL
+        if: ${{ matrix.mysql-version }}
+        run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/examples/custom-conf:/etc/mysql/conf.d -v $PWD/examples/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+          
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Wait mysql server is ready
+        if: ${{ matrix.mysql-version }}
+        run: node tools/wait-up.js
+
+      - name: Run tests
+        run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run coverage-test
+
+      - name: Run tests with built-in node test runner
+        if: ${{ matrix.use-builtin-test-runner }}
+        run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run test:builtin-node-runner

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -45,7 +45,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up docker
-        uses: docker-practice/actions-setup-docker@v1
+        run: |
+          brew install docker
+          brew install docker-compose
+          brew install docker-machine
+          docker-machine create --driver virtualbox default
+          docker-machine env default
+          eval $(docker-machine env default)
 
       - name: Set up MySQL
         if: ${{ matrix.mysql-version }}

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -44,6 +44,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: install lima
+        run: brew install lima
+
       - name: Setup Docker on macOS
         uses: douglascamata/setup-docker-macos-action@v1-alpha
     

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -354,7 +354,7 @@ class Connection extends EventEmitter {
       maxVersion: this.config.ssl.maxVersion
     });
     const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
-    const verifyIdentity = true; //this.config.ssl.verifyIdentity;
+    const verifyIdentity = this.config.ssl.verifyIdentity;
     const servername = this.config.host
 
     let secureEstablished = false;
@@ -366,17 +366,7 @@ class Connection extends EventEmitter {
       isServer: false,
       socket: this.stream,
       servername
-    });
-
-    // error handler for secure socket
-    secureSocket.on('error', err => {
-      if (secureEstablished) {
-        this._handleNetworkError(err);
-      } else {
-        onSecure(err);
-      }
-    });
-    secureSocket.on('secureConnect', () => {
+    }, () => {
       secureEstablished = true;
       if (rejectUnauthorized) {
         if (typeof servername === 'string' && verifyIdentity) {
@@ -389,6 +379,14 @@ class Connection extends EventEmitter {
         }
       }
       onSecure();
+    });
+    // error handler for secure socket
+    secureSocket.on('error', err => {
+      if (secureEstablished) {
+        this._handleNetworkError(err);
+      } else {
+        onSecure(err);
+      }
     });
     secureSocket.on('data', data => {
       this.packetParser.execute(data);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -355,7 +355,7 @@ class Connection extends EventEmitter {
     });
     const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
     const verifyIdentity = this.config.ssl.verifyIdentity;
-    const servername = this.config.host
+    const servername = this.config.host;
 
     let secureEstablished = false;
     this.stream.removeAllListeners('data');
@@ -393,24 +393,6 @@ class Connection extends EventEmitter {
     });
     this.write = buffer => secureSocket.write(buffer);
   }
-
-  /*
-  pipe() {
-    if (this.stream instanceof Net.Stream) {
-      this.stream.ondata = (data, start, end) => {
-        this.packetParser.execute(data, start, end);
-      };
-    } else {
-      this.stream.on('data', data => {
-        this.packetParser.execute(
-          data.parent,
-          data.offset,
-          data.offset + data.length
-        );
-      });
-    }
-  }
-  */
 
   protocolError(message, code) {
     // Starting with MySQL 8.0.24, if the client closes the connection

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -354,49 +354,51 @@ class Connection extends EventEmitter {
       maxVersion: this.config.ssl.maxVersion
     });
     const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
-    const verifyIdentity = this.config.ssl.verifyIdentity;
-    const host = this.config.host;
+    const verifyIdentity = true; //this.config.ssl.verifyIdentity;
+    const servername = this.config.host
 
     let secureEstablished = false;
-    const secureSocket = new Tls.TLSSocket(this.stream, {
-      rejectUnauthorized: rejectUnauthorized,
-      requestCert: true,
-      secureContext: secureContext,
-      isServer: false
+    this.stream.removeAllListeners('data');
+    const secureSocket = Tls.connect({
+      rejectUnauthorized,
+      requestCert: rejectUnauthorized,
+      secureContext,
+      isServer: false,
+      socket: this.stream,
+      servername
     });
-    if (typeof host === 'string') {
-      secureSocket.setServername(host);
-    }
+
     // error handler for secure socket
-    secureSocket.on('_tlsError', err => {
+    secureSocket.on('error', err => {
       if (secureEstablished) {
         this._handleNetworkError(err);
       } else {
         onSecure(err);
       }
     });
-    secureSocket.on('secure', () => {
+    secureSocket.on('secureConnect', () => {
       secureEstablished = true;
-      let callbackValue = null;
       if (rejectUnauthorized) {
-        callbackValue = secureSocket.ssl.verifyError()
-        if (!callbackValue && typeof host === 'string' && verifyIdentity) {
-          const cert = secureSocket.ssl.getPeerCertificate(true);
-          callbackValue = Tls.checkServerIdentity(host, cert)
+        if (typeof servername === 'string' && verifyIdentity) {
+          const cert = secureSocket.getPeerCertificate(true);
+          const serverIdentityCheckError = Tls.checkServerIdentity(servername, cert);
+          if (serverIdentityCheckError) {
+            onSecure(serverIdentityCheckError);
+            return;
+          }
         }
       }
-      onSecure(callbackValue);
+      onSecure();
     });
     secureSocket.on('data', data => {
       this.packetParser.execute(data);
     });
     this.write = buffer => {
-      secureSocket.write(buffer);
+      return secureSocket.write(buffer);
     };
-    // start TLS communications
-    secureSocket._start();
   }
 
+  /*
   pipe() {
     if (this.stream instanceof Net.Stream) {
       this.stream.ondata = (data, start, end) => {
@@ -412,6 +414,7 @@ class Connection extends EventEmitter {
       });
     }
   }
+  */
 
   protocolError(message, code) {
     // Starting with MySQL 8.0.24, if the client closes the connection
@@ -946,50 +949,6 @@ class Connection extends EventEmitter {
       `${typeof options.nestTables}/${options.nestTables}/${options.rowsAsArray}${options.sql}`
     );
   }
-}
-
-if (Tls.TLSSocket) {
-  // not supported
-} else {
-  Connection.prototype.startTLS = function _startTLS(onSecure) {
-    if (this.config.debug) {
-      // eslint-disable-next-line no-console
-      console.log('Upgrading connection to TLS');
-    }
-    const crypto = require('crypto');
-    const config = this.config;
-    const stream = this.stream;
-    const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
-    const credentials = crypto.createCredentials({
-      key: config.ssl.key,
-      cert: config.ssl.cert,
-      passphrase: config.ssl.passphrase,
-      ca: config.ssl.ca,
-      ciphers: config.ssl.ciphers
-    });
-    const securePair = Tls.createSecurePair(
-      credentials,
-      false,
-      true,
-      rejectUnauthorized
-    );
-
-    if (stream.ondata) {
-      stream.ondata = null;
-    }
-    stream.removeAllListeners('data');
-    stream.pipe(securePair.encrypted);
-    securePair.encrypted.pipe(stream);
-    securePair.cleartext.on('data', data => {
-      this.packetParser.execute(data);
-    });
-    this.write = function(buffer) {
-      securePair.cleartext.write(buffer);
-    };
-    securePair.on('secure', () => {
-      onSecure(rejectUnauthorized ? securePair.ssl.verifyError() : null);
-    });
-  };
 }
 
 module.exports = Connection;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -391,9 +391,7 @@ class Connection extends EventEmitter {
     secureSocket.on('data', data => {
       this.packetParser.execute(data);
     });
-    this.write = buffer => {
-      return secureSocket.write(buffer);
-    };
+    this.write = buffer => secureSocket.write(buffer);
   }
 
   /*

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -10,6 +10,7 @@ describe(
   () => {
     it('should report 0 actual parameters when 1 placeholder is used in ORDER BY ?', (t, done) => {
       const connection = {
+        sequenceId: 1,
         constructor: {
           statementKey: () => 0,
         },
@@ -23,9 +24,10 @@ describe(
         },
         writePacket: (packet) => {
           // client -> server COM_PREPARE
+          packet.writeHeader(1);
           assert.equal(
             packet.buffer.toString('hex'),
-            '000000001673656c656374202a2066726f6d207573657273206f72646572206279203f'
+            '1f0000011673656c656374202a2066726f6d207573657273206f72646572206279203f'
           );
         },
       };
@@ -68,7 +70,7 @@ describe(
   }
 );
 
-describe('E2E Prepare result with number of parameters incorrectly reported by the server', { timeout: 1000 }, () => {
+describe.skip('E2E Prepare result with number of parameters incorrectly reported by the server', { timeout: 1000 }, () => {
   let connection;
 
   function isNewerThan8_0_22() {

--- a/test/builtin-runner/regressions/2052.test.mjs
+++ b/test/builtin-runner/regressions/2052.test.mjs
@@ -70,7 +70,9 @@ describe(
   }
 );
 
-describe.skip('E2E Prepare result with number of parameters incorrectly reported by the server', { timeout: 1000 }, () => {
+describe('E2E Prepare result with number of parameters incorrectly reported by the server', 
+  { timeout: 1000 }, 
+  () => {
   let connection;
 
   function isNewerThan8_0_22() {

--- a/test/common.js
+++ b/test/common.js
@@ -84,7 +84,7 @@ exports.createConnection = function(args) {
     typeCast: args && args.typeCast,
     namedPlaceholders: args && args.namedPlaceholders,
     connectTimeout: args && args.connectTimeout,
-    ssl: (args && args.ssl) || config.ssl,
+    ssl: (args && args.ssl) ?? config.ssl,
   };
 
   const conn = driver.createConnection(params);
@@ -165,10 +165,12 @@ exports.createServer = function(onListening, handler) {
   const server = require('../index.js').createServer();
   server.on('connection', conn => {
     conn.on('error', () => {
-      // we are here when client drops connection
+      // server side of the connection
+      // ignore disconnects
     });
+    // remove ssl bit from the flags
     let flags = 0xffffff;
-    flags = flags ^ ClientFlags.COMPRESS;
+    flags = flags ^ (ClientFlags.COMPRESS | ClientFlags.SSL);
 
     conn.serverHandshake({
       protocolVersion: 10,

--- a/test/common.js
+++ b/test/common.js
@@ -12,7 +12,7 @@ const config = {
   port: process.env.MYSQL_PORT || 3306
 };
 
-if (process.env.MYSQL_USE_TLS) {
+if (process.env.MYSQL_USE_TLS === '1') {
   config.ssl = {
     rejectUnauthorized: false,
     ca: fs.readFileSync(
@@ -84,6 +84,7 @@ exports.createConnection = function(args) {
     typeCast: args && args.typeCast,
     namedPlaceholders: args && args.namedPlaceholders,
     connectTimeout: args && args.connectTimeout,
+    ssl: (args && args.ssl) || config.ssl,
   };
 
   const conn = driver.createConnection(params);

--- a/test/common.js
+++ b/test/common.js
@@ -32,7 +32,7 @@ exports.waitDatabaseReady = function(callback) {
   const tryConnect = function() {
     const conn = exports.createConnection({ database: 'mysql', password: process.env.MYSQL_PASSWORD });
     conn.once('error', err => {
-      if (err.code !== 'PROTOCOL_CONNECTION_LOST' && err.code !== 'ETIMEDOUT') {
+      if (err.code !== 'PROTOCOL_CONNECTION_LOST' && err.code !== 'ETIMEDOUT' && err.code !== 'ECONNREFUSED') {
         console.log('Unexpected error waiting for connection', err);
         process.exit(-1);
       }

--- a/test/integration/connection/test-disconnects.js
+++ b/test/integration/connection/test-disconnects.js
@@ -23,7 +23,8 @@ const server = common.createServer(
       // different host provided via MYSQL_HOST that identifies a real MySQL
       // server instance.
       host: 'localhost',
-      port: server._port
+      port: server._port,
+      ssl: false
     });
     connection.query('SELECT 123', (err, _rows, _fields) => {
       if (err) {

--- a/test/integration/connection/test-protocol-errors.js
+++ b/test/integration/connection/test-protocol-errors.js
@@ -22,7 +22,8 @@ const server = common.createServer(
       // different host provided via MYSQL_HOST that identifies a real MySQL
       // server instance.
       host: 'localhost',
-      port: server._port
+      port: server._port,
+      ssl: false
     });
     connection.query(query, (err, _rows, _fields) => {
       if (err) {

--- a/test/integration/connection/test-quit.js
+++ b/test/integration/connection/test-quit.js
@@ -22,7 +22,8 @@ const server = common.createServer(
       // different host provided via MYSQL_HOST that identifies a real MySQL
       // server instance.
       host: 'localhost',
-      port: server._port
+      port: server._port,
+      ssl: false
     });
 
     connection.query(queryCli, (err, _rows, _fields) => {

--- a/test/integration/connection/test-select-ssl.js
+++ b/test/integration/connection/test-select-ssl.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-const tls = require('tls');
 const common = require('../../common');
 const connection = common.createConnection();
 

--- a/test/integration/connection/test-select-ssl.js
+++ b/test/integration/connection/test-select-ssl.js
@@ -7,7 +7,7 @@ const connection = common.createConnection();
 connection.query(`SHOW STATUS LIKE 'Ssl_cipher'`, (err, rows) => {
   assert.ifError(err);
   if (process.env.MYSQL_USE_TLS === '1') {
-    assert(rows[0].Value.startsWith('TLS_AES_'));
+    assert.equal(rows[0].Value.slice(0, 8), 'TLS_AES_');
   } else {
     assert.deepEqual(rows, [{ Variable_name: 'Ssl_cipher', Value: '' }]);
   }

--- a/test/integration/connection/test-select-ssl.js
+++ b/test/integration/connection/test-select-ssl.js
@@ -7,7 +7,7 @@ const connection = common.createConnection();
 connection.query(`SHOW STATUS LIKE 'Ssl_cipher'`, (err, rows) => {
   assert.ifError(err);
   if (process.env.MYSQL_USE_TLS === '1') {
-    assert.equal(rows[0].Value.slice(0, 8), 'TLS_AES_');
+    assert.equal(rows[0].Value.length > 0, true);
   } else {
     assert.deepEqual(rows, [{ Variable_name: 'Ssl_cipher', Value: '' }]);
   }

--- a/test/integration/connection/test-select-ssl.js
+++ b/test/integration/connection/test-select-ssl.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const assert = require('assert');
+const tls = require('tls');
+const common = require('../../common');
+const connection = common.createConnection();
+
+connection.query(`SHOW STATUS LIKE 'Ssl_cipher'`, (err, rows, fields) => {
+  assert.ifError(err);
+  if (process.env.MYSQL_USE_TLS === '1') {
+    assert(rows[0].Value.startsWith('TLS_AES_'));
+  } else {
+     assert.deepEqual(rows, [{ Variable_name: 'Ssl_cipher', Value: '' }]);
+  }
+  connection.end();
+});

--- a/test/integration/connection/test-select-ssl.js
+++ b/test/integration/connection/test-select-ssl.js
@@ -4,12 +4,12 @@ const assert = require('assert');
 const common = require('../../common');
 const connection = common.createConnection();
 
-connection.query(`SHOW STATUS LIKE 'Ssl_cipher'`, (err, rows, fields) => {
+connection.query(`SHOW STATUS LIKE 'Ssl_cipher'`, (err, rows) => {
   assert.ifError(err);
   if (process.env.MYSQL_USE_TLS === '1') {
     assert(rows[0].Value.startsWith('TLS_AES_'));
   } else {
-     assert.deepEqual(rows, [{ Variable_name: 'Ssl_cipher', Value: '' }]);
+    assert.deepEqual(rows, [{ Variable_name: 'Ssl_cipher', Value: '' }]);
   }
   connection.end();
 });

--- a/test/integration/connection/test-stream-errors.js
+++ b/test/integration/connection/test-stream-errors.js
@@ -25,9 +25,13 @@ const server = common.createServer(
       // different host provided via MYSQL_HOST that identifies a real MySQL
       // server instance.
       host: 'localhost',
-      port: server._port
+      port: server._port,
+      ssl: false
     });
     clientConnection.query(query, err => {
+      if (err && err.code === 'HANDSHAKE_NO_SSL_SUPPORT') {
+        clientConnection.end();
+      }
       receivedError1 = err;
     });
     clientConnection.query('second query, should not be executed', () => {

--- a/test/integration/connection/test-then-on-query.js
+++ b/test/integration/connection/test-then-on-query.js
@@ -13,7 +13,7 @@ try {
   error = false;
 }
 q.on('end', () => {
-  connection.destroy();
+  connection.end();
 });
 
 process.on('exit', () => {

--- a/test/integration/regressions/test-#82.js
+++ b/test/integration/regressions/test-#82.js
@@ -1,6 +1,7 @@
 'use strict';
 
 // temporary disabling the test
+/*
 return;
 
 const common = require('../../common');
@@ -63,3 +64,4 @@ process.on('exit', () => {
   assert.equal(results[2].name2, 'BB');
   assert.equal(results[3].name2, 'AA');
 });
+*/

--- a/test/integration/regressions/test-#82.js
+++ b/test/integration/regressions/test-#82.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// temporary disabling the test
+return;
+
 const common = require('../../common');
 const connection = common.createConnection();
 const assert = require('assert');

--- a/test/integration/regressions/test-#82.js
+++ b/test/integration/regressions/test-#82.js
@@ -1,9 +1,5 @@
 'use strict';
 
-// temporary disabling the test
-/*
-return;
-
 const common = require('../../common');
 const connection = common.createConnection();
 const assert = require('assert');
@@ -49,7 +45,7 @@ prepareTestSet(err => {
     (err, rows) => {
       assert.ifError(err);
       results = rows;
-      connection.close();
+      connection.end();
     }
   );
 });
@@ -64,4 +60,3 @@ process.on('exit', () => {
   assert.equal(results[2].name2, 'BB');
   assert.equal(results[3].name2, 'AA');
 });
-*/


### PR DESCRIPTION
- raw stream 'data' events were not disconnected before starting TLS socket ( looks like node disconnects them for us, bun does not )
- use `TLS.connect()` instead of `new TLS.Socket()` + `secureSocket._start()`
- move logic from 'secure' handler to a `TLS.connect(options, callback)` callback. Note: if handled via event, correct document name should be `"secureConnection"` - see https://nodejs.org/dist/latest-v20.x/docs/api/tls.html#event-secureconnection
- fixes in `verifyIdentity` logic

Note: requires bun >= 0.6.13 due to functionality added in https://github.com/oven-sh/bun/pull/3457