### PR TITLE
fix: Malformed FieldPacket

### DIFF
--- a/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
@@ -16,7 +16,7 @@ declare interface FieldPacket {
   orgTable: string;
   protocol41?: boolean;
   table: string;
-  type: number;
+  type?: number;
   columnType?: number
   zerofill?: boolean;
   typeName?: string;

--- a/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
@@ -3,19 +3,18 @@ declare interface FieldPacket {
     name: 'FieldPacket';
   };
   catalog: string;
-  charsetNr: number;
-  db: string;
+  schema: string;
+  characterSet: number;
   decimals: number;
-  default: any;
-  flags: number;
-  length: number;
+  flags: string[];
   name: string;
   orgName: string;
   orgTable: string;
-  protocol41: boolean;
   table: string;
   type: number;
-  zerofill: boolean;
+  typeName: string;
+  encoding: string;
+  columnLength: number;
 }
 
 export { FieldPacket };

--- a/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
@@ -17,6 +17,7 @@ declare interface FieldPacket {
   protocol41?: boolean;
   table: string;
   type: number;
+  columnType?: number
   zerofill?: boolean;
   typeName?: string;
   encoding?: string;

--- a/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
@@ -3,18 +3,24 @@ declare interface FieldPacket {
     name: 'FieldPacket';
   };
   catalog: string;
-  schema: string;
-  characterSet: number;
+  charsetNr?: number;
+  db?: string;
+  schema?: string;
+  characterSet?: number;
   decimals: number;
-  flags: string[];
+  default?: any;
+  flags: number | string[];
+  length?: number;
   name: string;
   orgName: string;
   orgTable: string;
+  protocol41?: boolean;
   table: string;
   type: number;
-  typeName: string;
-  encoding: string;
-  columnLength: number;
+  zerofill?: boolean;
+  typeName?: string;
+  encoding?: string;
+  columnLength?: number;
 }
 
 export { FieldPacket };


### PR DESCRIPTION
This ought to fix https://github.com/sidorares/node-mysql2/issues/1276.

I confirm object in v3.6.3.

```
{
  catalog: 'def',
  schema: 'for_test',
  name: 'id',
  orgName: 'id',
  table: 'hotels',
  orgTable: 'hotels',
  characterSet: 63,
  encoding: 'binary',
  columnLength: 10,
  type: 3,
  flags: [ 'NOT NULL', 'PRIMARY KEY', 'AUTO_INCREMENT' ],
  decimals: 0,
  typeName: 'LONG'
}
```