### PR TITLE
chore: deprecate `OkPacket` type and `changedRows` property

### DIFF
--- a/typings/mysql/lib/protocol/packets/OkPacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/OkPacket.d.ts
@@ -1,9 +1,17 @@
+/**
+ * @deprecated
+ * `OkPacket` is deprecated and might be removed in the future major release. Please use `ResultSetHeader` instead.
+ */
 declare interface OkPacket {
   constructor: {
     name: 'OkPacket';
   };
   fieldCount: number;
   affectedRows: number;
+  /**
+   * @deprecated
+   * `changedRows` is deprecated and might be removed in the future major release. Please use `affectedRows` property instead.
+   */
   changedRows: number;
   insertId: number;
   serverStatus: number;

--- a/typings/mysql/lib/protocol/packets/ResultSetHeader.d.ts
+++ b/typings/mysql/lib/protocol/packets/ResultSetHeader.d.ts
@@ -8,6 +8,10 @@ declare interface ResultSetHeader {
   insertId: number;
   serverStatus: number;
   warningStatus: number;
+  /**
+   * @deprecated
+   * `changedRows` is deprecated and might be removed in the future major release. Please use `affectedRows` property instead.
+   */
   changedRows: number;
 }
 


### PR DESCRIPTION
Just showing how this appears for final user:

---

<img width="530" alt="Screenshot 2023-07-10 at 03 33 50" src="https://github.com/sidorares/node-mysql2/assets/46850407/d0ee989e-54e5-4b15-926d-71e4b6f9cb04">

---

<img width="252" alt="Screenshot 2023-07-10 at 03 32 43" src="https://github.com/sidorares/node-mysql2/assets/46850407/2956d446-06b0-4094-9ce2-f64d961b38ab">

