### PR TITLE
fix: support deno + caching_sha2_password FULL_AUTHENTICATION_PACKET flow

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -156,5 +156,5 @@ jobs:
           MYSQL_PORT: ${{ env.MYSQL_PORT }}
           MYSQL_USE_COMPRESSION: ${{ matrix.use-compression }}
           MYSQL_USE_TLS: ${{ matrix.use-tls }}
-        run: deno test --allow-net --allow-env --allow-read --allow-write --allow-plugin --unstable test/deno.ts
+        run: deno test --allow-net --allow-env --allow-read test/deno.ts
         timeout-minutes: 1      

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -109,52 +109,52 @@ jobs:
         run: bun run test:bun
         timeout-minutes: 1
 
-      tests-linux-deno:
-          runs-on: ubuntu-latest
-          strategy:
-            fail-fast: false
-            matrix:
-              deno-version: [latest, canary]
-              mysql-version: ["mysql:8.0.33"]
-              use-compression: [0, 1]
-              use-tls: [0,1]
-      
-          name: Deno ${{ matrix.deno-version }} - DB ${{ matrix.mysql-version }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
-      
-          steps:
-            - uses: actions/checkout@v4
-            - name: Set up MySQL
-              run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/test/fixtures/custom-conf:/etc/mysql/conf.d -v $PWD/test/fixtures/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}
-      
-            - name: Set up Deno ${{ matrix.deno-version }}
-              uses: denoland/setup-deno@v1
-              with:
-                bun-version: ${{ matrix.deno-version }}
-      
-            - name: Set up Node.js
-              uses: actions/setup-node@v4
-              with:
-                node-version: 20
-            - name: Cache dependencies
-              uses: actions/cache@v4
-              with:
-                path: ~/.npm
-                key: npm-linux-${{ hashFiles('package-lock.json') }}
-                restore-keys: npm-linux-
-      
-            - name: Install npm dependencies
-              run: npm ci
-      
-            - name: Wait mysql server is ready
-              run: node tools/wait-up.js
-      
-            # todo: check what we need to do to run all tests with deno
-            - name: run tests
-              env:
-                MYSQL_USER: ${{ env.MYSQL_USER }}
-                MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
-                MYSQL_PORT: ${{ env.MYSQL_PORT }}
-                MYSQL_USE_COMPRESSION: ${{ matrix.use-compression }}
-                MYSQL_USE_TLS: ${{ matrix.use-tls }}
-              run: deno test --allow-net --allow-env --allow-read --allow-write --allow-plugin --unstable test/deno.ts
-              timeout-minutes: 1      
+  tests-linux-deno:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        deno-version: [latest, canary]
+        mysql-version: ["mysql:8.0.33"]
+        use-compression: [0, 1]
+        use-tls: [0,1]
+
+    name: Deno ${{ matrix.deno-version }} - DB ${{ matrix.mysql-version }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up MySQL
+        run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/test/fixtures/custom-conf:/etc/mysql/conf.d -v $PWD/test/fixtures/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}
+
+      - name: Set up Deno ${{ matrix.deno-version }}
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: ${{ matrix.deno-version }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-linux-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-linux-
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Wait mysql server is ready
+        run: node tools/wait-up.js
+
+      # todo: check what we need to do to run all tests with deno
+      - name: run tests
+        env:
+          MYSQL_USER: ${{ env.MYSQL_USER }}
+          MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+          MYSQL_PORT: ${{ env.MYSQL_PORT }}
+          MYSQL_USE_COMPRESSION: ${{ matrix.use-compression }}
+          MYSQL_USE_TLS: ${{ matrix.use-tls }}
+        run: deno test --allow-net --allow-env --allow-read --allow-write --allow-plugin --unstable test/deno.ts
+        timeout-minutes: 1      

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [latest, canary]
+        deno-version: [v1.43.6, canary]
         mysql-version: ["mysql:8.0.33"]
         use-compression: [0, 1]
         use-tls: [0,1]

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -108,3 +108,53 @@ jobs:
           FILTER: test-select-1|test-select-ssl
         run: bun run test:bun
         timeout-minutes: 1
+
+      tests-linux-deno:
+          runs-on: ubuntu-latest
+          strategy:
+            fail-fast: false
+            matrix:
+              deno-version: [latest, canary]
+              mysql-version: ["mysql:8.0.33"]
+              use-compression: [0, 1]
+              use-tls: [0,1]
+      
+          name: Deno ${{ matrix.deno-version }} - DB ${{ matrix.mysql-version }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
+      
+          steps:
+            - uses: actions/checkout@v4
+            - name: Set up MySQL
+              run: docker run -d -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=${{ env.MYSQL_DATABASE }} -v $PWD/mysqldata:/var/lib/mysql/ -v $PWD/test/fixtures/custom-conf:/etc/mysql/conf.d -v $PWD/test/fixtures/ssl/certs:/certs -p ${{ env.MYSQL_PORT }}:3306 ${{ matrix.mysql-version }}
+      
+            - name: Set up Deno ${{ matrix.deno-version }}
+              uses: denoland/setup-deno@v1
+              with:
+                bun-version: ${{ matrix.deno-version }}
+      
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                node-version: 20
+            - name: Cache dependencies
+              uses: actions/cache@v4
+              with:
+                path: ~/.npm
+                key: npm-linux-${{ hashFiles('package-lock.json') }}
+                restore-keys: npm-linux-
+      
+            - name: Install npm dependencies
+              run: npm ci
+      
+            - name: Wait mysql server is ready
+              run: node tools/wait-up.js
+      
+            # todo: check what we need to do to run all tests with deno
+            - name: run tests
+              env:
+                MYSQL_USER: ${{ env.MYSQL_USER }}
+                MYSQL_DATABASE: ${{ env.MYSQL_DATABASE }}
+                MYSQL_PORT: ${{ env.MYSQL_PORT }}
+                MYSQL_USE_COMPRESSION: ${{ matrix.use-compression }}
+                MYSQL_USE_TLS: ${{ matrix.use-tls }}
+              run: deno test --allow-net --allow-env --allow-read --allow-write --allow-plugin --unstable test/deno.ts
+              timeout-minutes: 1      

--- a/lib/auth_plugins/caching_sha2_password.js
+++ b/lib/auth_plugins/caching_sha2_password.js
@@ -36,7 +36,10 @@ function encrypt(password, scramble, key) {
     Buffer.from(`${password}\0`, 'utf8'),
     scramble
   );
-  return crypto.publicEncrypt(key, stage1);
+  return crypto.publicEncrypt({
+    key,
+    padding: crypto.constants.RSA_PKCS1_OAEP_PADDING
+  }, stage1);
 }
 
 module.exports = (pluginOptions = {}) => ({ connection }) => {

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,0 +1,26 @@
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url);
+const mysql = require('../index.js');
+
+const connection = mysql.createConnection({
+  host: Deno.env.MYSQL_HOST,
+  port: Deno.env.MYSQL_PORT,
+  username: Deno.env.MYSQL_USER,
+  password: Deno.env.MYSQL_PASSWORD,
+  database: Deno.env.MYSQL_DATABASE,
+});
+
+connection.on('error', (err) => {
+  console.error(err);
+  Deno.exit(1);
+});
+
+connection.on('connect', () => {
+    connection.query('SELECT 1 + 1 AS solution', (err, rows) => {
+    if (err) {
+        console.error(err);
+        Deno.exit(1);
+    }
+    connection.end();
+    });
+});

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,3 +1,6 @@
+// TODO: fix "[warn] Code style issues found in the above file. Run Prettier to fix." error
+/* eslint-disable */
+
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const mysql = require('../index.js');
@@ -5,7 +8,7 @@ const mysql = require('../index.js');
 const connection = mysql.createConnection({
   host: Deno.env.get('MYSQL_HOST'),
   port: Deno.env.get('MYSQL_PORT'),
-  username: Deno.env.get('MYSQL_USER'),
+  user: Deno.env.get('MYSQL_USER'),
   password: Deno.env.get('MYSQL_PASSWORD'),
   database: Deno.env.get('MYSQL_DATABASE'),
 });

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,7 +1,4 @@
-// TODO: fix "[warn] Code style issues found in the above file. Run Prettier to fix." error
-/* eslint-disable */
-
-import { createRequire } from "node:module";
+import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const mysql = require('../index.js');
 

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,22 +1,22 @@
-import { createRequire } from 'node:module';
+import { createRequire } from "https://deno.land/std@0.177.0/node/module.ts";
 const require = createRequire(import.meta.url);
 const mysql = require('../index.js');
 
 const connection = mysql.createConnection({
-  host: Deno.env.MYSQL_HOST,
-  port: Deno.env.MYSQL_PORT,
-  username: Deno.env.MYSQL_USER,
-  password: Deno.env.MYSQL_PASSWORD,
-  database: Deno.env.MYSQL_DATABASE,
+  host: Deno.env.get('MYSQL_HOST'),
+  port: Deno.env.get('MYSQL_PORT'),
+  username: Deno.env.get('MYSQL_USER'),
+  password: Deno.env.get('MYSQL_PASSWORD'),
+  database: Deno.env.get('MYSQL_DATABASE'),
 });
 
-connection.on('error', (err) => {
+connection.on('error', (err: Error) => {
   console.error(err);
   Deno.exit(1);
 });
 
 connection.on('connect', () => {
-  connection.query('SELECT 1 + 1 AS solution', (err) => {
+  connection.query('SELECT 1 + 1 AS solution', (err: Error) => {
     if (err) {
       console.error(err);
       Deno.exit(1);

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,4 +1,4 @@
-import { createRequire } from "https://deno.land/std@0.177.0/node/module.ts";
+import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const mysql = require('../index.js');
 

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,4 +1,4 @@
-import { createRequire } from 'node:module'
+import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const mysql = require('../index.js');
 
@@ -16,11 +16,11 @@ connection.on('error', (err) => {
 });
 
 connection.on('connect', () => {
-    connection.query('SELECT 1 + 1 AS solution', (err, rows) => {
+  connection.query('SELECT 1 + 1 AS solution', (err) => {
     if (err) {
-        console.error(err);
-        Deno.exit(1);
+      console.error(err);
+      Deno.exit(1);
     }
     connection.end();
-    });
+  });
 });


### PR DESCRIPTION
Closes #2686

[Deno uses](https://github.com/denoland/deno/blob/b21004b1d16ad7b67c7b1cd235abf792bf9d9777/ext/node/polyfills/internal/crypto/cipher.ts#L430) default `RSA_PKCS1_PADDING` for publicEncrypt while [in node](https://github.com/nodejs/node/blob/2079a7aec4323e32ed4ae72bc56ac9125c72fe79/lib/internal/crypto/cipher.js#L84) it's `RSA_PKCS1_OAEP_PADDING` by default. As a result `PERFORM_FULL_AUTHENTICATION_PACKET` step returns password encoded differently from what server expects ( note: mysql versions prior to 8.0.5 might expect RSA_PKCS1_PADDING padding, need to validate that and maybe potentially use based on the server? https://github.com/mysql-net/MySqlConnector/issues/489 )