### PR TITLE
Fix big number accuracy

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -222,10 +222,9 @@ class Packet {
         return word1 * 0x100000000 + word0;
       }
       res = new Long(word0, word1, !signed); // Long need unsigned
-      const resNumber = res.toNumber();
       const resString = res.toString();
-      res = resNumber.toString() === resString ? resNumber : resString;
-      return bigNumberStrings ? resString : res;
+      const safeResNumberPreferred = res.greaterThan(Number.MAX_SAFE_INTEGER) || res.lessThan(Number.MIN_SAFE_INTEGER) ? resString : res.toNumber();
+      return bigNumberStrings ? resString : safeResNumberPreferred;
     }
     // eslint-disable-next-line no-console
     console.trace();
@@ -425,7 +424,7 @@ class Packet {
     return StringParser.decode(
       this.buffer,
       encoding,
-      this.offset - len, 
+      this.offset - len,
       this.offset
     );
   }
@@ -450,21 +449,18 @@ class Packet {
       this.offset++;
       sign = -1;
     }
-    // max precise int is 9007199254740992
+    // max precise int is Number.MAX_SAFE_INTEGER 9007199254740991
     let str;
     const numDigits = end - this.offset;
     if (supportBigNumbers) {
       if (numDigits >= 15) {
         str = this.readString(end - this.offset, 'binary');
-        result = parseInt(str, 10);
-        if (result.toString() === str) {
-          return sign * result;
-        }
-        return sign === -1 ? `-${str}` : str;
-      }
-      if (numDigits > 16) {
-        str = this.readString(end - this.offset);
-        return sign === -1 ? `-${str}` : str;
+        str = sign === -1 ? `-${str}` : str;
+        result = Long.fromString(str, false, 10);
+        if (result.greaterThan(Number.MAX_SAFE_INTEGER) || result.lessThan(Number.MIN_SAFE_INTEGER)) {
+          return result.toString();
+        } 
+        return result.toNumber();
       }
     }
     if (this.buffer[this.offset] === plus) {

--- a/test/integration/connection/test-insert-bigint.js
+++ b/test/integration/connection/test-insert-bigint.js
@@ -26,18 +26,18 @@ connection.query("INSERT INTO bigs SET title='test1'", (err, result) => {
   connection.query("INSERT INTO bigs SET title='test2'", (err, result) => {
     assert.strictEqual(result.insertId, 123456790);
     // big int
-    connection.query("INSERT INTO bigs SET title='test', id=9007199254740992");
+    connection.query("INSERT INTO bigs SET title='test', id=9007199254740991");
     connection.query("INSERT INTO bigs SET title='test3'", (err, result) => {
       assert.strictEqual(
-        Long.fromString('9007199254740993').compare(result.insertId),
+        Long.fromString('9007199254740992').compare(result.insertId),
         0
       );
       connection.query(
-        "INSERT INTO bigs SET title='test', id=90071992547409924"
+        "INSERT INTO bigs SET title='test', id=90071992547409923"
       );
       connection.query("INSERT INTO bigs SET title='test4'", (err, result) => {
         assert.strictEqual(
-          Long.fromString('90071992547409925').compare(result.insertId),
+          Long.fromString('90071992547409924').compare(result.insertId),
           0
         );
         connection.query(
@@ -51,10 +51,10 @@ connection.query("INSERT INTO bigs SET title='test1'", (err, result) => {
             assert.strictEqual(result[1].id, 124);
             assert.strictEqual(result[2].id, 123456789);
             assert.strictEqual(result[3].id, 123456790);
-            assert.strictEqual(result[4].id, 9007199254740992);
-            assert.strictEqual(result[5].id, '9007199254740993');
-            assert.strictEqual(result[6].id, '90071992547409924');
-            assert.strictEqual(result[7].id, '90071992547409925');
+            assert.strictEqual(result[4].id, 9007199254740991);
+            assert.strictEqual(result[5].id, '9007199254740992');
+            assert.strictEqual(result[6].id, '90071992547409923');
+            assert.strictEqual(result[7].id, '90071992547409924');
             connection.end();
           }
         );


### PR DESCRIPTION
Previously, big numbers were sometimes returned as number instead of string even if the number is larger than `Number.MAX_SAFE_INTEGER` or smaller than `Number.MIN_SAFE_INTEGER`. The behavior was conditional on the equality of `bigNumber.toString() === fullAccuracyNumberInString`. However, the number may not be at full accuracy: for many big numbers `BigInt(bigNumber).toString() !== bigNumber.toString()`, e.g., `99000001013466380`

<img width="303" alt="Screenshot 2023-11-13 at 7 43 29 PM" src="https://github.com/sidorares/node-mysql2/assets/122313953/c7876f14-8734-4b34-b75e-4dfcc01c89e2">
