### PR TITLE
fix(typeCast): ensure the same behavior for `field.string()` with `query` and `execute`

### DIFF
--- a/lib/parsers/binary_parser.js
+++ b/lib/parsers/binary_parser.js
@@ -102,6 +102,24 @@ function compile(fields, options, config) {
           );
         }
 
+        if (
+          [Types.DATETIME, Types.NEWDATE, Types.TIMESTAMP, Types.DATE].includes(
+            field.columnType,
+          )
+        ) {
+          return packet.readDateTimeString(parseInt(field.decimals, 10));
+        }
+
+        if (field.columnType === Types.TINY) {
+          const unsigned = field.flags & FieldFlags.UNSIGNED;
+
+          return String(unsigned ? packet.readInt8() : packet.readSInt8());
+        }
+
+        if (field.columnType === Types.TIME) {
+          return packet.readTimeString();
+        }
+
         return packet.readLengthCodedString(encoding);
       },
       buffer: function () {

--- a/test/esm/integration/parsers/typecast-field-string.test.mjs
+++ b/test/esm/integration/parsers/typecast-field-string.test.mjs
@@ -1,0 +1,57 @@
+import { describe, assert } from 'poku';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  createConnection,
+  describeOptions,
+} = require('../../../common.test.cjs');
+
+const conn = createConnection({
+  typeCast: (field) => field.string(),
+}).promise();
+
+describe('typeCast field.string', describeOptions);
+
+const query = new Map();
+const execute = new Map();
+
+await conn.query(
+  'CREATE TEMPORARY TABLE tmp_tiny (`tiny` TINYINT, `tinyUnsigned` TINYINT UNSIGNED)',
+);
+await conn.query(
+  'CREATE TEMPORARY TABLE tmp_date (`timestamp` TIMESTAMP, `time` TIME)',
+);
+
+await conn.query('INSERT INTO tmp_tiny (`tiny`, `tinyUnsigned`) VALUES (0, 1)');
+await conn.query(
+  'INSERT INTO tmp_date (`timestamp`, `time`) VALUES (CURRENT_TIMESTAMP(), CURTIME())',
+);
+
+{
+  const [date] = await conn.query('SELECT NOW() AS `now`');
+  const [time] = await conn.query('SELECT timestamp, time FROM tmp_date');
+  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+
+  query.set('date', date[0]);
+  query.set('time', time[0]);
+  query.set('tiny', tinyint[0]);
+}
+
+{
+  const [date] = await conn.execute('SELECT NOW() AS `now`');
+  const [time] = await conn.execute('SELECT timestamp, time FROM tmp_date');
+  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+
+  execute.set('date', date[0]);
+  execute.set('time', time[0]);
+  execute.set('tiny', tinyint[0]);
+}
+
+await conn.end();
+
+assert.deepStrictEqual(
+  query,
+  execute,
+  'Ensures the same behavior for field.string',
+);

