### PR TITLE
Fix server identity check

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -365,19 +365,14 @@ class Connection extends EventEmitter {
       secureContext,
       isServer: false,
       socket: this.stream,
-      servername
-    }, () => {
-      secureEstablished = true;
-      if (rejectUnauthorized) {
-        if (typeof servername === 'string' && verifyIdentity) {
-          const cert = secureSocket.getPeerCertificate(true);
-          const serverIdentityCheckError = Tls.checkServerIdentity(servername, cert);
-          if (serverIdentityCheckError) {
-            onSecure(serverIdentityCheckError);
-            return;
-          }
+      servername,
+      checkServerIdentity: (servername, cert) => {
+        if (rejectUnauthorized && typeof servername === 'string' && verifyIdentity) {
+          return Tls.checkServerIdentity(servername, cert);
         }
       }
+    }, () => {
+      secureEstablished = true;
       onSecure();
     });
     // error handler for secure socket
@@ -408,7 +403,7 @@ class Connection extends EventEmitter {
     err.code = code || 'PROTOCOL_ERROR';
     this.emit('error', err);
   }
-  
+
   get fatalError() {
     return this._fatalError;
   }


### PR DESCRIPTION
I don't think we are respecting the documented behavior for verifyIdentity. According to the [documentation](https://nodejs.org/api/tls.html#tlsconnectoptions-callback), in order to skip server identity check, we need to override checkServerIdentity by passing in a function as an argument to `tls.connect`. Currently we do that in the callback by which time the server identity check has already happened and error bubbled up.