### PR TITLE
Use the same regex as mysqljs for changed rows

### DIFF
--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -91,7 +91,8 @@ class ResultSetHeader {
     if (stateChanges) {
       this.stateChanges = stateChanges;
     }
-    const m = this.info.match(/\schanged:\s*(\d+)/i);
+    // Use the same regex as mysqljs at https://github.com/mysqljs/mysql/blob/dc9c152a87ec51a1f647447268917243d2eab1fd/lib/protocol/packets/OkPacket.js#L3C29-L3C91
+    const m = this.info.match(/^[^:0-9]+: [0-9]+[^:0-9]+: ([0-9]+)[^:0-9]+: [0-9]+[^:0-9]*$/);
     if (m !== null) {
       this.changedRows = parseInt(m[1], 10);
     } else {


### PR DESCRIPTION
For `INSERT ... ON DUPLICATE KEY UPDATE` queries, the changed rows the EOF packet is named Duplicates instead of Changed. Here is the a sample message:
```
Records: 4  Duplicates: 0  Warnings: 0
```
I propose using the regex from the mysqljs project which also handles this situation.