### PR TITLE
fix: binary parser sometimes reads out of packet bounds when results …

### DIFF
--- a/lib/parsers/binary_parser.js
+++ b/lib/parsers/binary_parser.js
@@ -169,6 +169,10 @@ function compile(fields, options, config) {
       lvalue = `result[${fieldName}]`;
     }
 
+    parserFn(`if (nullBitmaskByte${nullByteIndex} & ${currentFieldNullBit}) `);
+    parserFn(`${lvalue} = null;`);
+    parserFn('else {');
+
     if (options.typeCast === false) {
       parserFn(`${lvalue} = packet.readLengthCodedBuffer();`);
     } else {
@@ -176,9 +180,6 @@ function compile(fields, options, config) {
       parserFn(`const ${fieldWrapperVar} = wrap(fields[${i}], packet);`);
       const readCode = readCodeFor(fields[i], config, options, i);
 
-      parserFn(`if (nullBitmaskByte${nullByteIndex} & ${currentFieldNullBit})`);
-      parserFn(`${lvalue} = null;`);
-      parserFn('else {');
       if (typeof options.typeCast === 'function') {
         parserFn(
           `${lvalue} = options.typeCast(${fieldWrapperVar}, function() { return ${readCode} });`,
@@ -186,8 +187,9 @@ function compile(fields, options, config) {
       } else {
         parserFn(`${lvalue} = ${readCode};`);
       }
-      parserFn('}');
     }
+    parserFn('}');
+
 
     currentFieldNullBit *= 2;
     if (currentFieldNullBit === 0x100) {

--- a/test/integration/config/test-typecast-global-false.test.cjs
+++ b/test/integration/config/test-typecast-global-false.test.cjs
@@ -1,0 +1,33 @@
+'use strict';
+
+const common = require('../../common.test.cjs');
+const connection = common.createConnection({
+  typeCast: false,
+});
+
+const { assert } = require('poku');
+
+const COL_1_VALUE = 'col v1';
+const COL_2_VALUE = 'col v2';
+
+function executeTests(res) {
+  assert.equal(res[0].v1.toString('ascii'), COL_1_VALUE);
+  assert.equal(res[0].n1, null);
+  assert.equal(res[0].v2.toString('ascii'), COL_2_VALUE);
+}
+
+connection.query(
+  'CREATE TEMPORARY TABLE binpar_null_test (v1 VARCHAR(16) NOT NULL, n1 VARCHAR(16), v2 VARCHAR(16) NOT NULL)',
+);
+connection.query(
+  `INSERT INTO binpar_null_test (v1, n1, v2) VALUES ("${COL_1_VALUE}", NULL, "${COL_2_VALUE}")`,
+  (err) => {
+    if (err) throw err;
+  },
+);
+
+connection.execute('SELECT * FROM binpar_null_test', (err, res) => {
+  if (err) throw err;
+  executeTests(res);
+  connection.end();
+});


### PR DESCRIPTION
Fixes #2602.

Check the `nullBitmaskByte` before trying to `readLengthCodedBuffer()` when `typeCast: false` on binary results.