### PR TITLE
Fix EventEmitter on method sigatures to use spread syntax

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -115,7 +115,7 @@ export interface PoolCluster extends EventEmitter {
 
   of(pattern: string, selector?: string): PoolNamespace;
 
-  on(event: string, listener: (args: any[]) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
   on(event: 'remove', listener: (nodeId: number) => void): this;
   on(event: 'warn', listener: (err: Error) => void): this;
 }

--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -357,7 +357,7 @@ declare class Connection extends QueryableBase(ExecutableBase(EventEmitter)) {
 
   format(sql: string, values?: any | any[] | { [param: string]: any }): string;
 
-  on(event: string, listener: (args: any[]) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
 
   rollback(callback: (err: QueryError | null) => void): void;
 

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -63,7 +63,7 @@ declare class Pool extends QueryableBase(ExecutableBase(EventEmitter)) {
     callback?: (err: NodeJS.ErrnoException | null, ...args: any[]) => any
   ): void;
 
-  on(event: string, listener: (args: any[]) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
   on(event: 'connection', listener: (connection: PoolConnection) => any): this;
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;
   on(event: 'release', listener: (connection: PoolConnection) => any): this;

--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -78,7 +78,7 @@ declare class PoolCluster extends EventEmitter {
 
   of(pattern: string, selector?: string): PoolNamespace;
 
-  on(event: string, listener: (args: any[]) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
   on(event: 'remove', listener: (nodeId: number) => void): this;
   on(event: 'warn', listener: (err: Error) => void): this;
 }

--- a/typings/mysql/lib/protocol/sequences/Query.d.ts
+++ b/typings/mysql/lib/protocol/sequences/Query.d.ts
@@ -133,7 +133,7 @@ declare class Query extends Sequence {
    */
   stream(options?: StreamOptions): Readable;
 
-  on(event: string, listener: (args: any[]) => void): this;
+  on(event: string, listener: (...args: any[]) => void): this;
   on(event: 'error', listener: (err: QueryError) => any): this;
   on(
     event: 'fields',


### PR DESCRIPTION
The listener parameter of `emitter.on` takes a variable list of parameters instead of an array. See https://nodejs.org/api/events.html#passing-arguments-and-this-to-listeners for an example.