### PR TITLE
docs: add badges for CI and Coverage rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,18 @@
 [docs-faq]: https://sidorares.github.io/node-mysql2/docs/faq
 [docs-documentation]: https://sidorares.github.io/node-mysql2/docs/documentation
 [docs-contributing]: https://sidorares.github.io/node-mysql2/docs/contributing/website
+[coverage]: https://img.shields.io/codecov/c/github/sidorares/node-mysql2
+[coverage-url]: https://app.codecov.io/github/sidorares/node-mysql2
+[ci-url]: https://github.com/sidorares/node-mysql2/actions/workflows/ci-coverage.yml?query=branch%3Amaster
+[ci-image]: https://img.shields.io/github/actions/workflow/status/sidorares/node-mysql2/ci-coverage.yml?event=push&style=flat&label=CI&branch=master
 
 # MySQL2
 
 [![NPM Version][npm-image]][npm-url]
 [![NPM Downloads][downloads-image]][downloads-url]
 [![Node.js Version][node-version-image]][node-version-url]
+[![GitHub Workflow Status (with event)][ci-image]][ci-url]
+[![Codecov][coverage]][coverage-url]
 [![License][license-image]][license-url]
 
 [English][docs-base] | [简体中文][docs-base-zh-CN] | [Português (BR)][docs-base-pt-BR]
@@ -102,7 +108,7 @@ npm install --save-dev @types/node
 
 ## Contributing
 
-Want to improve something in **MySQL2**?  
+Want to improve something in **MySQL2**?
 Please check [Contributing.md][contributing] for detailed instruction on how to get started.
 
 To contribute in **MySQL2 Documentation**, please visit the [Website Contributing Guidelines][docs-contributing] for detailed instruction on how to get started.

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -20,6 +20,10 @@ import { PageTitle } from '@site/src/components/PageTitle';
 [license-url]: https://github.com/sidorares/node-mysql2/blob/master/License
 [license-image]: https://img.shields.io/npm/l/mysql2.svg?maxAge=2592000
 [node-mysql]: https://github.com/mysqljs/mysql
+[coverage]: https://img.shields.io/codecov/c/github/sidorares/node-mysql2
+[coverage-url]: https://app.codecov.io/github/sidorares/node-mysql2
+[ci-url]: https://github.com/sidorares/node-mysql2/actions/workflows/ci-coverage.yml?query=branch%3Amaster
+[ci-image]: https://img.shields.io/github/actions/workflow/status/sidorares/node-mysql2/ci-coverage.yml?event=push&style=flat&label=CI&branch=master
 
 # MySQL2
 
@@ -30,6 +34,8 @@ MySQL client for Node.js with focus on performance. Supports prepared statements
 [![NPM Version][npm-image]][npm-url]
 [![NPM Downloads][downloads-image]][downloads-url]
 [![Node.js Version][node-version-image]][node-version-url]
+[![GitHub Workflow Status (with event)][ci-image]][ci-url]
+[![Codecov][coverage]][coverage-url]
 [![License][license-image]][license-url]
 
 ## Installation

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/index.mdx
@@ -20,6 +20,8 @@ Cliente MySQL para Node.js com foco em performance. Suporta instruções prepara
 [![NPM Version][npm-image]][npm-url]
 [![NPM Downloads][downloads-image]][downloads-url]
 [![Node.js Version][node-version-image]][node-version-url]
+[![GitHub Workflow Status (with event)][ci-image]][ci-url]
+[![Codecov][coverage]][coverage-url]
 [![License][license-image]][license-url]
 
 ## Instalação
@@ -510,3 +512,7 @@ Se você encontrou um erro, [registre-o no GitHub](https://github.com/sidorares/
 [license-url]: https://github.com/sidorares/node-mysql2/blob/master/License
 [license-image]: https://img.shields.io/npm/l/mysql2.svg?maxAge=2592000
 [node-mysql]: https://github.com/mysqljs/mysql
+[coverage]: https://img.shields.io/codecov/c/github/sidorares/node-mysql2
+[coverage-url]: https://app.codecov.io/github/sidorares/node-mysql2
+[ci-url]: https://github.com/sidorares/node-mysql2/actions/workflows/ci-coverage.yml?query=branch%3Amaster
+[ci-image]: https://img.shields.io/github/actions/workflow/status/sidorares/node-mysql2/ci-coverage.yml?event=push&style=flat&label=CI&branch=master

--- a/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
+++ b/website/i18n/zh-CN/docusaurus-plugin-content-docs/current/index.mdx
@@ -20,6 +20,8 @@ import { PageTitle } from '@site/src/components/PageTitle';
 [![NPM Version][npm-image]][npm-url]
 [![NPM Downloads][downloads-image]][downloads-url]
 [![Node.js Version][node-version-image]][node-version-url]
+[![GitHub Workflow Status (with event)][ci-image]][ci-url]
+[![Codecov][coverage]][coverage-url]
 [![License][license-image]][license-url]
 
 ## 安装
@@ -510,3 +512,7 @@ If you've encountered an issue, please [file it on GitHub](https://github.com/si
 [license-url]: https://github.com/sidorares/node-mysql2/blob/master/License
 [license-image]: https://img.shields.io/npm/l/mysql2.svg?maxAge=2592000
 [node-mysql]: https://github.com/mysqljs/mysql
+[coverage]: https://img.shields.io/codecov/c/github/sidorares/node-mysql2
+[coverage-url]: https://app.codecov.io/github/sidorares/node-mysql2
+[ci-url]: https://github.com/sidorares/node-mysql2/actions/workflows/ci-coverage.yml?query=branch%3Amaster
+[ci-image]: https://img.shields.io/github/actions/workflow/status/sidorares/node-mysql2/ci-coverage.yml?event=push&style=flat&label=CI&branch=master


### PR DESCRIPTION
There are two new badges for the **README.md** plus both **en**, **zh-CN** and **pt-BR** website docs:

[![GitHub Workflow Status (with event)][ci-image]][ci-url]
[![Codecov][coverage]][coverage-url]

[coverage]: https://img.shields.io/codecov/c/github/sidorares/node-mysql2
[coverage-url]: https://app.codecov.io/github/sidorares/node-mysql2
[ci-url]: https://github.com/sidorares/node-mysql2/actions/workflows/ci-coverage.yml?query=branch%3Amaster
[ci-image]: https://img.shields.io/github/actions/workflow/status/sidorares/node-mysql2/ci-coverage.yml?event=push&style=flat&label=CI&branch=master