### PR TITLE
fix(security): improve results object creation

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -5,7 +5,7 @@
   "reporter": ["text", "lcov", "cobertura"],
   "statements": 88,
   "branches": 84,
-  "functions": 78,
+  "functions": 77,
   "lines": 88,
   "checkCoverage": true,
   "clean": true

--- a/lib/parsers/binary_parser.js
+++ b/lib/parsers/binary_parser.js
@@ -122,7 +122,13 @@ function compile(fields, options, config) {
   if (options.rowsAsArray) {
     parserFn(`const result = new Array(${fields.length});`);
   } else {
-    parserFn('const result = {};');
+    parserFn('const result = Object.create(null);');
+    parserFn(`Object.defineProperty(result, "constructor", {
+      value: Object.create(null),
+      writable: false,
+      configurable: false,
+      enumerable: false
+    });`);
   }
 
   // Global typeCast
@@ -154,7 +160,9 @@ function compile(fields, options, config) {
       )}]`;
     } else if (options.nestTables === true) {
       tableName = helpers.srcEscape(fields[i].table);
-      parserFn(`if (!result[${tableName}]) result[${tableName}] = {};`);
+      parserFn(
+        `if (!result[${tableName}]) result[${tableName}] = Object.create(null);`,
+      );
       lvalue = `result[${tableName}][${fieldName}]`;
     } else if (options.rowsAsArray) {
       lvalue = `result[${i.toString(10)}]`;

--- a/lib/parsers/text_parser.js
+++ b/lib/parsers/text_parser.js
@@ -111,9 +111,6 @@ function compile(fields, options, config) {
 
   const parserFn = genFunc();
 
-  /* eslint-disable no-trailing-spaces */
-  /* eslint-disable no-spaced-func */
-  /* eslint-disable no-unexpected-multiline */
   parserFn('(function () {')('return class TextRow {');
 
   // constructor method
@@ -134,7 +131,13 @@ function compile(fields, options, config) {
   if (options.rowsAsArray) {
     parserFn(`const result = new Array(${fields.length});`);
   } else {
-    parserFn('const result = {};');
+    parserFn('const result = Object.create(null);');
+    parserFn(`Object.defineProperty(result, "constructor", {
+      value: Object.create(null),
+      writable: false,
+      configurable: false,
+      enumerable: false
+    });`);
   }
 
   const resultTables = {};
@@ -146,7 +149,9 @@ function compile(fields, options, config) {
     }
     resultTablesArray = Object.keys(resultTables);
     for (let i = 0; i < resultTablesArray.length; i++) {
-      parserFn(`result[${helpers.srcEscape(resultTablesArray[i])}] = {};`);
+      parserFn(
+        `result[${helpers.srcEscape(resultTablesArray[i])}] = Object.create(null);`,
+      );
     }
   }
 
@@ -190,10 +195,6 @@ function compile(fields, options, config) {
   parserFn('return result;');
   parserFn('}');
   parserFn('};')('})()');
-
-  /* eslint-enable no-trailing-spaces */
-  /* eslint-enable no-spaced-func */
-  /* eslint-enable no-unexpected-multiline */
 
   if (config.debug) {
     helpers.printDebugWithCode(

--- a/test/common.test.cjs
+++ b/test/common.test.cjs
@@ -105,6 +105,7 @@ exports.createConnection = function (args) {
     typeCast: args && args.typeCast,
     namedPlaceholders: args && args.namedPlaceholders,
     connectTimeout: args && args.connectTimeout,
+    nestTables: args && args.nestTables,
     ssl: (args && args.ssl) ?? config.ssl,
   };
 

--- a/test/esm/unit/parsers/prototype-binary-results.test.mjs
+++ b/test/esm/unit/parsers/prototype-binary-results.test.mjs
@@ -50,6 +50,13 @@ Promise.all([
       '2.00',
       'Ensure that the end-user is able to use prototypes (manually): toFixed',
     );
+
+    results[0].customProp = true;
+    assert.strictEqual(
+      results[0].customProp,
+      true,
+      'Ensure that the end-user is able to use custom props',
+    );
   }),
   test(async () => {
     const [result] = await connection.execute('SET @1 = 1;');

--- a/test/esm/unit/parsers/prototype-binary-results.test.mjs
+++ b/test/esm/unit/parsers/prototype-binary-results.test.mjs
@@ -1,0 +1,65 @@
+import { test, describe, assert } from 'poku';
+import { createConnection, describeOptions } from '../../../common.test.cjs';
+
+const connection = createConnection().promise();
+
+describe('Binary Parser: Prototype Sanitization', describeOptions);
+
+Promise.all([
+  test(async () => {
+    const expected = [{}];
+    expected[0].test = 2;
+
+    const [results] = await connection.query('SELECT 1+1 AS `test`');
+
+    assert.notDeepStrictEqual(
+      results,
+      expected,
+      `Ensure "results" doesn't contain a standard object ({})`,
+    );
+  }),
+  test(async () => {
+    const expected = [Object.create(null)];
+    expected[0].test = 2;
+
+    const [results] = await connection.execute('SELECT 1+1 AS `test`');
+
+    assert.deepStrictEqual(results, expected, 'Ensure clean object "results"');
+    assert.strictEqual(
+      Object.getPrototypeOf(results[0]),
+      null,
+      'Ensure clean properties in results items',
+    );
+    assert.strictEqual(
+      typeof results[0].toString,
+      'undefined',
+      'Re-check prototypes (manually) in results columns',
+    );
+    assert.strictEqual(
+      typeof results[0].test.toString,
+      'function',
+      'Ensure that the end-user is able to use prototypes',
+    );
+    assert.strictEqual(
+      results[0].test.toString(),
+      '2',
+      'Ensure that the end-user is able to use prototypes (manually): toString',
+    );
+    assert.strictEqual(
+      results[0].test.toFixed(2),
+      '2.00',
+      'Ensure that the end-user is able to use prototypes (manually): toFixed',
+    );
+  }),
+  test(async () => {
+    const [result] = await connection.execute('SET @1 = 1;');
+
+    assert.strictEqual(
+      result.constructor.name,
+      'ResultSetHeader',
+      'Ensure constructor name in result object',
+    );
+  }),
+]).then(async () => {
+  await connection.end();
+});

