### PR TITLE
fix: setMaxParserCache throws TypeError

### DIFF
--- a/lib/parsers/parser_cache.js
+++ b/lib/parsers/parser_cache.js
@@ -2,7 +2,7 @@
 
 const LRU = require('lru-cache').default;
 
-const parserCache = new LRU({
+let parserCache = new LRU({
   max: 15000,
 });
 

--- a/lib/parsers/parser_cache.js
+++ b/lib/parsers/parser_cache.js
@@ -51,7 +51,7 @@ function getParser(type, fields, options, config, compiler) {
 }
 
 function setMaxCache(max) {
-  parserCache.max = max;
+  parserCache = new LRU({ max });
 }
 
 function clearCache() {


### PR DESCRIPTION
replace parser cache with a new one on setMaxParserCache to avoid TypeError, because `max` is now read-only on LRU caches and cannot be altered.