--- a/test/esm/integration/parsers/typecast-field-string.test.mjs
+++ b/test/esm/integration/parsers/typecast-field-string.test.mjs
@@ -13,45 +13,72 @@ const conn = createConnection({
 
 describe('typeCast field.string', describeOptions);
 
-const query = new Map();
-const execute = new Map();
+const query = {};
+const execute = {};
 
 await conn.query(
-  'CREATE TEMPORARY TABLE tmp_tiny (`tiny` TINYINT, `tinyUnsigned` TINYINT UNSIGNED)',
+  'CREATE TEMPORARY TABLE `tmp_tiny` (`signed` TINYINT, `unsigned` TINYINT UNSIGNED)',
 );
-await conn.query(
-  'CREATE TEMPORARY TABLE tmp_date (`timestamp` TIMESTAMP, `time` TIME)',
-);
+await conn.query('CREATE TEMPORARY TABLE `tmp_date` (`timestamp` TIMESTAMP)');
 
-await conn.query('INSERT INTO tmp_tiny (`tiny`, `tinyUnsigned`) VALUES (0, 1)');
+await conn.query('INSERT INTO `tmp_tiny` (`signed`, `unsigned`) VALUES (0, 1)');
 await conn.query(
-  'INSERT INTO tmp_date (`timestamp`, `time`) VALUES (CURRENT_TIMESTAMP(), CURTIME())',
+  'INSERT INTO `tmp_date` (`timestamp`) VALUES (CURRENT_TIMESTAMP())',
 );
 
 {
-  const [date] = await conn.query('SELECT NOW() AS `now`');
-  const [time] = await conn.query('SELECT timestamp, time FROM tmp_date');
-  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+  const [date] = await conn.query(
+    'SELECT STR_TO_DATE("2022-06-28", "%Y-%m-%d") AS `date`',
+  );
+  const [time] = await conn.query(
+    'SELECT STR_TO_DATE("12:34:56", "%H:%i:%s") AS `time`',
+  );
+  const [datetime] = await conn.query(
+    'SELECT STR_TO_DATE("2022-06-28 12:34:56", "%Y-%m-%d %H:%i:%s") AS `datetime`',
+  );
+  const [timestamp] = await conn.query('SELECT `timestamp` FROM `tmp_date`');
+  const [tiny] = await conn.query(
+    'SELECT `signed`, `unsigned` FROM `tmp_tiny`',
+  );
 
-  query.set('date', date[0]);
-  query.set('time', time[0]);
-  query.set('tiny', tinyint[0]);
+  query.date = date[0].date;
+  query.time = time[0].time;
+  query.timestamp = timestamp[0].timestamp;
+  query.datetime = datetime[0].datetime;
+  query.tiny = tiny[0];
 }
 
 {
-  const [date] = await conn.execute('SELECT NOW() AS `now`');
-  const [time] = await conn.execute('SELECT timestamp, time FROM tmp_date');
-  const [tinyint] = await conn.query('SELECT tiny, tinyUnsigned FROM tmp_tiny');
+  const [date] = await conn.execute(
+    'SELECT STR_TO_DATE("2022-06-28", "%Y-%m-%d") AS `date`',
+  );
+  const [time] = await conn.execute(
+    'SELECT STR_TO_DATE("12:34:56", "%H:%i:%s") AS `time`',
+  );
+  const [datetime] = await conn.execute(
+    'SELECT STR_TO_DATE("2022-06-28 12:34:56", "%Y-%m-%d %H:%i:%s") AS `datetime`',
+  );
+  const [timestamp] = await conn.execute('SELECT `timestamp` FROM `tmp_date`');
+  const [tiny] = await conn.execute(
+    'SELECT `signed`, `unsigned` FROM `tmp_tiny`',
+  );
 
-  execute.set('date', date[0]);
-  execute.set('time', time[0]);
-  execute.set('tiny', tinyint[0]);
+  execute.date = date[0].date;
+  execute.time = time[0].time;
+  execute.timestamp = timestamp[0].timestamp;
+  execute.datetime = datetime[0].datetime;
+  execute.tiny = tiny[0];
 }
 
 await conn.end();
 
+assert.deepStrictEqual(query.date, execute.date, 'DATE');
+assert.deepStrictEqual(query.time, execute.time, 'TIME');
+assert.deepStrictEqual(query.datetime, execute.datetime, 'DATETIME');
+assert.deepStrictEqual(query.timestamp, execute.timestamp, 'TIMESTAMP');
+assert.deepStrictEqual(query.tiny.signed, execute.tiny.signed, 'TINY (signed)');
 assert.deepStrictEqual(
-  query,
-  execute,
-  'Ensures the same behavior for field.string',
+  query.tiny.unsigned,
+  execute.tiny.unsigned,
+  'TINY (unsigned)',
 );


### PR DESCRIPTION
This _PR_ fixes a break changing reported in **Sequelize** (https://github.com/sequelize/sequelize/issues/17141) after introducing `typeCast` for execute method.

Following the same approach of _PR_ #2398, this _PR_ ensures that the `typeCast` usage for both `query` and `execute` methods are strictly equivalent when using `field.string()`.

> This isn't a new feature, but a part that was missed in #2398.

To illustrate it better:

```js
// typeCast: (field) => field.string()

assert.strictEqual(query.date, execute.date, 'DATE');
assert.strictEqual(query.time, execute.time, 'TIME');
assert.strictEqual(query.datetime, execute.datetime, 'DATETIME');
assert.strictEqual(query.timestamp, execute.timestamp, 'TIMESTAMP');
assert.strictEqual(query.tiny.signed, execute.tiny.signed, 'TINY (signed)');
assert.strictEqual(query.tiny.unsigned, execute.tiny.unsigned, 'TINY (unsigned)');
```

- Other column types didn't show issues with `field.string()`.

---

### From Sequelize

For everyone that uses the `bind` option, **MySQL2 3.9.0** causes a break changing, even if the user doesn't use `typeCast`:

<details>
<summary>
<i>repro.js</i>
</summary>

```js
import { Sequelize } from 'sequelize';

const sequelize = new Sequelize('test', 'root', '', {
  host: 'localhost',
  dialect: 'mysql',
  logging: false,
});

const [now] = await sequelize.query('SELECT NOW() as date WHERE 1 = $value;', {
  type: Sequelize.QueryTypes.SELECT,
  bind: {
    value: 1,
  },
});

const [custom] = await sequelize.query(
  'SELECT STR_TO_DATE("2022-06-28 12:34:56", "%Y-%m-%d %H:%i:%s") as date WHERE 1 = $value;',
  {
    type: Sequelize.QueryTypes.SELECT,
    bind: {
      value: 1,
    },
  }
);

const [date] = await sequelize.query(
  'SELECT DATE("2022-06-28") as string WHERE 1 = $value;',
  {
    type: Sequelize.QueryTypes.SELECT,
    bind: {
      value: 1,
    },
  }
);

await sequelize.close();

console.log('Now:', now.date);
console.log('Date:', custom.date);
console.log('Date (as string):', date.string);
```

</details>

> Output:
>
> <img width="583" alt="Screenshot 2024-06-30 at 19 17 36" src="https://github.com/wellwelwel/node-mysql2/assets/46850407/5d482bec-3c9e-4ec1-8185-3be451c4b355">

- There is no possibility for the **Sequelize** user to workaround this.

---

### From MySQL2

To get the same behavior with **MySQL2**, just use `field.string` from `typeCast` with specific column types:

> Current test of this _PR_

<img width="583" alt="Screenshot 2024-06-30 at 21 14 51" src="https://github.com/wellwelwel/node-mysql2/assets/46850407/49c07e98-2df8-4571-a0a3-6ed4efdbccd2">

---

### After this _PR_ 🧙🏻

#### Sequelize + `bind` option: 

> <img width="583" alt="Screenshot 2024-06-30 at 19 17 46" src="https://github.com/wellwelwel/node-mysql2/assets/46850407/8976f561-9a63-4d38-967b-5882758aa236">

#### MySQL2:

> <img width="583" alt="Screenshot 2024-06-30 at 21 15 08" src="https://github.com/wellwelwel/node-mysql2/assets/46850407/1f89f955-193a-4162-9c4d-ca7496218670">

---

> [!note]
> 
> - This issue don't occur with `next()`, only with `field.string()`.
> - These changes are unrelated to #2607 and don't introduce any new `typeCast` usage.