--- a/test/esm/unit/parsers/prototype-text-results.test.mjs
+++ b/test/esm/unit/parsers/prototype-text-results.test.mjs
@@ -1,0 +1,65 @@
+import { test, describe, assert } from 'poku';
+import { createConnection, describeOptions } from '../../../common.test.cjs';
+
+const connection = createConnection().promise();
+
+describe('Text Parser: Prototype Sanitization', describeOptions);
+
+Promise.all([
+  test(async () => {
+    const expected = [{}];
+    expected[0].test = 2;
+
+    const [results] = await connection.query('SELECT 1+1 AS `test`');
+
+    assert.notDeepStrictEqual(
+      results,
+      expected,
+      `Ensure "results" doesn't contain a standard object ({})`,
+    );
+  }),
+  test(async () => {
+    const expected = [Object.create(null)];
+    expected[0].test = 2;
+
+    const [results] = await connection.query('SELECT 1+1 AS `test`');
+
+    assert.deepStrictEqual(results, expected, 'Ensure clean object "results"');
+    assert.strictEqual(
+      Object.getPrototypeOf(results[0]),
+      null,
+      'Ensure clean properties in results items',
+    );
+    assert.strictEqual(
+      typeof results[0].toString,
+      'undefined',
+      'Re-check prototypes (manually) in results columns',
+    );
+    assert.strictEqual(
+      typeof results[0].test.toString,
+      'function',
+      'Ensure that the end-user is able to use prototypes',
+    );
+    assert.strictEqual(
+      results[0].test.toString(),
+      '2',
+      'Ensure that the end-user is able to use prototypes (manually): toString',
+    );
+    assert.strictEqual(
+      results[0].test.toFixed(2),
+      '2.00',
+      'Ensure that the end-user is able to use prototypes (manually): toFixed',
+    );
+  }),
+  test(async () => {
+    const [result] = await connection.query('SET @1 = 1;');
+
+    assert.strictEqual(
+      result.constructor.name,
+      'ResultSetHeader',
+      'Ensure constructor name in result object',
+    );
+  }),
+]).then(async () => {
+  await connection.end();
+});

--- a/test/esm/unit/parsers/prototype-text-results.test.mjs
+++ b/test/esm/unit/parsers/prototype-text-results.test.mjs
@@ -50,6 +50,13 @@ Promise.all([
       '2.00',
       'Ensure that the end-user is able to use prototypes (manually): toFixed',
     );
+
+    results[0].customProp = true;
+    assert.strictEqual(
+      results[0].customProp,
+      true,
+      'Ensure that the end-user is able to use custom props',
+    );
   }),
   test(async () => {
     const [result] = await connection.query('SET @1 = 1;');


### PR DESCRIPTION
Finishing the tasks started in #2424 (and #2572).

This _PR_ ensures a clean object evaluation for every item in results.

This is the final evaluation for both text and binary parsers:

```js
const result = Object.create(null);

Object.defineProperty(result, 'constructor', {
  value: Object.create(null),
  writable: false,
  configurable: false,
  enumerable: false
});

// ...

// nestTables
if (!result[${tableName}]) result[${tableName}] = Object.create(null);
```

> I also tried a simple `Object.freeze(result)`, but the unit tests (specific to this) didn't pass as expected 🔓

---

### Note

These changes preserve security without affecting the end user:

```js
const [results] = await connection.query('SELECT 1+1 AS `test`'); // or execute

results[0].test.toFixed(2); // '2.00' ✅
results[0].addCustomProp = true; // true ✅
```
