### PR TITLE
ci: ensure all tests are performed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "prettier": "^3.0.0",
         "progress": "^2.0.3",
         "typescript": "^5.0.2",
-        "urun": "0.0.8",
         "utest": "0.0.8"
       },
       "engines": {
@@ -2951,15 +2950,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/urun": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/urun/-/urun-0.0.8.tgz",
-      "integrity": "sha512-9nySKPSMjnT2egSGaaatEVrBz8gVn00Llv7CCbTgOD8HEEyPa7AiF4QcNZK4dxLLfHjBYpgD4UF6KRD0cBu84A==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/utest": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/utest/-/utest-0.0.8.tgz",
@@ -5200,12 +5190,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "urun": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/urun/-/urun-0.0.8.tgz",
-      "integrity": "sha512-9nySKPSMjnT2egSGaaatEVrBz8gVn00Llv7CCbTgOD8HEEyPa7AiF4QcNZK4dxLLfHjBYpgD4UF6KRD0cBu84A==",
-      "dev": true
     },
     "utest": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "prettier": "^3.0.0",
     "progress": "^2.0.3",
     "typescript": "^5.0.2",
-    "urun": "0.0.8",
     "utest": "0.0.8"
   }
 }

--- a/test/run.js
+++ b/test/run.js
@@ -7,8 +7,10 @@ const path = require('node:path');
 const { spawn } = require('node:child_process');
 const { EOL } = require('node:os');
 
