### PR TITLE
ci(coverage): disable Codecov patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: 89%
         threshold: 2%
+    patch:
+      default:
+        target: 0%
+        threshold: 100%


### PR DESCRIPTION
This _PR_ doesn't change the previously defined coverage percentages.

**Codecov** initiates two tests (`project` and `patch`). The `patch` analyzes the percentage file by file, without considering the overall project context, which can cause CI failures even when the project coverage is in line with the established.

In order to maintain better productivity, this _PR_ quiets the `patch` CI.

CI examples:

<img width="540" alt="Screenshot 2024-05-14 at 07 55 48" src="https://github.com/sidorares/node-mysql2/assets/46850407/15c06da3-de80-4489-b710-0699d8bca25b">

<img width="540" alt="Screenshot 2024-05-14 at 07 54 55" src="https://github.com/sidorares/node-mysql2/assets/46850407/9e2a340e-769f-4f71-8caa-467b4f239769">

---

Example of _PRs_ that would be less productive even with proper overall coverage:

- #1919
- #2289
- #2757