### PR TITLE
ci: refactor CI - OSX

### DIFF
--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18.x, 20.x]
-        mysql-version: ["mysql:8.0.22", "mysql:8.0.33"]
+        mysql-version: ["mysql:8.0.33"]
         use-compression: [0, 1]
         use-tls: [0]
         mysql_connection_url_key: [""]

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -18,24 +18,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [ 20.x]
         mysql-version: ["mysql:8.0.33"]
         use-compression: [0, 1]
-        use-tls: [0]
+        use-tls: [0, 1]
         mysql_connection_url_key: [""]
-        # TODO - add mariadb to the matrix. currently few tests are broken due to mariadb incompatibilities
-        include:
-          # 20.x
-          - node-version: "20.x"
-            mysql-version: "mysql:8.0.33"
-            use-compression: 1
-            use-tls: 0
-            use-builtin-test-runner: 1
-          - node-version: "20.x"
-            mysql-version: "mysql:8.0.33"
-            use-compression: 0
-            use-tls: 1
-            use-builtin-test-runner: 1
     env:
       MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}
 
@@ -82,7 +69,3 @@ jobs:
 
       - name: Run tests
         run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run coverage-test
-
-      - name: Run tests with built-in node test runner
-        if: ${{ matrix.use-builtin-test-runner }}
-        run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run test:builtin-node-runner


### PR DESCRIPTION
> See this _PR_ also as a discussion based on ["osx is a low priority and intended to be a smoke test"](https://github.com/sidorares/node-mysql2/pull/2308#issuecomment-1842002931) comment.

It's been some time that **GitHub** has been failing `macOS-based` tests.

These false positives motivated two other _PRs_ (#2308 and #2348), but the problem isn't really with the **CI**.

---

Since the tests "against" the **MySQL Server** already take place in `CI - Linux`, I would like to propose that the test focus on **Node.js** versions for `macOS-based` tests (how it's already done in `CI - Windows`), reducing the chance of false positives.

---

Currently, I frequently try and retry the `CI - OSX` until it passes without false positives.

