### PR TITLE
feat(docs): release documentation website

### DIFF
--- a/website/docs/contributing/website.mdx
+++ b/website/docs/contributing/website.mdx
@@ -11,7 +11,7 @@ import { ExternalCodeEmbed } from '@site/src/components/ExternalCodeEmbed';
 
 This website is built using [Docusaurus 3](https://docusaurus.io/), a modern static website generator.
 
----
+<hr />
 
 ## Environment
 
@@ -19,7 +19,7 @@ You will need these tools installed on your system:
 
 - [Node.js (18.x or higher)](https://nodejs.org/)
 
----
+<hr />
 
 ## Development
 
@@ -58,7 +58,7 @@ Note that the website has its own _package.json_.
 Please, do not install dependencies for the website in **node-mysql2** root.
 :::
 
----
+<hr />
 
 ## Extras Components
 
@@ -100,7 +100,7 @@ You can also utilize React components in the `changes` option.
   />
 </FAQ>
 
----
+<hr />
 
 ### Stability
 
@@ -126,7 +126,7 @@ Available levels: `0`, `1`, `1.1`, `1.2`, `2` and `3`.
   <Stability level={2} message='Some message.' />
 </FAQ>
 
----
+<hr />
 
 ### FAQ
 
@@ -157,7 +157,7 @@ import { FAQ } from '@site/src/components/FAQ';
   </FAQ>
 </FAQ>
 
----
+<hr />
 
 ### ExternalCodeEmbed
 
@@ -193,7 +193,7 @@ import { ExternalCodeEmbed } from '@site/src/components/ExternalCodeEmbed';
   />
 </FAQ>
 
----
+<hr />
 
 ## Running Tests
 

--- a/website/docs/documentation/00-index.mdx
+++ b/website/docs/documentation/00-index.mdx
@@ -29,13 +29,13 @@ Not only **MySQL2** offers better performance over [Node MySQL][node-mysql], we 
 - MySQL Compression
 - Binary Log Protocol Client
 
----
+<hr />
 
 ## Examples
 
 Please check these [examples](/docs/examples) for **MySQL2**.
 
----
+<hr />
 
 ## Known incompatibilities with [Node MySQL][node-mysql]
 
@@ -54,7 +54,7 @@ Please check these [examples](/docs/examples) for **MySQL2**.
 This option could lose precision on the number as Javascript Number is a Float!
 :::
 
----
+<hr />
 
 ## Other Resources
 
@@ -64,7 +64,7 @@ This option could lose precision on the number as Javascript Number is a Float!
 - [node-libmysqlclient](https://github.com/Sannis/node-mysql-libmysqlclient) - Bindings to libmysqlclient
 - [go-mysql](https://github.com/siddontang/go-mysql) - MySQL Go client (prepared statements, binlog protocol, server)
 
----
+<hr />
 
 ## Benchmarks
 

--- a/website/docs/documentation/mysql-server.mdx
+++ b/website/docs/documentation/mysql-server.mdx
@@ -10,7 +10,7 @@
 - **connect**
   - new incoming connection.
 
----
+<hr />
 
 ## Connection
 

--- a/website/docs/documentation/typescript-examples.mdx
+++ b/website/docs/documentation/typescript-examples.mdx
@@ -16,7 +16,7 @@ npm install --save-dev @types/node
 Requires **TypeScript** `>=4.5.2`.
 :::
 
----
+<hr />
 
 ## Usage
 
@@ -90,7 +90,7 @@ The `rows` output will be these possible types:
 
 In this example, you need to manually check the output types
 
----
+<hr />
 
 ## Type Specification
 
@@ -156,7 +156,7 @@ conn.query<RowDataPacket[]>('SHOW TABLES FROM `test`;', (_err, rows) => {
 });
 ```
 
----
+<hr />
 
 ### RowDataPacket[][]
 
@@ -186,7 +186,7 @@ conn.query<RowDataPacket[][]>(sql, (_err, rows) => {
 });
 ```
 
----
+<hr />
 
 ### ResultSetHeader
 
@@ -244,7 +244,7 @@ conn.query<ResultSetHeader>(sql, (_err, result) => {
 });
 ```
 
----
+<hr />
 
 ### ResultSetHeader[]
 
@@ -306,7 +306,7 @@ conn.query<ResultSetHeader[]>(sql, (_err, results) => {
 });
 ```
 
----
+<hr />
 
 ### ProcedureCallPacket
 
@@ -379,7 +379,7 @@ By using `SELECT` and `SHOW` queries in a **Procedure Call**, it groups the resu
 
 For `ProcedureCallPacket<RowDataPacket[]>`, please see the following examples.
 
----
+<hr />
 
 ### OkPacket
 
@@ -395,7 +395,7 @@ For `ProcedureCallPacket<RowDataPacket[]>`, please see the following examples.
   }
 />
 
----
+<hr />
 
 ## Examples
 

--- a/website/docs/examples/connections/create-connection.mdx
+++ b/website/docs/examples/connections/create-connection.mdx
@@ -53,7 +53,7 @@ connection.addListener('error', (err) => {
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ## createConnection(config)
 
@@ -102,7 +102,7 @@ connection.addListener('error', (err) => {
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ## createConnection(config) — SHA1
 
@@ -148,7 +148,7 @@ connection.addListener('error', (err) => {
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ## createConnection(config) — SSL
 
@@ -208,7 +208,7 @@ connection.addListener('error', (err) => {
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ## createConnection(config) — RDS SSL
 
@@ -297,7 +297,7 @@ connectionquery('SHOW `status` LIKE "Ssl_cipher"', function (err, res) {
   - [#2119 — fix: make startTls code compatible with Bun](https://github.com/sidorares/node-mysql2/pull/2119)
   - [#2131 — Update Amazon RDS SSL CA cert](https://github.com/sidorares/node-mysql2/pull/2131)
 
----
+<hr />
 
 ## createConnection(config) — Socks
 
@@ -379,7 +379,7 @@ connection.execute('SELECT SLEEP(1) AS `qqq`', (err, rows, fields) => {
 
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/examples/connections/create-pool.mdx
+++ b/website/docs/examples/connections/create-pool.mdx
@@ -70,7 +70,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## createPool(config)
 
@@ -140,7 +140,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## createPool(config) — SHA1
 
@@ -207,7 +207,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## createPool(config) — SSL
 
@@ -288,7 +288,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## createPool(config) — RDS SSL
 
@@ -398,7 +398,7 @@ Don't forget to release the connection when finished by using:
   - [#2119 — fix: make startTls code compatible with Bun](https://github.com/sidorares/node-mysql2/pull/2119)
   - [#2131 — Update Amazon RDS SSL CA cert](https://github.com/sidorares/node-mysql2/pull/2131)
 
----
+<hr />
 
 ## createPool(config) — Socks
 
@@ -472,22 +472,24 @@ pool.execute('SELECT SLEEP(1) AS `qqq`', (err, rows, fields) => {
 
 :::
 
----
+<hr />
 
 ## Glossary
 
 ### PoolOptions
 
-> **PoolOptions** extends all options from **ConnectionOptions**:
->
-> <FAQ title='ConnectionOptions Specification'>
->   <ExternalCodeEmbed
->     language='ts'
->     url='https://raw.githubusercontent.com/sidorares/node-mysql2/master/typings/mysql/lib/Connection.d.ts'
->     extractMethod='ConnectionOptions'
->     methodType='interface'
->   />
-> </FAQ>
+<blockquote>
+  **PoolOptions** extends all options from **ConnectionOptions**:
+
+  <FAQ title='ConnectionOptions Specification'>
+    <ExternalCodeEmbed
+      language='ts'
+      url='https://raw.githubusercontent.com/sidorares/node-mysql2/master/typings/mysql/lib/Connection.d.ts'
+      extractMethod='ConnectionOptions'
+      methodType='interface'
+    />
+  </FAQ>
+</blockquote>
 
 <FAQ title='PoolOptions Specification'>
   <ExternalCodeEmbed

--- a/website/docs/examples/connections/createPoolCluster.mdx
+++ b/website/docs/examples/connections/createPoolCluster.mdx
@@ -76,7 +76,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## add(group, config)
 
@@ -152,7 +152,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## add(group, config) — SHA1
 
@@ -225,7 +225,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## add(group, config) — SSL
 
@@ -312,7 +312,7 @@ Don't forget to release the connection when finished by using:
 
 :::
 
----
+<hr />
 
 ## add(group, config) — RDS SSL
 
@@ -428,7 +428,7 @@ Don't forget to release the connection when finished by using:
   - [#2119 — fix: make startTls code compatible with Bun](https://github.com/sidorares/node-mysql2/pull/2119)
   - [#2131 — Update Amazon RDS SSL CA cert](https://github.com/sidorares/node-mysql2/pull/2131)
 
----
+<hr />
 
 ## add(group, config) — Socks
 
@@ -512,22 +512,24 @@ poolNamespace.execute('SELECT SLEEP(1) AS `qqq`', (err, rows, fields) => {
 
 :::
 
----
+<hr />
 
 ## Glossary
 
 ### PoolOptions
 
-> **PoolOptions** extends all options from **ConnectionOptions**:
->
-> <FAQ title='ConnectionOptions Specification'>
->   <ExternalCodeEmbed
->     language='ts'
->     url='https://raw.githubusercontent.com/sidorares/node-mysql2/master/typings/mysql/lib/Connection.d.ts'
->     extractMethod='ConnectionOptions'
->     methodType='interface'
->   />
-> </FAQ>
+<blockquote>
+  **PoolOptions** extends all options from **ConnectionOptions**:
+
+  <FAQ title='ConnectionOptions Specification'>
+    <ExternalCodeEmbed
+      language='ts'
+      url='https://raw.githubusercontent.com/sidorares/node-mysql2/master/typings/mysql/lib/Connection.d.ts'
+      extractMethod='ConnectionOptions'
+      methodType='interface'
+    />
+  </FAQ>
+</blockquote>
 
 <FAQ title='PoolOptions Specification'>
   <ExternalCodeEmbed

--- a/website/docs/examples/queries/prepared-statements/delete.mdx
+++ b/website/docs/examples/queries/prepared-statements/delete.mdx
@@ -60,7 +60,7 @@ connection.execute(sql, values, (err, result, fields) => {
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options)
 
@@ -124,7 +124,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options, values)
 
@@ -190,7 +190,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/examples/queries/prepared-statements/index.mdx
+++ b/website/docs/examples/queries/prepared-statements/index.mdx
@@ -9,7 +9,7 @@ See detailed documentaion in [Prepared Statements](/docs/documentation/prepared-
 If you execute same statement again, it will be picked form a **LRU cache** which will save query preparation time and give better performance.
 :::
 
----
+<hr />
 
 Usage examples:
 

--- a/website/docs/examples/queries/prepared-statements/insert.mdx
+++ b/website/docs/examples/queries/prepared-statements/insert.mdx
@@ -60,7 +60,7 @@ connection.execute(sql, values, (err, result, fields) => {
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options)
 
@@ -124,7 +124,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options, values)
 
@@ -190,7 +190,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/examples/queries/prepared-statements/select.mdx
+++ b/website/docs/examples/queries/prepared-statements/select.mdx
@@ -60,7 +60,7 @@ connection.execute(sql, values, (err, rows, fields) => {
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options)
 
@@ -124,7 +124,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options, values)
 
@@ -190,7 +190,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/examples/queries/prepared-statements/update.mdx
+++ b/website/docs/examples/queries/prepared-statements/update.mdx
@@ -60,7 +60,7 @@ connection.execute(sql, values, (err, result, fields) => {
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options)
 
@@ -124,7 +124,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## execute(options, values)
 
@@ -190,7 +190,7 @@ connection.execute(
 The connection used for the query (`execute`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/examples/queries/simple-queries/delete.mdx
+++ b/website/docs/examples/queries/simple-queries/delete.mdx
@@ -60,7 +60,7 @@ connection.query(sql, (err, result, fields) => {
 The connection used for the query (`.query()`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## query(options)
 
@@ -120,7 +120,7 @@ connection.query(
 The connection used for the query (`.query()`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/examples/queries/simple-queries/index.mdx
+++ b/website/docs/examples/queries/simple-queries/index.mdx
@@ -4,7 +4,7 @@
 For **Prepared Statements** or **Placeholders** / **Parameters** examples, please see [here](/docs/examples/queries/prepared-statements).
 :::
 
----
+<hr />
 
 Usage examples:
 

--- a/website/docs/examples/queries/simple-queries/select.mdx
+++ b/website/docs/examples/queries/simple-queries/select.mdx
@@ -60,7 +60,7 @@ connection.query(sql, (err, rows, fields) => {
 The connection used for the query (`.query()`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## query(options)
 
@@ -120,7 +120,7 @@ connection.query(
 The connection used for the query (`.query()`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## query(options) — Row as Array
 
@@ -182,7 +182,7 @@ connection.query(
 The connection used for the query (`.query()`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/examples/queries/simple-queries/update.mdx
+++ b/website/docs/examples/queries/simple-queries/update.mdx
@@ -60,7 +60,7 @@ connection.query(sql, (err, result, fields) => {
 The connection used for the query (`.query()`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## query(options)
 
@@ -120,7 +120,7 @@ connection.query(
 The connection used for the query (`.query()`) can be obtained through the `createConnection`, `createPool` or `createPoolCluster` methods.
 :::
 
----
+<hr />
 
 ## Glossary
 

--- a/website/docs/faq/how-to-handle-errors.mdx
+++ b/website/docs/faq/how-to-handle-errors.mdx
@@ -273,7 +273,7 @@ try {
 
 </FAQ>
 
----
+<hr />
 
 ## Related Links
 

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -56,7 +56,7 @@ npm install --save-dev @types/node
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ### First Query
 
@@ -137,7 +137,7 @@ connection.query(
 </TabItem>
 </Tabs>
 
----
+<hr />
 
 ### Using Prepared Statements
 
@@ -207,7 +207,7 @@ connection.execute(
 If you execute same statement again, it will be picked from a LRU cache which will save query preparation time and give better performance.
 :::
 
----
+<hr />
 
 ### Using Connection Pools
 
@@ -266,7 +266,7 @@ const pool = mysql.createPool({
 The pool does not create all connections upfront but creates them on demand until the connection limit is reached.
 :::
 
----
+<hr />
 
 You can use the pool in the same way as connections (using `pool.query()` and `pool.execute()`):
 
@@ -335,7 +335,7 @@ pool.getConnection(function (err, conn) {
 conn.release();
 ```
 
----
+<hr />
 
 ### Using Promise Wrapper
 
@@ -427,7 +427,7 @@ conn
   .then(() => conn.end());
 ```
 
----
+<hr />
 
 ### Array Results
 
@@ -504,7 +504,7 @@ conn.query(
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 :::tip Getting Help
 Need help? Ask your question on [Stack Overflow](https://stackoverflow.com/questions/tagged/mysql2) or [GitHub](https://github.com/sidorares/node-mysql2/discussions).

--- a/website/docs/stability-badges.mdx
+++ b/website/docs/stability-badges.mdx
@@ -11,7 +11,7 @@ The stability indices are as follows:
   message='The feature might generate warnings and does not assure backward compatibility.'
 />
 
----
+<hr />
 
 **Experimental**: These features are not bound by semantic versioning. They may undergo non-backward compatible changes or be removed in future releases. Their use in production is discouraged.
 
@@ -34,14 +34,14 @@ Experimental features are classified into stages:
   message='Experimental features are close to reaching stability. Major changes are not expected, but they could still occur based on user feedback. Testing and feedback are important to ascertain the readiness of these features for stable classification.'
 />
 
----
+<hr />
 
 <Stability
   level={2}
   message='Compatibility with the MySQL ecosystem is a high priority.'
 />
 
----
+<hr />
 
 <Stability
   level={3}

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
@@ -46,7 +46,7 @@ O MySQL2 não tem restrições nativas e pode ser instalado no Linux, Mac OS ou 
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ### Primeira Consulta (_Query_)
 
@@ -127,7 +127,7 @@ connection.query(
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ### Usando Instruções Preparadas (_Prepared Statements_)
 
@@ -197,7 +197,7 @@ connection.execute(
 Se você executar a mesma declaração novamente, ela será selecionada a partir do LRU Cache, o que economizará tempo de preparação da consulta e proporcionará melhor desempenho.
 :::
 
----
+<hr />
 
 ### Usando Conjunto de Conexões (_pools_) {#using-connection-pools}
 
@@ -256,7 +256,7 @@ const pool = mysql.createPool({
 O _pool_ não estabelece todas as conexões previamente, mas as cria sob demanda até que o limite de conexões seja atingido.
 :::
 
----
+<hr />
 
 Você pode usar o _pool_ da mesma maneira como em uma conexão (usando `pool.query()` e `pool.execute()`):
 
@@ -325,7 +325,7 @@ pool.getConnection(function (err, conn) {
   conn.release();
   ```
 
----
+<hr />
 
 ### Usando o _Promise Wrapper_
 
@@ -417,7 +417,7 @@ conn
   .then(() => conn.end());
 ```
 
----
+<hr />
 
 ### Resultados em _Array_
 
@@ -494,7 +494,7 @@ conn.query(
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 :::tip Obtendo Ajuda
 Precisa de ajuda? Faça sua pergunta no [Stack Overflow](https://stackoverflow.com/questions/tagged/mysql2) ou [GitHub](https://github.com/sidorares/node-mysql2/discussions).

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
@@ -46,7 +46,7 @@ npm install --save-dev @types/node
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ### 查询数据
 
@@ -127,7 +127,7 @@ connection.query(
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 ### SQL预处理的使用
 
@@ -197,7 +197,7 @@ connection.execute(
 如果再次执行相同的语句，他将从缓存中选取，这能有效的节省准备查询时间获得更好的性能。
 :::
 
----
+<hr />
 
 ### 连接池的使用 {#using-connection-pools}
 
@@ -256,7 +256,7 @@ const pool = mysql.createPool({
 该池不会预先创建所有连接，而是根据需要创建它们，直到达到连接限制。
 :::
 
----
+<hr />
 
 您可以像直接连接一样使用池（使用 `pool.query()` 和 `pool.execute()`）：
 
@@ -325,7 +325,7 @@ pool.getConnection(function (err, conn) {
   conn.release();
   ```
 
----
+<hr />
 
 ### Promise封装
 
@@ -417,7 +417,7 @@ conn
   .then(() => conn.end());
 ```
 
----
+<hr />
 
 ### 结果返回
 
@@ -494,7 +494,7 @@ conn.query(
   </TabItem>
 </Tabs>
 
----
+<hr />
 
 :::tip Getting Help
 Need help? Ask your question on [Stack Overflow](https://stackoverflow.com/questions/tagged/mysql2) or [GitHub](https://github.com/sidorares/node-mysql2/discussions).

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -6,7 +6,7 @@ function Home() {
   const { baseUrl } = siteConfig;
   const currentLocale = i18n.currentLocale;
   const setLocaleRedirectMap = () =>
-    currentLocale === 'en'
+    currentLocale === 'en' || baseUrl.includes(currentLocale)
       ? `${baseUrl}docs`
       : `${baseUrl}${currentLocale}/docs`;
   const redirectUrl = setLocaleRedirectMap();


### PR DESCRIPTION
@sidorares, _maybe_, finally a simple way to record anything we want into _[Changelog.md](https://github.com/sidorares/node-mysql2/blob/master/Changelog.md)_, for example:

- **fix(docs):** GitHub MDX parser conflict
- **fix(website):** i18n home breadcrumb

This way is not exclusive to **Release Please**, but to **Conventional Commits** itself.

ℹ️ In these cases, it's important to note that merging will create a release.

> I'll use this PR to see it in practice and "announce" the Documentation Website 🧑🏻‍🔧✨

---

I see it in this [commit](https://github.com/nextauthjs/next-auth/commit/1b9ef7f1259bbd367f2e71a809bc5c8489259445) from [next-auth](https://github.com/nextauthjs/next-auth).
 
Then, it appears as:
 
> ## Bugfixes
> - **docs:** update links, fix codeblocks, rephrase (https://github.com/nextauthjs/next-auth/pull/9566) (https://github.com/nextauthjs/next-auth/commit/1b9ef7f1259bbd367f2e71a809bc5c8489259445)

---

## About this PR

This _PR_ fixes a **GitHub** conflict on its **MDX** parser that doesn't recognize the `---` as `<hr />`.

### Why?

Before this PR:
https://github.com/sidorares/node-mysql2/blob/323ab122331debebd8038e096a1bc18bdc3dca70/website/docs/examples/queries/prepared-statements/select.mdx#L73-L89

After this PR, **GitHub** will parse the **MDX** correctly:

```js
try {
  const sql = 'SELECT * FROM `users` WHERE `name` = ? AND `age` > ?';
  const values = ['Page', 45];

  // highlight-start
  const [rows, fields] = await connection.execute({
    sql,
    values,
    // ... other options
  });
  // highlight-end

  console.log(rows);
  console.log(fields);
} catch (err) {
  console.log(err);
}
```

