### PR TITLE
fix: The removeIdleTimeoutConnectionsTimer did not clean up when the …

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -100,6 +100,7 @@ class Pool extends EventEmitter {
 
   end(cb) {
     this._closed = true;
+    clearTimeout(this._removeIdleTimeoutConnectionsTimer);
     if (typeof cb !== 'function') {
       cb = function(err) {
         if (err) {

--- a/test/integration/test-pool-release-idle-connection.js
+++ b/test/integration/test-pool-release-idle-connection.js
@@ -38,7 +38,6 @@ pool.getConnection((err1, connection1) => {
           connection4.release();
           connection4.destroy();
           pool.end();
-          setTimeout(() => process.exit(0), 1000);
         });
       }, 7000);
     });


### PR DESCRIPTION
…pool was closed.

 #1917