### PR TITLE
feat: add checkServerIdentity override

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -353,8 +353,9 @@ class Connection extends EventEmitter {
       minVersion: this.config.ssl.minVersion,
       maxVersion: this.config.ssl.maxVersion
     });
-    const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
-    const verifyIdentity = this.config.ssl.verifyIdentity;
+    const rejectUnauthorized = this.config.ssl.rejectUnauthorized === undefined ? true : this.config.ssl.rejectUnauthorized;
+    const verifyIdentity = this.config.ssl.verifyIdentity === undefined ? true : this.config.ssl.verifyIdentity;
+    const checkServerIdentity = (verifyIdentity && rejectUnauthorized) ? (this.config.ssl.checkServerIdentity || Tls.checkServerIdentity) : () => null;
     const servername = this.config.host;
 
     let secureEstablished = false;
@@ -365,19 +366,10 @@ class Connection extends EventEmitter {
       secureContext,
       isServer: false,
       socket: this.stream,
-      servername
+      servername,
+      checkServerIdentity
     }, () => {
       secureEstablished = true;
-      if (rejectUnauthorized) {
-        if (typeof servername === 'string' && verifyIdentity) {
-          const cert = secureSocket.getPeerCertificate(true);
-          const serverIdentityCheckError = Tls.checkServerIdentity(servername, cert);
-          if (serverIdentityCheckError) {
-            onSecure(serverIdentityCheckError);
-            return;
-          }
-        }
-      }
       onSecure();
     });
     // error handler for secure socket


### PR DESCRIPTION
This fixes the issue described by https://github.com/sidorares/node-mysql2/pull/2119#issuecomment-1655735558 and partially resolves https://github.com/sidorares/node-mysql2/issues/2172. 

This doesn't implement the changes described in the issue regarding deprecating the Amazon RDS profile in favor of moving that out to a new package but it does allow for a path forward to re-enabling `rejectUnauthorized`.

The follow scenarios are now true:
- Set `rejectUnauthorized: false` - never any server identity verification
- Set `rejectUnauthorized: true` or not provided:
  
  - set `verifyIdentity: true` or not provided - run provided `checkServerIdentity()` or use default `tls.checkServerIdentity()` function

  - set `verifyIdentity: false` - `checkServerIdentity` set to no-op function

How was this tested? 

I tested changes locally against a tls-enabled postgresql instance. I'm not sure of how to incorporate any unit or integration tests for this as there does not currently appear to be any. Any support here would be lovely. 