+const escapeRegExp = string => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const startTime = Date.now();
-const filter = process.env.FILTER ? new RegExp(process.env.FILTER, 'i') : null;
+const filter = process.env.FILTER ? new RegExp(escapeRegExp(process.env.FILTER), 'i') : null;
 
 const format = {
   time: startTime => {

--- a/test/run.js
+++ b/test/run.js
@@ -2,15 +2,124 @@
 
 'use strict';
 
-const options = {
-  verbose: true
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { EOL } = require('node:os');
+
+const startTime = Date.now();
+const filter = process.env.FILTER ? new RegExp(process.env.FILTER, 'i') : null;
+
+const format = {
+  time: startTime => {
+    const elapsedTime = Date.now() - startTime;
+    const hours = Math.floor((elapsedTime / (1000 * 60 * 60)) % 24)
+      .toString()
+      .padStart(2, '0');
+    const minutes = Math.floor((elapsedTime / (1000 * 60)) % 60)
+      .toString()
+      .padStart(2, '0');
+    const seconds = Math.floor((elapsedTime / 1000) % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${hours}:${minutes}:${seconds}`;
+  },
+  counter: (current, total, pad = ' ') => {
+    const totalDigits = String(total).length;
+    return `${String(current).padStart(totalDigits, pad)}`;
+  },
+  percent: (current, total) => {
+    const percentage = ((current / total) * 100).toFixed(0);
+    return `${format.counter(percentage, 100)}%`;
+  },
 };
 
-if (process.env.FILTER) {
-  options.include = new RegExp(`${process.env.FILTER}.*\\.js$`);
-}
+const getFiles = (dirPath, files = []) => {
+  const currentFiles = fs.readdirSync(dirPath);
 
-require('urun')(__dirname, options);
+  for (const file of currentFiles) {
+    const fullPath = path.join(dirPath, file);
+
+    if (fs.statSync(fullPath).isDirectory()) {
+      getFiles(fullPath, files);
+    } else if (
+      (fullPath.endsWith('.js') || fullPath.endsWith('.mjs')) &&
+      (!filter || fullPath.match(filter))
+    ) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+};
+
+const runTestFile = filePath =>
+  new Promise(resolve => {
+    const child = spawn('node', [filePath], { stdio: 'inherit' });
+
+    child.on('close', code => {
+      if (code === 0) {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    });
+
+    child.on('error', err => {
+      console.log(`Failed to start test: ${filePath}`, err);
+      resolve(false);
+    });
+  });
+
+const runTests = async dir => {
+  const testDir = path.join(__dirname, dir);
+  const files = getFiles(testDir);
+  const totalTests = files.length;
+
+  let passed = true;
+
+  console.log(`${EOL}Directory: ${path.relative(process.cwd(), testDir)}${EOL}`);
+
+  for (let i = 0; i < files.length; i++) {
+    const filePath = files[i];
+    const fileRelative = path.relative(process.cwd(), filePath);
+    const testPassed = await runTestFile(filePath);
+    const testNumber = i + 1;
+    const elapsedTime = format.time(startTime);
+    const counter = format.counter(
+      testNumber,
+      totalTests,
+    );
+    const percent = format.percent(
+      testNumber,
+      totalTests,
+    );
+    const command = `node ${fileRelative}`;
+    const log = `${elapsedTime} ${counter}/${totalTests} ${percent} ${command}`;
+
+    if (testPassed) {
+      console.log(`✅ [ 0 ${log} ]`, EOL);
+    } else {
+      console.log(`❌ [ 1 ${log} ]`, EOL);
+      passed = false;
+    }
+  }
+
+  return passed;
+};
+
+(async () => {
+  const unitTestsPassed = await runTests('./unit');
+  const integrationTestsPassed = await runTests('./integration');
+
+  if (!unitTestsPassed || !integrationTestsPassed) {
+    console.log('Some tests failed.');
+    process.exit(1);
+  } else {
+    console.log('All tests passed.');
+    process.exit(0);
+  }
+})();
 
 process.on('exit', code => {
   console.log(`About to exit with code: ${code}`);
@@ -18,8 +127,10 @@ process.on('exit', code => {
 
 process.on('unhandledRejection', reason => {
   console.log('unhandledRejection', reason);
+  process.exit(1);
 });
 
 process.on('uncaughtException', err => {
   console.log('uncaughtException', err);
+  process.exit(1);
 });

--- a/test/unit/test-Pool.js
+++ b/test/unit/test-Pool.js
@@ -9,7 +9,7 @@ const poolConfig = {}; // config: { connectionConfig: {} } };
 const pool = new mysql.createPool(poolConfig);
 test('Pool', {
   'exposes escape': () => {
-    assert.equal(pool.escape(123), '123');
+    assert.equal(pool.escape(123), '1234');
   },
 
   'exposes escapeId': () => {

--- a/test/unit/test-Pool.js
+++ b/test/unit/test-Pool.js
@@ -9,7 +9,7 @@ const poolConfig = {}; // config: { connectionConfig: {} } };
 const pool = new mysql.createPool(poolConfig);
 test('Pool', {
   'exposes escape': () => {
-    assert.equal(pool.escape(123), '1234');
+    assert.equal(pool.escape(123), '123');
   },
 
   'exposes escapeId': () => {

--- a/tools/create-db.js
+++ b/tools/create-db.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const conn = require('../test/common.js').createConnection({ database: 'mysql' });
-conn.query('CREATE DATABASE IF NOT EXISTS test', (err) => {
-    if (err) {
-        console.log(err);
-        return process.exit(-1);
-    }
+conn.query('CREATE DATABASE IF NOT EXISTS test', err => {
+  if (err) {
+    console.log(err);
+    return process.exit(-1);
+  }
 
-    conn.end();
+  conn.end();
 });

--- a/tools/generate-charset-mapping.js
+++ b/tools/generate-charset-mapping.js
@@ -30,7 +30,7 @@ const mysql2iconv = {
 
 const missing = {};
 
-conn.query('show collation', function(err, res) {
+conn.query('show collation', (err, res) => {
   console.log(res);
   res.forEach(r => {
     const charset = r.Charset;
@@ -43,7 +43,7 @@ conn.query('show collation', function(err, res) {
   //console.log(JSON.stringify(missing, 4, null));
   //console.log(JSON.stringify(charsets, 4, null));
   for (let i = 0; i < charsets.length; i += 8) {
-    console.log("  '" + charsets.slice(i, i + 8).join("', '") + "',");
+    console.log(`  '${charsets.slice(i, i + 8).join("', '")}',`);
   }
 });
 


### PR DESCRIPTION
While working on another PR, I noticed a problem with tests that have been occurring for a long time.
Tests are started using `urun`, but when analyzing the logs, there are some inconsistencies:

#### 1.

It counts the total files, but change the step while still running the previous test:

```sh
[0:00:00 0 1/132 0.8% node test/integration/test-auth-switch-plugin-async-error.js]
[0:00:00 0 2/132 1.5% node test/integration/test-auth-switch-plugin-async-error.js]
```

---

#### 2.

Some time counters don't respect a specific rule:

```sh
[0:00:00 0 4/132 3.0% node test/integration/test-auth-switch.js]
[0:00:00 0 4/132 3.0% node test/integration/test-handshake-unknown-packet-error.js]
[0:00:00 0 5/132 3.8% node test/integration/test-handshake-unknown-packet-error.js]
[0:00:00 0 5/132 3.8% node test/integration/test-namedPlaceholders.js]
```

---

#### 3.

The total of current valid tests are not `132`, but **`133`** (**18** for unit and **115** for integration).

---

#### 4.

Some tests aren't performed, giving the false impression that all the tests have passed.
The missing tests are random. For example, sometimes `test-packet-parser.js` is missing, other times it is there.

---

#### 5.

In contrast, the counter works fine locally, but when running tests locally, the missing test range is more variable:

> Local tests in question are running on a Mac (_arm64_).

- Instead of running 18 unit tests, it runs ~8
- Instead of running 115 integration tests, it runs ~18

---

#### 6.

When running tests on **GitHub Actions**:

- ~38 (of 18) unit tests are displayed, but if we disregard the repeated ones, usually it runs all 18 unit tests.
- ~100 (of 115) integration tests are displayed, but if we consider that each appears between two or three times, it's possible that less than ~50 from 115 integration tests are running.
- In my next _PR_, I created an additional test directory inside the "unit" and both locally and on **GitHub Actions**, it was ignored, while the coverage shows it as covered by tests (that may not be performed).

---

#### 7.

In the case of `unhandledRejection` or `uncaughtException`, the logs are displayed, but the process exit is `0`.

---

### This PR

- This PR implements a simple native solution to list all the contents from test directories, listing and running all current **133** valid tests (**js**, **mjs**) sequentially.
- It will also ensure that `unhandledRejection` and `uncaughtException` are finished with process `1`.
- This _PR_ also keeps the environment variable `FILTER` in effect.
- Fix a false positive from CodeQL about Regular expression injection when using `FILTER` on tests
- It doesn't consider the `builtin-runner` tests, as they already have their own test.

---

### Example

> You can also see this PR Actions logs.

I kept the logs to be as similar as possible from `urun`:

```sh
Directory: test/unit

✅ [ 0 00:00:00  1/18   6% node test/unit/commands/test-query.js ]

✅ [ 0 00:00:00  2/18  11% node test/unit/commands/test-quit.js ]

✅ [ 0 00:00:00  3/18  17% node test/unit/connection/test-connection_config.js ]

# ...
```

```sh
Directory: test/integration

test connect timeout
ok
✅ [ 0 00:00:02   1/115   1% node test/integration/config/test-connect-timeout.js ]

✅ [ 0 00:00:03   2/115   2% node test/integration/config/test-typecast-global-option.js ]

✅ [ 0 00:00:03   3/115   3% node test/integration/connection/encoding/test-charset-results.js ]
```

Error example:

```sh
Failed: Pool exposes escape

  AssertionError [ERR_ASSERTION]: '123' == '1234'
      at exposes escape (/usr/app/test/unit/test-Pool.js:12:12)
      at TestCase.run (/usr/app/node_modules/utest/lib/TestCase.js:30:10)
      at Collection._runTestCase (/usr/app/node_modules/utest/lib/Collection.js:44:6)
      at Collection.run (/usr/app/node_modules/utest/lib/Collection.js:23:10)
      at process.processTicksAndRejections (node:internal/process/task_queues:77:11)

1 fail | 8 pass | 1 ms 
❌ [ 1 00:00:02 17/18  94% node test/unit/test-Pool.js ]
```

Naturally: `About to exit with code: 1`.

---

### Notes

- The **Action** in question is [**CI - Linux #1017**](https://github.com/sidorares/node-mysql2/actions/runs/7723365582/job/21053340700), but everyone will serve as an example.
