### PR TITLE
ci: report coverage data to Codecov

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -3,7 +3,7 @@ name: CI - Coverage
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
   workflow_dispatch:
 
@@ -21,8 +21,8 @@ jobs:
       matrix:
         node-version: [20.x]
         mysql-version: ["mysql:8.0.33"]
-        use-compression: [0]
-        use-tls: [0]
+        use-compression: [0, 1]
+        use-tls: [0, 1]
         mysql_connection_url_key: [""]
     env:
       MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}
@@ -31,13 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Delete artifacts
-        uses: jimschubert/delete-artifacts-action@v1
-        with:
-          log_level: 'debug'
-          min_bytes: '0'
-          pattern: '\.xml'
 
       - name: Set up MySQL
         if: ${{ matrix.mysql-version }}
@@ -64,23 +57,3 @@ jobs:
 
       - name: Run tests
         run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run coverage-test
-
-      - name: get list of coverage files
-        run: echo "coverage-files=`find coverage | grep xml | paste -s -d\; -`"  >> $GITHUB_ENV
-
-      - name: ReportGenerator
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.2.2
-        with:
-          reports: "${{ env.coverage-files }}"
-          targetdir: '.'
-          reporttypes: 'Cobertura'
-
-      - name: Debug
-        run: cat Cobertura.xml
-
-      - name: Display coverage
-        uses: ewjoachim/coverage-comment-action@v1
-        continue-on-error: true
-        with:
-          COVERAGE_FILE: "Cobertura.xml"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x]
-        mysql-version: ["mysql:8.0.33"]
+        mysql-version: ["mysql:5.7", "mysql:8.0.33"]
         use-compression: [0, 1]
         use-tls: [0, 1]
         mysql_connection_url_key: [""]
@@ -57,3 +57,10 @@ jobs:
 
       - name: Run tests
         run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run coverage-test
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: compression-${{ matrix.use-compression }},tls-${{ matrix.use-tls }}
+          name: codecov-umbrella-${{ matrix.node-version }}-${{ matrix.mysql-version }}-compression-${{ matrix.use-compression }}-tls-${{ matrix.use-tls }}

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -58,4 +58,4 @@ jobs:
           mysql -u root -e "CREATE DATABASE IF NOT EXISTS ${MYSQL_DATABASE};"
 
       - name: Run tests
-        run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run coverage-test
+        run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run test


### PR DESCRIPTION
There are some different behaviors as mentioned by @sidorares in https://github.com/sidorares/node-mysql2/pull/2472#issuecomment-1980620283:

- New and old MySQL Server versions
- SSL as `0` and `1`
- Compression as `0` and `1`

As the tests now run equally for all versions of **Node.js** and both platforms (**OS**), there's no need to send a report for each version of them.

That's why I opted to create an individual CI for the coverage report.

Naturally, to compare the coverages with the `master` branch, `CI - Coverage` will now be run for each push on the `master` too.