### PR TITLE
fix(types): expose TypeCast types

### DIFF
--- a/typings/mysql/lib/parsers/index.d.ts
+++ b/typings/mysql/lib/parsers/index.d.ts
@@ -1,5 +1,11 @@
 import { setMaxParserCache, clearParserCache } from './ParserCache.js';
-import { TypeCast, Field as TypeCastField, Geometry as TypeCastGeometry, Next as TypeCastNext, Type as TypeCastType } from './typeCast.js';
+import {
+  TypeCast,
+  Field as TypeCastField,
+  Geometry as TypeCastGeometry,
+  Next as TypeCastNext,
+  Type as TypeCastType,
+} from './typeCast.js';
 
 export {
   setMaxParserCache,

--- a/typings/mysql/lib/parsers/index.d.ts
+++ b/typings/mysql/lib/parsers/index.d.ts
@@ -1,12 +1,12 @@
 import { setMaxParserCache, clearParserCache } from './ParserCache.js';
-import { TypeCast, Field, Geometry, Next, Type } from './typeCast.js';
+import { TypeCast, Field as TypeCastField, Geometry as TypeCastGeometry, Next as TypeCastNext, Type as TypeCastType } from './typeCast.js';
 
 export {
   setMaxParserCache,
   clearParserCache,
   TypeCast,
-  Field,
-  Geometry,
-  Next,
-  Type,
+  TypeCastField,
+  TypeCastGeometry,
+  TypeCastNext,
+  TypeCastType,
 };

--- a/typings/mysql/lib/parsers/index.d.ts
+++ b/typings/mysql/lib/parsers/index.d.ts
@@ -1,3 +1,12 @@
 import { setMaxParserCache, clearParserCache } from './ParserCache.js';
+import { TypeCast, Field, Geometry, Next, Type } from './typeCast.js';
 
-export { setMaxParserCache, clearParserCache };
+export {
+  setMaxParserCache,
+  clearParserCache,
+  TypeCast,
+  Field,
+  Geometry,
+  Next,
+  Type,
+};

--- a/typings/mysql/lib/parsers/typeCast.d.ts
+++ b/typings/mysql/lib/parsers/typeCast.d.ts
@@ -1,9 +1,9 @@
-type Geometry = {
+export type Geometry = {
   x: number;
   y: number;
 };
 
-type Type = {
+export type Type = {
   type:
     | 'DECIMAL'
     | 'TINY'
@@ -38,7 +38,7 @@ type Type = {
     | 'GEOMETRY';
 };
 
-type Field = Type & {
+export type Field = Type & {
   length: number;
   db: string;
   table: string;
@@ -48,6 +48,6 @@ type Field = Type & {
   geometry: () => Geometry | Geometry[] | null;
 };
 
-type Next = () => void;
+export type Next = () => void;
 
 export type TypeCast = ((field: Field, next: Next) => any) | boolean;

--- a/typings/mysql/lib/protocol/packets/Field.d.ts
+++ b/typings/mysql/lib/protocol/packets/Field.d.ts
@@ -1,9 +1,9 @@
 // TODO (major version): remove workaround for `Field` compatibility.
-import { Field as TypeCastField } from '../../../lib/parsers/typeCast.js';
+import { TypeCastField } from '../../../lib/parsers/index.js';
 
 /**
  * @deprecated
- * `Field` is deprecated and might be removed in the future major release. Please use `TypeCastField` property instead.
+ * `Field` is deprecated and might be removed in the future major release. Please use `TypeCastField` type instead.
  */
 declare interface Field extends TypeCastField {}
 

--- a/typings/mysql/lib/protocol/packets/Field.d.ts
+++ b/typings/mysql/lib/protocol/packets/Field.d.ts
@@ -1,6 +1,10 @@
+// TODO (major version): remove workaround for `Field` compatibility.
 import { Field as TypeCastField } from '../../../lib/parsers/typeCast.js';
 
-// TODO (major version): remove workaround for `Field` compatibility.
+/**
+ * @deprecated
+ * `Field` is deprecated and might be removed in the future major release. Please use `TypeCastField` property instead.
+ */
 declare interface Field extends TypeCastField {}
 
 export { Field };

--- a/typings/mysql/lib/protocol/packets/Field.d.ts
+++ b/typings/mysql/lib/protocol/packets/Field.d.ts
@@ -1,15 +1,6 @@
-declare interface Field {
-  constructor: {
-    name: 'Field';
-  };
-  db: string;
-  table: string;
-  name: string;
-  type: string;
-  length: number;
-  string: () => any;
-  buffer: () => any;
-  geometry: () => any;
-}
+import { Field as TypeCastField } from '../../../lib/parsers/typeCast.js';
+
+// TODO (major version): remove workaround for `Field` compatibility.
+declare interface Field extends TypeCastField {}
 
 export { Field };


### PR DESCRIPTION
This **PR** just expose (export) all TypeCast typings:

- **TypeCast**
- **TypeCastField**
- **TypeCastGeometry**
- **TypeCastNext**
- **TypeCastType**

The `Field` interface has been deprecated, suggesting to use `TypeCastField` instead.

Now, it's possible for **TypeScript** users:

```ts
import mysql, { TypeCast, TypeCastField, TypeCastNext } from 'mysql2/promise';

const typeCast: TypeCast = (_: TypeCastField, next: TypeCastNext) => next();

// ...

await conn.execute({
  sql: `SELECT * FROM test`,
  typeCast,
});
```

- The same for `mysql` import.

---

It was motivated by this [commit](https://github.com/sequelize/sequelize/blob/34f2413e7984039b0e47d73ae971a6e417eae954/packages/core/src/dialects/mysql/connection-manager.ts#L9) from **Sequelize**, where they needed to import type cast `Field` using a workaround:

```ts
import type { Field } from 'mysql2/typings/mysql/lib/parsers/typeCast';
```

---

Next week, I plan to elaborate some usage examples for `typeCast` and include the types in the **TypeScript** section.