### PR TITLE
Fix premature close of the stream when it is paused

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -30,7 +30,7 @@ class Query extends Command {
     this._receivedFieldsCount = 0;
     this._resultIndex = 0;
     this._localStream = null;
-    this._unpipeStream = function() {};
+    this._unpipeStream = function () { };
     this._streamFactory = options.infileStreamFactory;
     this._connection = null;
   }
@@ -155,7 +155,7 @@ class Query extends Command {
     const onPause = () => {
       this._localStream.pause();
     };
-    const onData = function(data) {
+    const onData = function (data) {
       const dataWithHeader = Buffer.allocUnsafe(data.length + 4);
       data.copy(dataWithHeader, 4);
       connection.writePacket(
@@ -227,7 +227,7 @@ class Query extends Command {
   }
 
   /* eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */
-  row(packet, _connection) { 
+  row(packet, _connection) {
     if (packet.isEOF()) {
       const status = packet.eofStatusFlags();
       const moreResults = status & ServerStatus.SERVER_MORE_RESULTS_EXISTS;
@@ -279,10 +279,12 @@ class Query extends Command {
     });
     this.on('end', () => {
       stream.push(null); // pushing null, indicating EOF
-      setImmediate(() => stream.emit('close')); // notify readers that query has completed
     });
     this.on('fields', fields => {
       stream.emit('fields', fields); // replicate old emitter
+    });
+    stream.on('end', () => {
+      stream.emit('close');
     });
     return stream;
   }
@@ -302,7 +304,7 @@ class Query extends Command {
       Timers.clearTimeout(this.queryTimeout);
       this.queryTimeout = null;
     }
-    
+
     const err = new Error('Query inactivity timeout');
     err.errorno = 'PROTOCOL_SEQUENCE_TIMEOUT';
     err.code = 'PROTOCOL_SEQUENCE_TIMEOUT';

--- a/package-lock.json
+++ b/package-lock.json
@@ -3443,8 +3443,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -3868,8 +3867,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-async-await": {
       "version": "0.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3443,7 +3443,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -3867,7 +3868,8 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-async-await": {
       "version": "0.0.0",

--- a/test/integration/connection/test-stream.js
+++ b/test/integration/connection/test-stream.js
@@ -8,6 +8,7 @@ let rows;
 const rows1 = [];
 const rows2 = [];
 const rows3 = [];
+const rows4 = [];
 
 connection.query(
   [
@@ -65,6 +66,11 @@ connection.execute('SELECT * FROM announcements', async (err, _rows) => {
   for await (const row of s3) {
     rows3.push(row);
   }
+  const s4 = connection.query('SELECT * FROM announcements').stream();
+  for await (const row of s4) {
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    rows4.push(row);
+  }
 });
 
 process.on('exit', () => {
@@ -72,4 +78,5 @@ process.on('exit', () => {
   assert.deepEqual(rows, rows1);
   assert.deepEqual(rows, rows2);
   assert.deepEqual(rows, rows3);
+  assert.deepEqual(rows, rows4);
 });


### PR DESCRIPTION
This pull request addresses a problem I have found with this pull request - [#2389](https://github.com/sidorares/node-mysql2/pull/2389).
When using streams with a pause (introduced by a timeout or similar asynchronous operation), the stream prematurely closes, leading to an `Error [ERR_STREAM_PREMATURE_CLOSE]: Premature close`.
Here's a code snippet to reproduce the issue:

```javascript
const mysql = require('mysql2/promise');

(async () => {
    const connection = {
        user: '***',
        host: '***',
        database: '***',
        password: '***',
    };
    const dbConnection = mysql.createPool(connection);
    const query = dbConnection.pool.query(`select n from sequential_data limit 5`).stream();
    for await (const row of query) {
        await new Promise(r => setTimeout(r, 1000));
        console.log(row)
    }
    await dbConnection.end();
})();
```
I have implemented a fix that handles the stream's pause state more gracefully, preventing the premature close error. 
With my approach we no longer need to use `setImmediate` which creates a risk of emitting `close` before the stream had fully processed the `null` signal.

Here is output without timeout and with timeout:
![CleanShot 2024-01-30 at 14 51 59@2x](https://github.com/sidorares/node-mysql2/assets/5667073/c1db2216-5da2-4722-8699-88d859220cab)
