### PR TITLE
ci: prepare tests for Deno

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-markdown": "^5.0.0",
         "husky": "^9.0.2",
         "lint-staged": "^15.0.1",
-        "poku": "^1.8.1",
+        "poku": "^1.13.0",
         "portfinder": "^1.0.28",
         "prettier": "^3.0.0",
         "progress": "^2.0.3",
@@ -40,35 +40,6 @@
       },
       "engines": {
         "node": ">= 8.0"
-      }
-    },
-    "../../../weslley.io/nodejs/poku": {
-      "version": "1.7.0",
-      "extraneous": true,
-      "license": "MIT",
-      "bin": {
-        "poku": "lib/bin/index.js"
-      },
-      "devDependencies": {
-        "@types/node": "^20.11.21",
-        "@typescript-eslint/eslint-plugin": "^7.1.0",
-        "@typescript-eslint/parser": "^7.1.0",
-        "c8": "^9.1.0",
-        "eslint": "^8.57.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-import-resolver-typescript": "^3.6.1",
-        "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-prettier": "^5.1.3",
-        "packages-update": "^1.2.1",
-        "prettier": "^3.2.5",
-        "tsx": "^4.7.1",
-        "typescript": "^5.3.3"
-      },
-      "engines": {
-        "bun": ">=0.5.3",
-        "deno": ">=1.17.0",
-        "node": ">=6.0.0",
-        "typescript": ">=5.0.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2441,6 +2412,7 @@
       "resolved": "https://registry.npmjs.org/poku/-/poku-1.13.0.tgz",
       "integrity": "sha512-B84dFiA0tRI5ZyJDSZw/kKIydgx1DrVy2YVKvkuIrlz6rIPTGCdB8630dmUy6a07JnClypnE5k9Y41wBJ3/S+A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "poku": "lib/bin/index.js"
       },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-markdown": "^5.0.0",
     "husky": "^9.0.2",
     "lint-staged": "^15.0.1",
-    "poku": "^1.8.1",
+    "poku": "^1.13.0",
     "portfinder": "^1.0.28",
     "prettier": "^3.0.0",
     "progress": "^2.0.3",

--- a/test/common.test.cjs
+++ b/test/common.test.cjs
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const process = require('node:process');
 
 const config = {
   host: process.env.MYSQL_HOST || 'localhost',
@@ -179,7 +180,7 @@ exports.createConnectionWithURI = function () {
 
 exports.createTemplate = function () {
   const jade = require('jade');
-  const template = require('fs').readFileSync(
+  const template = require('node:fs').readFileSync(
     `${__dirname}/template.jade`,
     'ascii',
   );

--- a/test/esm/integration/connection/test-column-inspect.test.mjs
+++ b/test/esm/integration/connection/test-column-inspect.test.mjs
@@ -1,6 +1,9 @@
 import { test, assert, describe, beforeEach } from 'poku';
 import util from 'node:util';
-import common from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const common = require('../../../common.test.cjs');
 
 (async () => {
   const connection = common.createConnection().promise();

--- a/test/esm/integration/connection/test-execute-1.test.mjs
+++ b/test/esm/integration/connection/test-execute-1.test.mjs
@@ -1,5 +1,8 @@
 import { test, assert, describe } from 'poku';
-import common from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const common = require('../../../common.test.cjs');
 
 (async () => {
   const connection = common.createConnection().promise();

--- a/test/esm/integration/named-placeholders.test.mjs
+++ b/test/esm/integration/named-placeholders.test.mjs
@@ -1,10 +1,13 @@
 // TODO: `namedPlaceholders` can't be disabled at query level
 import { assert, test, describe } from 'poku';
-import {
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
   createConnection,
   describeOptions,
   createPool,
-} from '../../common.test.cjs';
+} = require('../../common.test.cjs');
 
 const query =
   'SELECT result FROM (SELECT 1 as result) temp WHERE temp.result=:named';

--- a/test/esm/integration/parsers/execute-results-creation.test.mjs
+++ b/test/esm/integration/parsers/execute-results-creation.test.mjs
@@ -1,5 +1,8 @@
 import { test, describe, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createConnection, describeOptions } = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/integration/parsers/execute-results-creation.test.mjs
+++ b/test/esm/integration/parsers/execute-results-creation.test.mjs
@@ -2,7 +2,10 @@ import { test, describe, assert } from 'poku';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { createConnection, describeOptions } = require('../../../common.test.cjs');
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/integration/parsers/query-results-creation.test.mjs
+++ b/test/esm/integration/parsers/query-results-creation.test.mjs
@@ -1,5 +1,8 @@
 import { test, describe, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createConnection, describeOptions } = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/integration/parsers/query-results-creation.test.mjs
+++ b/test/esm/integration/parsers/query-results-creation.test.mjs
@@ -2,7 +2,10 @@ import { test, describe, assert } from 'poku';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { createConnection, describeOptions } = require('../../../common.test.cjs');
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/integration/pool-cluster/test-promise-wrapper.test.mjs
+++ b/test/esm/integration/pool-cluster/test-promise-wrapper.test.mjs
@@ -1,6 +1,9 @@
 import { test, assert, describe } from 'poku';
-import { createPoolCluster } from '../../../../promise.js';
-import common from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const common = require('../../../common.test.cjs');
+const { createPoolCluster } = require('../../../../promise.js');
 
 (async () => {
   describe('Test pool cluster', common.describeOptions);

--- a/test/esm/integration/test-pool.test.mjs
+++ b/test/esm/integration/test-pool.test.mjs
@@ -1,6 +1,9 @@
 import { assert, test, describe } from 'poku';
-import mysql from '../../../index.js';
-import { describeOptions } from '../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { describeOptions } = require('../../common.test.cjs');
+const mysql = require('../../../index.js');
 
 const poolConfig = {}; // config: { connectionConfig: {} };
 

--- a/test/esm/regressions/2052.test.mjs
+++ b/test/esm/regressions/2052.test.mjs
@@ -1,7 +1,11 @@
 import { assert, describe, test } from 'poku';
-import common from '../../common.test.cjs';
-import PrepareCommand from '../../../lib/commands/prepare.js';
-import packets from '../../../lib/packets/index.js';
+import { createRequire } from 'node:module';
+import { Buffer } from 'node:buffer';
+
+const require = createRequire(import.meta.url);
+const common = require('../../common.test.cjs');
+const packets = require('../../../lib/packets/index.js');
+const PrepareCommand = require('../../../lib/commands/prepare.js');
 
 (async () => {
   await test(async () => {

--- a/test/esm/unit/parsers/big-numbers-strings-binary-sanitization.test.mjs
+++ b/test/esm/unit/parsers/big-numbers-strings-binary-sanitization.test.mjs
@@ -2,7 +2,10 @@ import { describe, test, assert } from 'poku';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
-const { createConnection, describeOptions } = require('../../../common.test.cjs');
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/unit/parsers/big-numbers-strings-binary-sanitization.test.mjs
+++ b/test/esm/unit/parsers/big-numbers-strings-binary-sanitization.test.mjs
@@ -1,5 +1,8 @@
 import { describe, test, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createConnection, describeOptions } = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/unit/parsers/big-numbers-strings-text-sanitization.test.mjs
+++ b/test/esm/unit/parsers/big-numbers-strings-text-sanitization.test.mjs
@@ -1,5 +1,11 @@
 import { describe, test, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/unit/parsers/cache-key-serialization.test.mjs
+++ b/test/esm/unit/parsers/cache-key-serialization.test.mjs
@@ -1,5 +1,9 @@
 import { assert } from 'poku';
-import { _keyFromFields } from '../../../../lib/parsers/parser_cache.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const { _keyFromFields } = require('../../../../lib/parsers/parser_cache.js');
 
 // Invalid
 const test1 = {

--- a/test/esm/unit/parsers/ensure-safe-binary-fields.test.mjs
+++ b/test/esm/unit/parsers/ensure-safe-binary-fields.test.mjs
@@ -1,7 +1,10 @@
 import { describe, assert } from 'poku';
-import { describeOptions } from '../../../common.test.cjs';
-import getBinaryParser from '../../../../lib/parsers/binary_parser.js';
-import { privateObjectProps } from '../../../../lib/helpers.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { describeOptions } = require('../../../common.test.cjs');
+const getBinaryParser = require('../../../../lib/parsers/binary_parser.js');
+const { privateObjectProps } = require('../../../../lib/helpers.js');
 
 describe('Binary Parser: Block Native Object Props', describeOptions);
 

--- a/test/esm/unit/parsers/ensure-safe-text-fields.test.mjs
+++ b/test/esm/unit/parsers/ensure-safe-text-fields.test.mjs
@@ -1,7 +1,10 @@
 import { describe, assert } from 'poku';
-import { describeOptions } from '../../../common.test.cjs';
-import TextRowParser from '../../../../lib/parsers/text_parser.js';
-import { privateObjectProps } from '../../../../lib/helpers.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { describeOptions } = require('../../../common.test.cjs');
+const TextRowParser = require('../../../../lib/parsers/text_parser.js');
+const { privateObjectProps } = require('../../../../lib/helpers.js');
 
 describe('Text Parser: Block Native Object Props', describeOptions);
 

--- a/test/esm/unit/parsers/support-big-numbers-binary-sanitization.test.mjs
+++ b/test/esm/unit/parsers/support-big-numbers-binary-sanitization.test.mjs
@@ -1,5 +1,11 @@
 import { describe, test, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/unit/parsers/support-big-numbers-text-sanitization.test.mjs
+++ b/test/esm/unit/parsers/support-big-numbers-text-sanitization.test.mjs
@@ -1,5 +1,11 @@
 import { describe, test, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/unit/parsers/timezone-binary-sanitization.test.mjs
+++ b/test/esm/unit/parsers/timezone-binary-sanitization.test.mjs
@@ -1,5 +1,12 @@
+import process from 'node:process';
 import { describe, test, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/unit/parsers/timezone-text-sanitization.test.mjs
+++ b/test/esm/unit/parsers/timezone-text-sanitization.test.mjs
@@ -1,5 +1,12 @@
+import process from 'node:process';
 import { describe, test, assert } from 'poku';
-import { createConnection, describeOptions } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
 
 const connection = createConnection().promise();
 

--- a/test/esm/unit/protocol/SqlString.test.mjs
+++ b/test/esm/unit/protocol/SqlString.test.mjs
@@ -1,5 +1,9 @@
 import { assert, test, describe } from 'poku';
-import { describeOptions, SqlString } from '../../../common.test.cjs';
+import { createRequire } from 'node:module';
+import { Buffer } from 'node:buffer';
+
+const require = createRequire(import.meta.url);
+const { SqlString, describeOptions } = require('../../../common.test.cjs');
 
 describe('SqlString.escapeId tests', describeOptions);
 

--- a/test/integration/config/test-connect-timeout.test.cjs
+++ b/test/integration/config/test-connect-timeout.test.cjs
@@ -1,9 +1,11 @@
 'use strict';
 const portfinder = require('portfinder');
 const mysql = require('../../../index.js');
+const assert = require('node:assert');
+const process = require('node:process');
 
-// Poku intentionally doesn't allow "rewriting" after uncaughtException
-const assert = require('assert');
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 console.log('test connect timeout');
 

--- a/test/integration/config/test-typecast-global-option.test.cjs
+++ b/test/integration/config/test-typecast-global-option.test.cjs
@@ -16,7 +16,6 @@ const connection = common.createConnection({
   typeCast: typeCastWrapper('toUpperCase'),
 });
 
-
 // query option override global typeCast
 connection.query(
   {

--- a/test/integration/config/test-typecast-global-option.test.cjs
+++ b/test/integration/config/test-typecast-global-option.test.cjs
@@ -1,5 +1,8 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+
 const typeCastWrapper = function (stringMethod) {
   return function (field, next) {
     if (field.type === 'VAR_STRING') {
@@ -9,12 +12,10 @@ const typeCastWrapper = function (stringMethod) {
   };
 };
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnection({
   typeCast: typeCastWrapper('toUpperCase'),
 });
 
-const { assert } = require('poku');
 
 // query option override global typeCast
 connection.query(

--- a/test/integration/connection/encoding/test-charset-results.test.cjs
+++ b/test/integration/connection/encoding/test-charset-results.test.cjs
@@ -1,14 +1,16 @@
 'use strict';
 
+const mysql = require('../../../../index.js');
+const common = require('../../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale (unsupported non utf8 charsets)');
   process.exit(0);
 }
 
-const mysql = require('../../../../index.js');
-const common = require('../../../common.test.cjs');
 const connection = common.createConnection();
-const { assert } = require('poku');
 
 const payload = 'привет, мир';
 

--- a/test/integration/connection/encoding/test-client-encodings.test.cjs
+++ b/test/integration/connection/encoding/test-client-encodings.test.cjs
@@ -1,12 +1,13 @@
 'use strict';
 
+const common = require('../../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale (unsupported non utf8 charsets)');
   process.exit(0);
 }
-
-const common = require('../../../common.test.cjs');
-const { assert } = require('poku');
 
 const connection = common.createConnection({ charset: 'UTF8MB4_GENERAL_CI' });
 connection.query('drop table if exists __test_client_encodings');

--- a/test/integration/connection/encoding/test-non-bmp-chars.test.cjs
+++ b/test/integration/connection/encoding/test-non-bmp-chars.test.cjs
@@ -2,6 +2,7 @@
 
 const common = require('../../../common.test.cjs');
 const { assert } = require('poku');
+const process = require('node:process');
 
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');

--- a/test/integration/connection/test-binary-charset-string.test.cjs
+++ b/test/integration/connection/test-binary-charset-string.test.cjs
@@ -1,8 +1,11 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 // TODO - this could be re-enabled
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {

--- a/test/integration/connection/test-binary-longlong.test.cjs
+++ b/test/integration/connection/test-binary-longlong.test.cjs
@@ -1,8 +1,8 @@
 'use strict';
 
 const { assert } = require('poku');
-
 const common = require('../../common.test.cjs');
+
 const conn = common.createConnection();
 
 conn.query(

--- a/test/integration/connection/test-binary-multiple-results.test.cjs
+++ b/test/integration/connection/test-binary-multiple-results.test.cjs
@@ -5,6 +5,9 @@
 
 'use strict';
 
+const assert = require('assert-diff');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
@@ -13,7 +16,7 @@ if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
 const mysql = require('../../common.test.cjs').createConnection({
   multipleStatements: true,
 });
-const assert = require('assert-diff');
+
 mysql.query('CREATE TEMPORARY TABLE no_rows (test int)');
 mysql.query('CREATE TEMPORARY TABLE some_rows (test int)');
 mysql.query('INSERT INTO some_rows values(0)');

--- a/test/integration/connection/test-buffer-params.test.cjs
+++ b/test/integration/connection/test-buffer-params.test.cjs
@@ -3,6 +3,8 @@
 const common = require('../../common.test.cjs');
 const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
 
 let rows = undefined;
 let rows1 = undefined;

--- a/test/integration/connection/test-change-user-multi-factor.test.cjs
+++ b/test/integration/connection/test-change-user-multi-factor.test.cjs
@@ -5,8 +5,12 @@
 const mysql = require('../../../index.js');
 const Command = require('../../../lib/commands/command.js');
 const Packets = require('../../../lib/packets/index.js');
-
+const { Buffer } = require('node:buffer');
 const { assert } = require('poku');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 class TestChangeUserMultiFactor extends Command {
   constructor(args) {

--- a/test/integration/connection/test-change-user-plugin-auth.test.cjs
+++ b/test/integration/connection/test-change-user-plugin-auth.test.cjs
@@ -1,12 +1,15 @@
 'use strict';
 
+const { assert } = require('poku');
+const common = require('../../common.test.cjs');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const { assert } = require('poku');
-const common = require('../../common.test.cjs');
 const connection = common.createConnection();
 const onlyUsername = function (name) {
   return name.substring(0, name.indexOf('@'));

--- a/test/integration/connection/test-change-user.test.cjs
+++ b/test/integration/connection/test-change-user.test.cjs
@@ -1,12 +1,15 @@
 'use strict';
 
+const { assert } = require('poku');
+const common = require('../../common.test.cjs');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const { assert } = require('poku');
-const common = require('../../common.test.cjs');
 const connection = common.createConnection();
 const onlyUsername = function (name) {
   return name.substring(0, name.indexOf('@'));

--- a/test/integration/connection/test-charset-encoding.test.cjs
+++ b/test/integration/connection/test-charset-encoding.test.cjs
@@ -3,6 +3,7 @@
 const common = require('../../common.test.cjs');
 const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
 
 // test data stores
 const testData = [

--- a/test/integration/connection/test-connect-after-connection-error.test.cjs
+++ b/test/integration/connection/test-connect-after-connection-error.test.cjs
@@ -2,6 +2,10 @@
 
 const mysql = require('../../../index.js');
 const { assert } = require('poku');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 const ERROR_TEXT = 'Connection lost: The server closed the connection.';
 

--- a/test/integration/connection/test-connect-after-connection.test.cjs
+++ b/test/integration/connection/test-connect-after-connection.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let connection2;
 

--- a/test/integration/connection/test-connect-connection-closed-error.test.cjs
+++ b/test/integration/connection/test-connect-connection-closed-error.test.cjs
@@ -2,10 +2,13 @@
 
 const mysql = require('../../../index.js');
 const { assert } = require('poku');
+const process = require('node:process');
+const portfinder = require('portfinder');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 const ERROR_TEXT = 'Connection lost: The server closed the connection.';
-
-const portfinder = require('portfinder');
 
 portfinder.getPort((err, port) => {
   const server = mysql.createServer();

--- a/test/integration/connection/test-connect-sha1.test.cjs
+++ b/test/integration/connection/test-connect-sha1.test.cjs
@@ -3,6 +3,11 @@
 const mysql = require('../../../index.js');
 const auth = require('../../../lib/auth_41.js');
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 function authenticate(params, cb) {
   const doubleSha = auth.doubleSha1('testpassword');

--- a/test/integration/connection/test-connect-time-error.test.cjs
+++ b/test/integration/connection/test-connect-time-error.test.cjs
@@ -2,10 +2,14 @@
 
 const mysql = require('../../../index.js');
 const { assert } = require('poku');
+const process = require('node:process');
+const portfinder = require('portfinder');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 const ERROR_TEXT = 'test error';
 
-const portfinder = require('portfinder');
 portfinder.getPort((err, port) => {
   const server = mysql.createServer();
   server.listen(port);

--- a/test/integration/connection/test-connect-with-uri.test.cjs
+++ b/test/integration/connection/test-connect-with-uri.test.cjs
@@ -1,5 +1,9 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 if (process.env.MYSQL_CONNECTION_URL) {
   console.log(
     'skipping test when mysql server is configured using MYSQL_CONNECTION_URL',
@@ -7,9 +11,7 @@ if (process.env.MYSQL_CONNECTION_URL) {
   process.exit(0);
 }
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnectionWithURI();
-const { assert } = require('poku');
 
 let rows = undefined;
 let fields = undefined;

--- a/test/integration/connection/test-connection-reset-while-closing.test.cjs
+++ b/test/integration/connection/test-connection-reset-while-closing.test.cjs
@@ -1,9 +1,8 @@
 'use strict';
 
+const assert = require('node:assert');
 const common = require('../../common.test.cjs');
-
-// Poku intentionally doesn't allow "rewriting" after uncaughtException
-const assert = require('assert');
+const process = require('node:process');
 
 const error = new Error('read ECONNRESET');
 error.code = 'ECONNRESET';

--- a/test/integration/connection/test-custom-date-parameter.test.cjs
+++ b/test/integration/connection/test-custom-date-parameter.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection({ timezone: 'Z' });
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection({ timezone: 'Z' });
 
 let rows = undefined;
 

--- a/test/integration/connection/test-date-parameter.test.cjs
+++ b/test/integration/connection/test-date-parameter.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection({ timezone: 'Z' });
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection({ timezone: 'Z' });
 
 let rows = undefined;
 

--- a/test/integration/connection/test-datetime.test.cjs
+++ b/test/integration/connection/test-datetime.test.cjs
@@ -1,12 +1,14 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 const connection = common.createConnection();
 const connection1 = common.createConnection({ dateStrings: true });
 const connection2 = common.createConnection({ dateStrings: ['DATE'] });
 const connectionZ = common.createConnection({ timezone: 'Z' });
 const connection0930 = common.createConnection({ timezone: '+09:30' });
-const { assert } = require('poku');
 
 let rows,
   rowsZ,

--- a/test/integration/connection/test-decimals-as-numbers.test.cjs
+++ b/test/integration/connection/test-decimals-as-numbers.test.cjs
@@ -1,6 +1,7 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
+const { assert } = require('poku');
 
 const connection1 = common.createConnection({
   decimalNumbers: false,
@@ -8,7 +9,6 @@ const connection1 = common.createConnection({
 const connection2 = common.createConnection({
   decimalNumbers: true,
 });
-const { assert } = require('poku');
 
 const largeDecimal = 900719.547409;
 const largeDecimalExpected = '900719.547409000000000000000000000000';

--- a/test/integration/connection/test-disconnects.test.cjs
+++ b/test/integration/connection/test-disconnects.test.cjs
@@ -9,6 +9,10 @@
 
 const common = require('../../common.test.cjs');
 const { assert } = require('poku');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 let rows;
 let fields;

--- a/test/integration/connection/test-error-events.test.cjs
+++ b/test/integration/connection/test-error-events.test.cjs
@@ -2,6 +2,7 @@
 
 const common = require('../../common.test.cjs');
 const { assert } = require('poku');
+const process = require('node:process');
 
 let callCount = 0;
 let exceptionCount = 0;

--- a/test/integration/connection/test-errors.test.cjs
+++ b/test/integration/connection/test-errors.test.cjs
@@ -1,14 +1,16 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 // different error codes for PS, disabling for now
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnection();
-const { assert } = require('poku');
 
 let onExecuteResultError = undefined;
 let onQueryResultError = undefined;

--- a/test/integration/connection/test-execute-bind-boolean.test.cjs
+++ b/test/integration/connection/test-execute-bind-boolean.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows;
 connection.execute(

--- a/test/integration/connection/test-execute-bind-date.test.cjs
+++ b/test/integration/connection/test-execute-bind-date.test.cjs
@@ -1,9 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
 
+const connection = common.createConnection();
 const date = new Date(2018, 2, 10, 15, 12, 34, 1234);
 
 let rows;

--- a/test/integration/connection/test-execute-bind-function.test.cjs
+++ b/test/integration/connection/test-execute-bind-function.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let error = null;
 

--- a/test/integration/connection/test-execute-bind-json.test.cjs
+++ b/test/integration/connection/test-execute-bind-json.test.cjs
@@ -1,9 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
 
+const connection = common.createConnection();
 const table = 'jsontable';
 const testJson = [{ a: 1, b: true, c: ['foo'] }];
 

--- a/test/integration/connection/test-execute-bind-null.test.cjs
+++ b/test/integration/connection/test-execute-bind-null.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows;
 connection.execute(

--- a/test/integration/connection/test-execute-bind-number.test.cjs
+++ b/test/integration/connection/test-execute-bind-number.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows;
 connection.execute(

--- a/test/integration/connection/test-execute-bind-undefined.test.cjs
+++ b/test/integration/connection/test-execute-bind-undefined.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let error = null;
 

--- a/test/integration/connection/test-execute-cached.test.cjs
+++ b/test/integration/connection/test-execute-cached.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows = undefined;
 let rows1 = undefined;

--- a/test/integration/connection/test-execute-newdecimal.test.cjs
+++ b/test/integration/connection/test-execute-newdecimal.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 connection.query('CREATE TEMPORARY TABLE t (f DECIMAL(19,4))');
 connection.query('INSERT INTO t VALUES(12345.67)');

--- a/test/integration/connection/test-execute-nocolumndef.test.cjs
+++ b/test/integration/connection/test-execute-nocolumndef.test.cjs
@@ -5,15 +5,17 @@
 
 'use strict';
 
+const common = require('../../common.test.cjs');
+const assert = require('assert-diff');
+const process = require('node:process');
+
 // different error codes for PS, disabling for now
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnection();
-const assert = require('assert-diff');
 
 // https://github.com/sidorares/node-mysql2/issues/130
 // https://github.com/sidorares/node-mysql2/issues/37

--- a/test/integration/connection/test-execute-order.test.cjs
+++ b/test/integration/connection/test-execute-order.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 const order = [];
 connection.execute('select 1+2', (err) => {

--- a/test/integration/connection/test-execute-signed.test.cjs
+++ b/test/integration/connection/test-execute-signed.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows = undefined;
 

--- a/test/integration/connection/test-execute-type-casting.test.cjs
+++ b/test/integration/connection/test-execute-type-casting.test.cjs
@@ -1,8 +1,11 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 common.useTestDb(connection);
 

--- a/test/integration/connection/test-insert-bigint-big-number-strings.test.cjs
+++ b/test/integration/connection/test-insert-bigint-big-number-strings.test.cjs
@@ -1,11 +1,12 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+
 const connection = common.createConnection({
   supportBigNumbers: true,
   bigNumberStrings: true,
 });
-const { assert } = require('poku');
 
 connection.query(
   [

--- a/test/integration/connection/test-insert-bigint.test.cjs
+++ b/test/integration/connection/test-insert-bigint.test.cjs
@@ -1,9 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
 const Long = require('long');
+
+const connection = common.createConnection();
 
 connection.query(
   [

--- a/test/integration/connection/test-insert-json.test.cjs
+++ b/test/integration/connection/test-insert-json.test.cjs
@@ -6,8 +6,10 @@
  */
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let result;
 let errorCodeInvalidJSON;

--- a/test/integration/connection/test-insert-large-blob.test.cjs
+++ b/test/integration/connection/test-insert-large-blob.test.cjs
@@ -4,6 +4,10 @@
 // eslint-disable-next-line no-constant-condition
 if (false) {
   const common = require('../../common.test.cjs');
+  const { assert } = require('poku');
+  const { Buffer } = require('node:buffer');
+  const process = require('node:process');
+
   const connection = common.createConnection();
 
   /*
@@ -14,8 +18,6 @@ if (false) {
   });
   return;
 */
-
-  const { assert } = require('poku');
 
   const table = 'insert_large_test';
   const length = 35777416;

--- a/test/integration/connection/test-insert-negative-ai.test.cjs
+++ b/test/integration/connection/test-insert-negative-ai.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 const testTable = 'neg-ai-test';
 const testData = 'test negative ai';

--- a/test/integration/connection/test-insert-results.test.cjs
+++ b/test/integration/connection/test-insert-results.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 // common.useTestDb(connection);
 

--- a/test/integration/connection/test-invalid-date-result.test.cjs
+++ b/test/integration/connection/test-invalid-date-result.test.cjs
@@ -6,8 +6,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows = undefined;
 

--- a/test/integration/connection/test-load-infile.test.cjs
+++ b/test/integration/connection/test-load-infile.test.cjs
@@ -1,14 +1,16 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const fs = require('node:fs');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnection();
-const { assert } = require('poku');
-const fs = require('fs');
 
 const table = 'load_data_test';
 connection.query('SET GLOBAL local_infile = true', assert.ifError);
@@ -62,7 +64,7 @@ connection.query(sql, [badPath, ','], (err, result) => {
 
 // test path mapping
 const createMyStream = function () {
-  const Stream = require('stream').PassThrough;
+  const Stream = require('node:stream').PassThrough;
   const myStream = new Stream();
   setTimeout(() => {
     myStream.write('11,Hello World\n');

--- a/test/integration/connection/test-multiple-results.test.cjs
+++ b/test/integration/connection/test-multiple-results.test.cjs
@@ -5,6 +5,9 @@
 
 'use strict';
 
+const assert = require('assert-diff');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
@@ -13,7 +16,6 @@ if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
 const mysql = require('../../common.test.cjs').createConnection({
   multipleStatements: true,
 });
-const assert = require('assert-diff');
 mysql.query('CREATE TEMPORARY TABLE no_rows (test int)');
 mysql.query('CREATE TEMPORARY TABLE some_rows (test int)');
 mysql.query('INSERT INTO some_rows values(0)');

--- a/test/integration/connection/test-named-placeholders.test.cjs
+++ b/test/integration/connection/test-named-placeholders.test.cjs
@@ -1,8 +1,9 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+
+const connection = common.createConnection();
 
 connection.query(
   [

--- a/test/integration/connection/test-nested-tables-query.test.cjs
+++ b/test/integration/connection/test-nested-tables-query.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 common.useTestDb(connection);
 

--- a/test/integration/connection/test-null-buffer.test.cjs
+++ b/test/integration/connection/test-null-buffer.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rowsTextProtocol;
 let rowsBinaryProtocol;

--- a/test/integration/connection/test-null-double.test.cjs
+++ b/test/integration/connection/test-null-double.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows;
 

--- a/test/integration/connection/test-null-int.test.cjs
+++ b/test/integration/connection/test-null-int.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows;
 

--- a/test/integration/connection/test-null.test.cjs
+++ b/test/integration/connection/test-null.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows, rows1;
 let fields1;

--- a/test/integration/connection/test-prepare-and-close.test.cjs
+++ b/test/integration/connection/test-prepare-and-close.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 const max = 500;
 const start = process.hrtime();

--- a/test/integration/connection/test-prepare-simple.test.cjs
+++ b/test/integration/connection/test-prepare-simple.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let _stmt1, _stmt2, _stmt3;
 const query1 = 'select 1 + ? + ? as test';

--- a/test/integration/connection/test-prepare-then-execute.test.cjs
+++ b/test/integration/connection/test-prepare-then-execute.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let _stmt = null;
 let _columns = null;

--- a/test/integration/connection/test-protocol-errors.test.cjs
+++ b/test/integration/connection/test-protocol-errors.test.cjs
@@ -9,6 +9,10 @@
 
 const { assert } = require('poku');
 const common = require('../../common.test.cjs');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 let fields, error;
 const query = 'SELECT 1';

--- a/test/integration/connection/test-query-timeout.test.cjs
+++ b/test/integration/connection/test-query-timeout.test.cjs
@@ -3,9 +3,11 @@
 const portfinder = require('portfinder');
 const common = require('../../common.test.cjs');
 const mysql = require('../../../index.js');
+const assert = require('node:assert');
+const process = require('node:process');
 
-// Poku intentionally doesn't allow "rewriting" after uncaughtException
-const assert = require('assert');
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 const connection = common.createConnection({ debug: false });
 

--- a/test/integration/connection/test-query-zero.test.cjs
+++ b/test/integration/connection/test-query-zero.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows;
 connection.query('SELECT ? AS result', 0, (err, _rows) => {

--- a/test/integration/connection/test-quit.test.cjs
+++ b/test/integration/connection/test-quit.test.cjs
@@ -9,6 +9,11 @@
 
 const { assert } = require('poku');
 const common = require('../../common.test.cjs');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
+
 let quitReceived = false;
 const queryCli = 'SELECT 1';
 let queryServ;

--- a/test/integration/connection/test-select-1.test.cjs
+++ b/test/integration/connection/test-select-1.test.cjs
@@ -2,6 +2,8 @@
 
 const { assert } = require('poku');
 const common = require('../../common.test.cjs');
+const process = require('node:process');
+
 const connection = common.createConnection();
 
 connection.query('SELECT 1 as result', (err, rows, fields) => {

--- a/test/integration/connection/test-select-empty-string.test.cjs
+++ b/test/integration/connection/test-select-empty-string.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows, fields;
 connection.query('SELECT ""', (err, _rows, _fields) => {

--- a/test/integration/connection/test-select-json.test.cjs
+++ b/test/integration/connection/test-select-json.test.cjs
@@ -5,8 +5,10 @@
  * issue#409: https://github.com/sidorares/node-mysql2/issues/409
  */
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let textFetchedRows = undefined;
 let binaryFetchedRows = undefined;

--- a/test/integration/connection/test-select-negative.test.cjs
+++ b/test/integration/connection/test-select-negative.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows = undefined;
 let rows1 = undefined;

--- a/test/integration/connection/test-select-ssl.test.cjs
+++ b/test/integration/connection/test-select-ssl.test.cjs
@@ -2,6 +2,8 @@
 
 const { assert } = require('poku');
 const common = require('../../common.test.cjs');
+const process = require('node:process');
+
 const connection = common.createConnection();
 
 connection.query(`SHOW STATUS LIKE 'Ssl_cipher'`, (err, rows) => {

--- a/test/integration/connection/test-select-utf8.test.cjs
+++ b/test/integration/connection/test-select-utf8.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows = undefined;
 const multibyteText = '本日は晴天なり';

--- a/test/integration/connection/test-signed-tinyint.test.cjs
+++ b/test/integration/connection/test-signed-tinyint.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows = undefined;
 

--- a/test/integration/connection/test-stream-errors.test.cjs
+++ b/test/integration/connection/test-stream-errors.test.cjs
@@ -9,6 +9,10 @@
 
 const { assert } = require('poku');
 const common = require('../../common.test.cjs');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 let clientConnection;
 const err = new Error('This socket has been ended by the other party');

--- a/test/integration/connection/test-stream.test.cjs
+++ b/test/integration/connection/test-stream.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let rows;
 const rows1 = [];

--- a/test/integration/connection/test-then-on-query.test.cjs
+++ b/test/integration/connection/test-then-on-query.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 let error = true;
 

--- a/test/integration/connection/test-timestamp.test.cjs
+++ b/test/integration/connection/test-timestamp.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 connection.query('SET SQL_MODE="ALLOW_INVALID_DATES";');
 connection.query('CREATE TEMPORARY TABLE t (f TIMESTAMP)');

--- a/test/integration/connection/test-track-state-change.test.cjs
+++ b/test/integration/connection/test-track-state-change.test.cjs
@@ -1,13 +1,15 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnection();
-const { assert } = require('poku');
 
 let result1, result2;
 

--- a/test/integration/connection/test-transaction-rollback.test.cjs
+++ b/test/integration/connection/test-transaction-rollback.test.cjs
@@ -1,8 +1,9 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+
+const connection = common.createConnection();
 
 common.useTestDb(connection);
 

--- a/test/integration/connection/test-type-cast-null-fields-execute.test.cjs
+++ b/test/integration/connection/test-type-cast-null-fields-execute.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 common.useTestDb(connection);
 

--- a/test/integration/connection/test-type-cast-null-fields.test.cjs
+++ b/test/integration/connection/test-type-cast-null-fields.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 common.useTestDb(connection);
 

--- a/test/integration/connection/test-type-casting-execute.test.cjs
+++ b/test/integration/connection/test-type-casting-execute.test.cjs
@@ -2,8 +2,11 @@
 
 const common = require('../../common.test.cjs');
 const driver = require('../../../index.js'); //needed to check driver.Types
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 common.useTestDb(connection);
 

--- a/test/integration/connection/test-type-casting.test.cjs
+++ b/test/integration/connection/test-type-casting.test.cjs
@@ -2,8 +2,11 @@
 
 const common = require('../../common.test.cjs');
 const driver = require('../../../index.js'); //needed to check driver.Types
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 common.useTestDb(connection);
 

--- a/test/integration/connection/test-typecast-execute.test.cjs
+++ b/test/integration/connection/test-typecast-execute.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+
+const connection = common.createConnection();
 
 connection.execute('CREATE TEMPORARY TABLE json_test (json_test JSON)');
 connection.execute('INSERT INTO json_test VALUES (?)', [

--- a/test/integration/connection/test-typecast-geometry-execute.test.cjs
+++ b/test/integration/connection/test-typecast-geometry-execute.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+
+const connection = common.createConnection();
 
 connection.execute('select 1', () => {
   const serverVersion = connection._handshakePacket.serverVersion;

--- a/test/integration/connection/test-typecast-geometry.test.cjs
+++ b/test/integration/connection/test-typecast-geometry.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+
+const connection = common.createConnection();
 
 connection.query('select 1', () => {
   const serverVersion = connection._handshakePacket.serverVersion;

--- a/test/integration/connection/test-typecast.test.cjs
+++ b/test/integration/connection/test-typecast.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const { Buffer } = require('node:buffer');
+
+const connection = common.createConnection();
 
 connection.query('CREATE TEMPORARY TABLE json_test (json_test JSON)');
 connection.query(

--- a/test/integration/connection/test-update-changed-rows.test.cjs
+++ b/test/integration/connection/test-update-changed-rows.test.cjs
@@ -1,5 +1,9 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 // "changedRows" is not part of the mysql protocol and extracted from "info string" response
 // while valid for most mysql servers, it's not guaranteed to be present in all cases
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
@@ -12,9 +16,7 @@ if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
  *
  * issue#288: https://github.com/sidorares/node-mysql2/issues/288
  */
-const common = require('../../common.test.cjs');
 const connection = common.createConnection();
-const { assert } = require('poku');
 
 let result1 = undefined;
 let result2 = undefined;

--- a/test/integration/connection/type-casting-tests.test.cjs
+++ b/test/integration/connection/type-casting-tests.test.cjs
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Buffer } = require('node:buffer');
+
 module.exports = function (connection) {
   const serverVersion = connection._handshakePacket.serverVersion;
   // mysql8 renamed some standard functions

--- a/test/integration/promise-wrappers/test-async-stack.test.cjs
+++ b/test/integration/promise-wrappers/test-async-stack.test.cjs
@@ -1,8 +1,12 @@
 'use strict';
 
+const process = require('node:process');
 const config = require('../../common.test.cjs').config;
 const { assert } = require('poku');
 const ErrorStackParser = require('error-stack-parser');
+
+// Uncaught Error: connect ECONNREFUSED 127.0.0.1:33066 - Local (undefined:undefined)
+if (typeof Deno !== 'undefined') process.exit(0);
 
 const createConnection = async function (args) {
   const connect = require('../../../promise.js').createConnection;

--- a/test/integration/promise-wrappers/test-promise-wrappers.test.cjs
+++ b/test/integration/promise-wrappers/test-promise-wrappers.test.cjs
@@ -1,13 +1,13 @@
 'use strict';
 
+const config = require('../../common.test.cjs').config;
+const { assert } = require('poku');
+const process = require('node:process');
+
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
-
-const config = require('../../common.test.cjs').config;
-
-const { assert } = require('poku');
 
 const createConnection = require('../../../promise.js').createConnection;
 const createPool = require('../../../promise.js').createPool;

--- a/test/integration/regressions/test-#433.test.cjs
+++ b/test/integration/regressions/test-#433.test.cjs
@@ -1,14 +1,16 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 // TODO: reach out to PlanetScale to clarify charset support
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnection({ charset: 'KOI8R_GENERAL_CI' });
-const { assert } = require('poku');
 
 const tableName = 'МояТаблица';
 const testFields = ['поле1', 'поле2', 'поле3', 'поле4'];

--- a/test/integration/regressions/test-#442.test.cjs
+++ b/test/integration/regressions/test-#442.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 const tableName = '商城';
 const testFields = ['商品类型', '商品说明', '价格', '剩余'];

--- a/test/integration/regressions/test-#485.test.cjs
+++ b/test/integration/regressions/test-#485.test.cjs
@@ -1,10 +1,10 @@
 'use strict';
 
 const config = require('../../common.test.cjs').config;
-
 const { assert } = require('poku');
 const createPoolPromise = require('../../../promise.js').createPool;
 const PoolConnection = require('../../../lib/pool_connection.js');
+const process = require('node:process');
 
 function createPool(args) {
   if (!args && process.env.MYSQL_CONNECTION_URL) {

--- a/test/integration/regressions/test-#617.test.cjs
+++ b/test/integration/regressions/test-#617.test.cjs
@@ -1,5 +1,9 @@
 'use strict';
 
+const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 // PlanetScale response has trailing 000 in 2017-07-26 09:36:42.000
 // TODO: rewrite test to account for variations. Skipping for now on PS
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
@@ -7,9 +11,7 @@ if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   process.exit(0);
 }
 
-const common = require('../../common.test.cjs');
 const connection = common.createConnection({ dateStrings: true });
-const { assert } = require('poku');
 
 const tableName = 'dates';
 const testFields = ['id', 'date', 'name'];

--- a/test/integration/regressions/test-#629.test.cjs
+++ b/test/integration/regressions/test-#629.test.cjs
@@ -1,11 +1,13 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
+const { assert } = require('poku');
+const process = require('node:process');
+
 const connection = common.createConnection({
   dateStrings: false,
   timezone: 'Z',
 });
-const { assert } = require('poku');
 
 const tableName = 'dates';
 const testFields = ['id', 'date1', 'date2', 'name'];

--- a/test/integration/regressions/test-#82.test.cjs
+++ b/test/integration/regressions/test-#82.test.cjs
@@ -1,8 +1,10 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const connection = common.createConnection();
 const { assert } = require('poku');
+const process = require('node:process');
+
+const connection = common.createConnection();
 
 const config = {
   table1: 'test82t1',

--- a/test/integration/test-auth-switch-multi-factor.test.cjs
+++ b/test/integration/test-auth-switch-multi-factor.test.cjs
@@ -5,8 +5,12 @@
 const mysql = require('../../index.js');
 const Command = require('../../lib/commands/command.js');
 const Packets = require('../../lib/packets/index.js');
-
+const { Buffer } = require('node:buffer');
 const { assert } = require('poku');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 class TestAuthMultiFactor extends Command {
   constructor(args) {

--- a/test/integration/test-auth-switch-plugin-async-error.test.cjs
+++ b/test/integration/test-auth-switch-plugin-async-error.test.cjs
@@ -5,9 +5,12 @@
 const mysql = require('../../index.js');
 const Command = require('../../lib/commands/command.js');
 const Packets = require('../../lib/packets/index.js');
+const { Buffer } = require('node:buffer');
+const assert = require('node:assert');
+const process = require('node:process');
 
-// Poku intentionally doesn't allow "rewriting" after uncaughtException
-const assert = require('assert');
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 class TestAuthSwitchPluginError extends Command {
   constructor(args) {

--- a/test/integration/test-auth-switch-plugin-error.test.cjs
+++ b/test/integration/test-auth-switch-plugin-error.test.cjs
@@ -5,9 +5,12 @@
 const mysql = require('../../index.js');
 const Command = require('../../lib/commands/command.js');
 const Packets = require('../../lib/packets/index.js');
+const { Buffer } = require('node:buffer');
+const assert = require('node:assert');
+const process = require('node:process');
 
-// Poku intentionally doesn't allow "rewriting" after uncaughtException
-const assert = require('assert');
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 class TestAuthSwitchPluginError extends Command {
   constructor(args) {

--- a/test/integration/test-auth-switch.test.cjs
+++ b/test/integration/test-auth-switch.test.cjs
@@ -4,8 +4,12 @@ const mysql = require('../../index.js');
 const Command = require('../../lib/commands/command.js');
 const Packets = require('../../lib/packets/index.js');
 const { version } = require('../../package.json');
-
+const { Buffer } = require('node:buffer');
 const { assert } = require('poku');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 const connectAttributes = { foo: 'bar', baz: 'foo' };
 

--- a/test/integration/test-handshake-unknown-packet-error.test.cjs
+++ b/test/integration/test-handshake-unknown-packet-error.test.cjs
@@ -6,9 +6,12 @@ const mysql = require('../../index.js');
 const Command = require('../../lib/commands/command.js');
 const Packet = require('../../lib/packets/packet.js');
 const Packets = require('../../lib/packets/index.js');
+const { Buffer } = require('node:buffer');
+const assert = require('node:assert');
+const process = require('node:process');
 
-// Poku intentionally doesn't allow "rewriting" after uncaughtException
-const assert = require('assert');
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 class TestUnknownHandshakePacket extends Command {
   constructor(args) {

--- a/test/integration/test-pool-connect-error.test.cjs
+++ b/test/integration/test-pool-connect-error.test.cjs
@@ -1,8 +1,12 @@
 'use strict';
 
 const mysql = require('../../index.js');
-
 const { assert } = require('poku');
+const process = require('node:process');
+const portfinder = require('portfinder');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
 
 const server = mysql.createServer((conn) => {
   conn.serverHandshake({
@@ -20,7 +24,6 @@ const server = mysql.createServer((conn) => {
 
 let err1, err2;
 
-const portfinder = require('portfinder');
 portfinder.getPort((err, port) => {
   server.listen(port);
   const conn = mysql.createConnection({

--- a/test/integration/test-pool-disconnect.test.cjs
+++ b/test/integration/test-pool-disconnect.test.cjs
@@ -2,6 +2,7 @@
 
 const { assert } = require('poku');
 const mysql = require('../common.test.cjs');
+const process = require('node:process');
 
 // planetscale does not support KILL, skipping this test
 // https://planetscale.com/docs/reference/mysql-compatibility

--- a/test/integration/test-server-close.test.cjs
+++ b/test/integration/test-server-close.test.cjs
@@ -2,17 +2,17 @@
 
 'use strict';
 
-const errors = require('../../lib/constants/errors');
+const errors = require('../../lib/constants/errors.js');
 const common = require('../common.test.cjs');
-const connection = common.createConnection();
-
-// Poku intentionally doesn't allow "rewriting" after uncaughtException
-const assert = require('assert');
+const assert = require('node:assert');
+const process = require('node:process');
 
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
+
+const connection = common.createConnection();
 
 const customWaitTimeout = 1; // seconds
 

--- a/test/unit/commands/test-query.test.cjs
+++ b/test/unit/commands/test-query.test.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('poku');
-const Query = require('../../../lib/commands/query');
+const Query = require('../../../lib/commands/query.js');
 
 const testError = new Error('something happened');
 const testQuery = new Query({}, (err, res) => {

--- a/test/unit/commands/test-quit.test.cjs
+++ b/test/unit/commands/test-quit.test.cjs
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('poku');
-const Quit = require('../../../lib/commands/quit');
+const Quit = require('../../../lib/commands/quit.js');
 
 const testCallback = (err) => console.info(err.message);
 const testQuit = new Quit(testCallback);

--- a/test/unit/connection/test-connection_config.test.cjs
+++ b/test/unit/connection/test-connection_config.test.cjs
@@ -1,7 +1,6 @@
 'use strict';
 
 const ConnectionConfig = require('../../../lib/connection_config.js');
-
 const { assert } = require('poku');
 
 const expectedMessage = "SSL profile must be an object, instead it's a boolean";

--- a/test/unit/packets/test-datetime.test.cjs
+++ b/test/unit/packets/test-datetime.test.cjs
@@ -2,6 +2,7 @@
 
 const { assert } = require('poku');
 const packets = require('../../../lib/packets/index.js');
+const { Buffer } = require('node:buffer');
 
 let buf = Buffer.from('0a000004000007dd070116010203', 'hex');
 

--- a/test/unit/packets/test-ok-sessiontrack.test.cjs
+++ b/test/unit/packets/test-ok-sessiontrack.test.cjs
@@ -4,6 +4,7 @@ const { assert } = require('poku');
 const Packet = require('../../../lib/packets/packet.js');
 const ResultSetHeader = require('../../../lib/packets/resultset_header.js');
 const clientConstants = require('../../../lib/constants/client.js');
+const { Buffer } = require('node:buffer');
 
 const mockConnection = {
   config: {},

--- a/test/unit/packets/test-time.test.cjs
+++ b/test/unit/packets/test-time.test.cjs
@@ -2,6 +2,7 @@
 
 const { assert } = require('poku');
 const packets = require('../../../lib/packets/index.js');
+const { Buffer } = require('node:buffer');
 
 [
   ['01:23:45', '0b000004000008000000000001172d'], // CONVERT('01:23:45', TIME)

--- a/test/unit/pool-cluster/test-connection-error-remove.test.cjs
+++ b/test/unit/pool-cluster/test-connection-error-remove.test.cjs
@@ -1,17 +1,20 @@
 'use strict';
 
+const { assert } = require('poku');
+const portfinder = require('portfinder');
+const common = require('../../common.test.cjs');
+const mysql = require('../../../index.js');
+const { exit } = require('node:process');
+const process = require('node:process');
+
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
+
 // TODO: config poolCluster to work with MYSQL_CONNECTION_URL run
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
-
-const { assert } = require('poku');
-const portfinder = require('portfinder');
-
-const common = require('../../common.test.cjs');
-const mysql = require('../../../index.js');
-const { exit } = require('process');
 
 if (process.platform === 'win32') {
   console.log('This test is known to fail on windows. FIXME: investi=gate why');

--- a/test/unit/pool-cluster/test-connection-order.test.cjs
+++ b/test/unit/pool-cluster/test-connection-order.test.cjs
@@ -1,13 +1,15 @@
 'use strict';
 
+const { assert } = require('poku');
+const common = require('../../common.test.cjs');
+const process = require('node:process');
+
 // TODO: config poolCluster to work with MYSQL_CONNECTION_URL run
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const { assert } = require('poku');
-const common = require('../../common.test.cjs');
 const cluster = common.createPoolCluster();
 
 const order = [];

--- a/test/unit/pool-cluster/test-connection-restore.test.cjs
+++ b/test/unit/pool-cluster/test-connection-restore.test.cjs
@@ -1,5 +1,11 @@
 'use strict';
 
+const { assert } = require('poku');
+const portfinder = require('portfinder');
+const common = require('../../common.test.cjs');
+const mysql = require('../../../index.js');
+const process = require('node:process');
+
 // TODO: config poolCluster to work with MYSQL_CONNECTION_URL run
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
@@ -11,10 +17,9 @@ if (process.platform === 'win32') {
   process.exit(0);
 }
 
-const { assert } = require('poku');
-const portfinder = require('portfinder');
-const common = require('../../common.test.cjs');
-const mysql = require('../../../index.js');
+// The process is not terminated in Deno
+if (typeof Deno !== 'undefined') process.exit(0);
+
 const cluster = common.createPoolCluster({
   canRetry: true,
   removeNodeErrorCount: 1,

--- a/test/unit/pool-cluster/test-connection-rr.test.cjs
+++ b/test/unit/pool-cluster/test-connection-rr.test.cjs
@@ -1,13 +1,15 @@
 'use strict';
 
+const { assert } = require('poku');
+const common = require('../../common.test.cjs');
+const process = require('node:process');
+
 // TODO: config poolCluster to work with MYSQL_CONNECTION_URL run
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const { assert } = require('poku');
-const common = require('../../common.test.cjs');
 const cluster = common.createPoolCluster();
 
 const order = [];

--- a/test/unit/pool-cluster/test-query.test.cjs
+++ b/test/unit/pool-cluster/test-query.test.cjs
@@ -1,13 +1,15 @@
 'use strict';
 
+const { assert } = require('poku');
+const common = require('../../common.test.cjs');
+const process = require('node:process');
+
 // TODO: config poolCluster to work with MYSQL_CONNECTION_URL run
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   console.log('skipping test for planetscale');
   process.exit(0);
 }
 
-const { assert } = require('poku');
-const common = require('../../common.test.cjs');
 const cluster = common.createPoolCluster();
 const poolConfig = common.getConfig();
 

--- a/test/unit/test-packet-parser.test.cjs
+++ b/test/unit/test-packet-parser.test.cjs
@@ -2,7 +2,7 @@
 
 const PacketParser = require('../../lib/packet_parser.js');
 const Packet = require('../../lib/packets/packet.js');
-
+const { Buffer } = require('node:buffer');
 const { assert } = require('poku');
 
 let pp;


### PR DESCRIPTION
Improving tests interoperability by using:

- explicit extensions for all test `import` and `require`
- explicit import native **Node.js** features (such as `process`, `buffer`, etc.)
- use `node:` prefix for **Node.js** native features (e.g., `node:process`, `node:buffer`, etc.)
- Use `require` to import `.cjs` into `.mjs` tests

> [!Note]
> 
> No changes have been made to the main code.

---

I'm developing a polyfill to allow testing **CommonJS** with **Deno** directly.
Here's the **MySQL2** spoiler:

<img width="974" alt="Screenshot 2024-05-28 at 12 29 08" src="https://github.com/sidorares/node-mysql2/assets/46850407/3bde6a9f-7b62-41df-a4fe-37a90f653f5f">

> **131/150**