### PR TITLE
Perf: cache iconv decoder

### DIFF
--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -1,22 +1,34 @@
 'use strict';
 
 const Iconv = require('iconv-lite');
-const decoderCache = new Map();
+const LRU = require('lru-cache');
+
+const decoderCache = new LRU({
+  max: 500,
+});
 
 exports.decode = function (buffer, encoding, start, end, options) {
   if (Buffer.isEncoding(encoding)) {
     return buffer.toString(encoding, start, end);
   }
 
-  const decoderArgs = { encoding, options: options || {} };
-  const decoder =
-    decoderCache.get(decoderArgs) ||
-    decoderCache
-      .set(
-        decoderArgs,
-        Iconv.getDecoder(decoderArgs.encoding, decoderArgs.options),
-      )
-      .get(decoderArgs);
+  // Optimize for common case: encoding="short_string", options=undefined.
+  let decoder;
+  if (!options) {
+    decoder = decoderCache.get(encoding);
+    if (!decoder) {
+      decoder = Iconv.getDecoder(encoding);
+      decoderCache.set(encoding, decoder);
+    }
+  } else {
+    const decoderArgs = { encoding, options };
+    const decoderKey = JSON.stringify(decoderArgs);
+    decoder = decoderCache.get(decoderKey);
+    if (!decoder) {
+      decoder = Iconv.getDecoder(decoderArgs.encoding, decoderArgs.options);
+      decoderCache.set(decoderKey, decoder);
+    }
+  }
 
   const res = decoder.write(buffer.slice(start, end));
   const trail = decoder.end();

--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -1,13 +1,22 @@
 'use strict';
 
 const Iconv = require('iconv-lite');
+const decoderCache = new Map();
 
-exports.decode = function(buffer, encoding, start, end, options) {
+exports.decode = function (buffer, encoding, start, end, options) {
   if (Buffer.isEncoding(encoding)) {
     return buffer.toString(encoding, start, end);
   }
 
-  const decoder = Iconv.getDecoder(encoding, options || {});
+  const decoderArgs = { encoding, options: options || {} };
+  const decoder =
+    decoderCache.get(decoderArgs) ||
+    decoderCache
+      .set(
+        decoderArgs,
+        Iconv.getDecoder(decoderArgs.encoding, decoderArgs.options),
+      )
+      .get(decoderArgs);
 
   const res = decoder.write(buffer.slice(start, end));
   const trail = decoder.end();
@@ -15,7 +24,7 @@ exports.decode = function(buffer, encoding, start, end, options) {
   return trail ? res + trail : res;
 };
 
-exports.encode = function(string, encoding, options) {
+exports.encode = function (string, encoding, options) {
   if (Buffer.isEncoding(encoding)) {
     return Buffer.from(string, encoding);
   }

--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Iconv = require('iconv-lite');
-const LRU = require('lru-cache');
+const LRU = require('lru-cache').default;
 
 const decoderCache = new LRU({
   max: 500,


### PR DESCRIPTION
While getting an iconv decoder isn't particularly slow, I noticed it happens a lot when decoding lots of varchar rows. From internal testing, with 5000 rows of a table containing two varchar utf8mb3 columns (length 100 and 500), I'm seeing about 12% speedup with this change.