### PR TITLE
fix: add decodeuricomponent to parse uri encoded special characters in host, username, password and datbase keys

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -260,11 +260,11 @@ class ConnectionConfig {
   static parseUrl(url) {
     const parsedUrl = new URL(url);
     const options = {
-      host: parsedUrl.hostname,
+      host: decodeURIComponent(parsedUrl.hostname),
       port: parseInt(parsedUrl.port, 10),
-      database: parsedUrl.pathname.slice(1),
-      user: parsedUrl.username,
-      password: parsedUrl.password
+      database: decodeURIComponent(parsedUrl.pathname.slice(1)),
+      user: decodeURIComponent(parsedUrl.username),
+      password: decodeURIComponent(parsedUrl.password),
     };
     parsedUrl.searchParams.forEach((value, key) => {
       try {

--- a/test/unit/connection/test-connection_config.js
+++ b/test/unit/connection/test-connection_config.js
@@ -45,7 +45,36 @@ assert.doesNotThrow(() => {
 
 assert.strictEqual(
   ConnectionConfig.parseUrl(
-    String.raw`fml://test:pass!@$%^&*()\word:@www.example.com/database`
+    String.raw`fml://test:pass!%40%24%25%5E%26*()word%3A@www.example.com/database`,
   ).password,
-  'pass!%40$%%5E&*()%5Cword%3A'
+  'pass!@$%^&*()word:',
 );
+
+assert.strictEqual(
+  ConnectionConfig.parseUrl(
+    String.raw`fml://user%40test.com:pass!%40%24%25%5E%26*()word%3A@www.example.com/database`,
+  ).user,
+  'user@test.com',
+);
+
+assert.strictEqual(
+  ConnectionConfig.parseUrl(
+    String.raw`fml://test:pass@wordA@fe80%3A3438%3A7667%3A5c77%3Ace27%2518/database`,
+  ).host,
+  'fe80:3438:7667:5c77:ce27%18',
+);
+
+assert.strictEqual(
+  ConnectionConfig.parseUrl(
+    String.raw`fml://test:pass@wordA@www.example.com/database`,
+  ).host,
+  'www.example.com',
+);
+
+assert.strictEqual(
+  ConnectionConfig.parseUrl(
+    String.raw`fml://test:pass@wordA@www.example.com/database%24`,
+  ).database,
+  'database$',
+);
+


### PR DESCRIPTION
This is PR to make changes as per last discussion here - https://github.com/sidorares/node-mysql2/pull/1621#issuecomment-1236397707

Also resolves https://github.com/sidorares/node-mysql2/issues/1384

Added decodeURIComponent for username, password, host and database. Currently, if mysql DB has password with special characters like '@', it isnt working at all it seems. After this change, this seems to be working. Also the discussion also clarifies that we should go ahead with this minimal change at least to keep it consistent with MySQL docs.