### PR TITLE
ci: ensure coverage limits

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 2%


### PR DESCRIPTION
@sidorares, if you _want_ to allow the **Codecov** app to this repository, these conditions (configurable) will now be considered **CI** failures:

- ❌ More than **2%** loss of coverage compared to the base
- ❌ Less than **90%** of total coverage

> Actual coverage is **90.25%**.
