### PR TITLE
Fixed typing for caching_sha2_password where misspelt jonServerPublicKey is replaced by onServerPublicKey

### DIFF
--- a/typings/mysql/lib/Auth.d.ts
+++ b/typings/mysql/lib/Auth.d.ts
@@ -14,7 +14,7 @@ export const authPlugins: {
   caching_sha2_password: AuthPluginDefinition<{
     overrideIsSecure?: boolean;
     serverPublicKey?: RsaPublicKey | RsaPrivateKey | KeyLike;
-    joinServerPublicKey?: (data: Buffer) => void;
+    onServerPublicKey?: (data: Buffer) => void;
   }>;
   mysql_clear_password: AuthPluginDefinition<{
     password?: string;
@@ -25,6 +25,6 @@ export const authPlugins: {
   }>;
   sha256_password: AuthPluginDefinition<{
     serverPublicKey?: RsaPublicKey | RsaPrivateKey | KeyLike;
-    joinServerPublicKey?: (data: Buffer) => void;
+    onServerPublicKey?: (data: Buffer) => void;
   }>;
 };

--- a/typings/mysql/lib/Auth.d.ts
+++ b/typings/mysql/lib/Auth.d.ts
@@ -14,7 +14,7 @@ export const authPlugins: {
   caching_sha2_password: AuthPluginDefinition<{
     overrideIsSecure?: boolean;
     serverPublicKey?: RsaPublicKey | RsaPrivateKey | KeyLike;
-    jonServerPublicKey?: (data: Buffer) => void;
+    joinServerPublicKey?: (data: Buffer) => void;
   }>;
   mysql_clear_password: AuthPluginDefinition<{
     password?: string;


### PR DESCRIPTION
Just a minor character missing as I assume it was supposed to be `joinServerPublicKey`  instead of `jonServerPublicKey`.