### PR TITLE
feat: add conn-level `infileStreamFactory` option

### DIFF
--- a/documentation/en/Extras.md
+++ b/documentation/en/Extras.md
@@ -68,6 +68,28 @@ connection.query(
 );
 ```
 
+The `infileStreamFactory` option may also be set at a connection-level:
+
+```js
+const fs = require("fs");
+const mysql = require('mysql2');
+
+const connection = mysql.createConnection({
+  user: 'test',
+  database: 'test',
+  infileStreamFactory: path => {
+    // Validate file path
+    const validPaths = ['/tmp/data.csv'];
+    if (!validPaths.includes(path)) {
+      throw new Error(`invalid file path: ${path}: expected to be one of ${validPaths.join(',')}`);
+    }
+    return fs.createReadStream(path);
+  }
+});
+
+connection.query('LOAD DATA LOCAL INFILE "/tmp/data.csv" INTO TABLE test', onInserted);
+```
+
 ## Connecting using custom stream:
 
 ```js

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -615,10 +615,15 @@ class Connection extends EventEmitter {
   }
 
   execute(sql, values, cb) {
-    let options = {};
+    let options = {
+      infileStreamFactory: this.config.infileStreamFactory
+    };
     if (typeof sql === 'object') {
       // execute(options, cb)
-      options = sql;
+      options = {
+        ...options,
+        ...sql
+      };
       if (typeof values === 'function') {
         cb = values;
       } else {
@@ -899,11 +904,15 @@ class Connection extends EventEmitter {
 
   static createQuery(sql, values, cb, config) {
     let options = {
-      rowsAsArray: config.rowsAsArray
+      rowsAsArray: config.rowsAsArray,
+      infileStreamFactory: config.infileStreamFactory
     };
     if (typeof sql === 'object') {
       // query(options, cb)
-      options = sql;
+      options = {
+        ...options,
+        ...sql
+      };
       if (typeof values === 'function') {
         cb = values;
       } else if (values !== undefined) {

--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -30,6 +30,7 @@ const validOptions = {
   flags: 1,
   host: 1,
   insecureAuth: 1,
+  infileStreamFactory: 1,
   isServer: 1,
   keepAliveInitialDelay: 1,
   localAddress: 1,
@@ -108,6 +109,7 @@ class ConnectionConfig {
       ? 10 * 1000
       : options.connectTimeout;
     this.insecureAuth = options.insecureAuth || false;
+    this.infileStreamFactory = options.infileStreamFactory || undefined;
     this.supportBigNumbers = options.supportBigNumbers || false;
     this.bigNumberStrings = options.bigNumberStrings || false;
     this.decimalNumbers = options.decimalNumbers || false;

--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -4,6 +4,7 @@
 // Modifications copyright (c) 2021, Oracle and/or its affiliates.
 
 import { EventEmitter } from 'events';
+import { Readable } from 'stream';
 import { Query, QueryError } from './protocol/sequences/Query.js';
 import { Prepare, PrepareStatementInfo } from './protocol/sequences/Prepare.js';
 import {
@@ -164,6 +165,11 @@ export interface ConnectionOptions {
    * Allow connecting to MySQL instances that ask for the old (insecure) authentication method. (Default: false)
    */
   insecureAuth?: boolean;
+
+  /**
+   * By specifying a function that returns a readable stream, an arbitrary stream can be sent when sending a local fs file.
+   */
+  infileStreamFactory?: (path: string) => Readable;
 
   /**
    * Determines if column values should be converted to native JavaScript types. It is not recommended (and may go away / change in the future)


### PR DESCRIPTION
This PR provides support for the `infileStreamFactory` option at the connection level. This will be useful for users who are looking to validate the file path at the connection/pool level. For downstream libraries like [sequelize](https://github.com/sequelize/sequelize) and [typeorm](https://github.com/typeorm/typeorm), exposing this option at the connection-level will also allow users to set `infileStreamFactory` option through the [`dialectOptions`](https://sequelize.org/docs/v6/other-topics/dialect-specific-things/#mysql) and [`extra`](https://typeorm.io/data-source-options#mysql--mariadb-data-source-options) parameters respectively.

With the change, the `infileStreamFactory` option can be supplied when instantiating a new connection:

```js
const fs = require("fs");
const mysql = require('mysql2');

const connection = mysql.createConnection({
  user: 'test',
  database: 'test',
  infileStreamFactory: (path) => {
    // Validate file path
    const validPaths = ['/tmp/data.csv'];
    if (!validPaths.includes(path)) {
      throw new Error(`invalid file path: ${path}: expected to be one of ${validPaths.join(',')}`);
    }
    return fs.createReadStream(path);
  }
});

connection.query('LOAD DATA LOCAL INFILE "/tmp/data.csv" INTO TABLE test', onInserted);
```

Fixes #2151