### PR TITLE
fix: typo on unsupported SSL connection

### DIFF
--- a/lib/commands/client_handshake.js
+++ b/lib/commands/client_handshake.js
@@ -137,7 +137,7 @@ class ClientHandshake extends Command {
     if (connection.config.ssl) {
       // client requires SSL but server does not support it
       if (!serverSSLSupport) {
-        const err = new Error('Server does not support secure connnection');
+        const err = new Error('Server does not support secure connection');
         err.code = 'HANDSHAKE_NO_SSL_SUPPORT';
         err.fatal = true;
         this.emit('error', err);


### PR DESCRIPTION
this is just a simple PR to fix typo, from

```
connnection
```

to

```
connection
```