### PR TITLE
chore(docs): create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+website/** linguist-documentation


### PR DESCRIPTION
This PR simply indicates the **./website** directory as a documentation directory.