### PR TITLE
fix(connection_config): remove keepAliveInitialDelay default value

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -118,7 +118,7 @@ class ConnectionConfig {
     this.trace = options.trace !== false;
     this.stringifyObjects = options.stringifyObjects || false;
     this.enableKeepAlive = options.enableKeepAlive !== false;
-    this.keepAliveInitialDelay = options.keepAliveInitialDelay || 0;
+    this.keepAliveInitialDelay = options.keepAliveInitialDelay;
     if (
       options.timezone &&
       !/^(?:local|Z|[ +-]\d\d:\d\d)$/.test(options.timezone)


### PR DESCRIPTION
Resolves https://github.com/sidorares/node-mysql2/issues/2599.

TL;DR: having the `keepAliveInitialDelay` set to 0 by default behaves differently on some environments causing ECONNRESET errors. You're not able to set it to `undefined` again. 