### PR TITLE
ci: adapt tests for MySQL v9

### DIFF
--- a/test/common.test.cjs
+++ b/test/common.test.cjs
@@ -232,3 +232,20 @@ exports.describeOptions = {
   icon: '🔬',
   background: false,
 };
+
+exports.getMysqlVersion = async function (connection) {
+  const conn = connection.promise ? connection.promise() : connection;
+
+  const [rows] = await conn.query('SELECT VERSION() AS `version`');
+  const serverVersion = rows[0].version;
+
+  const [major, minor, patch] = serverVersion
+    .split('.')
+    .map((x) => parseInt(x, 10));
+
+  return {
+    major,
+    minor,
+    patch,
+  };
+};

--- a/test/integration/connection/test-execute-type-casting.test.cjs
+++ b/test/integration/connection/test-execute-type-casting.test.cjs
@@ -1,87 +1,89 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const { assert } = require('poku');
+const { assert, test } = require('poku');
 const { Buffer } = require('node:buffer');
 const process = require('node:process');
 
-const connection = common.createConnection();
+test(async () => {
+  const connection = common.createConnection();
 
-common.useTestDb(connection);
+  common.useTestDb(connection);
 
-connection.query('select 1', (waitConnectErr) => {
-  assert.ifError(waitConnectErr);
-  const tests = require('./type-casting-tests.test.cjs')(connection);
+  connection.query('select 1', async (waitConnectErr) => {
+    assert.ifError(waitConnectErr);
+    const tests = await require('./type-casting-tests.test.cjs')(connection);
 
-  const table = 'type_casting';
+    const table = 'type_casting';
 
-  const schema = [];
-  const inserts = [];
+    const schema = [];
+    const inserts = [];
 
-  tests.forEach((test, index) => {
-    const escaped = test.insertRaw || connection.escape(test.insert);
+    tests.forEach((test, index) => {
+      const escaped = test.insertRaw || connection.escape(test.insert);
 
-    test.columnName = `${test.type}_${index}`;
+      test.columnName = `${test.type}_${index}`;
 
-    schema.push(`\`${test.columnName}\` ${test.type},`);
-    inserts.push(`\`${test.columnName}\` = ${escaped}`);
-  });
+      schema.push(`\`${test.columnName}\` ${test.type},`);
+      inserts.push(`\`${test.columnName}\` = ${escaped}`);
+    });
 
-  const createTable = [
-    `CREATE TEMPORARY TABLE \`${table}\` (`,
-    '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
-  ]
-    .concat(schema)
-    .concat(['PRIMARY KEY (`id`)', ') ENGINE=InnoDB DEFAULT CHARSET=utf8'])
-    .join('\n');
+    const createTable = [
+      `CREATE TEMPORARY TABLE \`${table}\` (`,
+      '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+    ]
+      .concat(schema)
+      .concat(['PRIMARY KEY (`id`)', ') ENGINE=InnoDB DEFAULT CHARSET=utf8'])
+      .join('\n');
 
-  connection.query(createTable);
+    connection.query(createTable);
 
-  connection.query(`INSERT INTO ${table} SET${inserts.join(',\n')}`);
+    connection.query(`INSERT INTO ${table} SET${inserts.join(',\n')}`);
 
-  let row;
-  connection.execute(
-    `SELECT * FROM ${table} WHERE id = ?;`,
-    [1],
-    (err, rows) => {
-      if (err) {
-        throw err;
-      }
+    let row;
+    connection.execute(
+      `SELECT * FROM ${table} WHERE id = ?;`,
+      [1],
+      (err, rows) => {
+        if (err) {
+          throw err;
+        }
 
-      row = rows[0];
-      connection.end();
-    },
-  );
+        row = rows[0];
+        connection.end();
+      },
+    );
 
-  process.on('exit', () => {
-    tests.forEach((test) => {
-      let expected = test.expect || test.insert;
-      let got = row[test.columnName];
-      let message;
+    process.on('exit', () => {
+      tests.forEach((test) => {
+        let expected = test.expect || test.insert;
+        let got = row[test.columnName];
+        let message;
 
-      if (expected instanceof Date) {
-        assert.equal(got instanceof Date, true, test.type);
+        if (expected instanceof Date) {
+          assert.equal(got instanceof Date, true, test.type);
 
-        expected = String(expected);
-        got = String(got);
-      } else if (Buffer.isBuffer(expected)) {
-        assert.equal(Buffer.isBuffer(got), true, test.type);
+          expected = String(expected);
+          got = String(got);
+        } else if (Buffer.isBuffer(expected)) {
+          assert.equal(Buffer.isBuffer(got), true, test.type);
 
-        expected = String(Array.prototype.slice.call(expected));
-        got = String(Array.prototype.slice.call(got));
-      }
+          expected = String(Array.prototype.slice.call(expected));
+          got = String(Array.prototype.slice.call(got));
+        }
 
-      if (test.deep) {
-        message = `got: "${JSON.stringify(got)}" expected: "${JSON.stringify(
-          expected,
-        )}" test: ${test.type}`;
-        assert.deepEqual(expected, got, message);
-      } else {
-        message = `got: "${got}" (${typeof got}) expected: "${expected}" (${typeof expected}) test: ${
-          test.type
-        }`;
-        assert.strictEqual(expected, got, message);
-      }
+        if (test.deep) {
+          message = `got: "${JSON.stringify(got)}" expected: "${JSON.stringify(
+            expected,
+          )}" test: ${test.type}`;
+          assert.deepEqual(expected, got, message);
+        } else {
+          message = `got: "${got}" (${typeof got}) expected: "${expected}" (${typeof expected}) test: ${
+            test.type
+          }`;
+          assert.strictEqual(expected, got, message);
+        }
+      });
     });
   });
 });

--- a/test/integration/connection/test-type-casting-execute.test.cjs
+++ b/test/integration/connection/test-type-casting-execute.test.cjs
@@ -2,97 +2,99 @@
 
 const common = require('../../common.test.cjs');
 const driver = require('../../../index.js'); //needed to check driver.Types
-const { assert } = require('poku');
+const { test, assert } = require('poku');
 const { Buffer } = require('node:buffer');
 const process = require('node:process');
 
-const connection = common.createConnection();
+test(async () => {
+  const connection = common.createConnection();
 
-common.useTestDb(connection);
+  common.useTestDb(connection);
 
-connection.execute('select 1', (waitConnectErr) => {
-  assert.ifError(waitConnectErr);
+  connection.execute('select 1', async (waitConnectErr) => {
+    assert.ifError(waitConnectErr);
 
-  const tests = require('./type-casting-tests.test.cjs')(connection);
+    const tests = await require('./type-casting-tests.test.cjs')(connection);
 
-  const table = 'type_casting';
+    const table = 'type_casting';
 
-  const schema = [];
-  const inserts = [];
+    const schema = [];
+    const inserts = [];
 
-  tests.forEach((test, index) => {
-    const escaped = test.insertRaw || connection.escape(test.insert);
+    tests.forEach((test, index) => {
+      const escaped = test.insertRaw || connection.escape(test.insert);
 
-    test.columnName = `${test.type}_${index}`;
+      test.columnName = `${test.type}_${index}`;
 
-    schema.push(`\`${test.columnName}\` ${test.type},`);
-    inserts.push(`\`${test.columnName}\` = ${escaped}`);
-  });
+      schema.push(`\`${test.columnName}\` ${test.type},`);
+      inserts.push(`\`${test.columnName}\` = ${escaped}`);
+    });
 
-  const createTable = [
-    `CREATE TEMPORARY TABLE \`${table}\` (`,
-    '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
-  ]
-    .concat(schema)
-    .concat(['PRIMARY KEY (`id`)', ') ENGINE=InnoDB DEFAULT CHARSET=utf8'])
-    .join('\n');
+    const createTable = [
+      `CREATE TEMPORARY TABLE \`${table}\` (`,
+      '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+    ]
+      .concat(schema)
+      .concat(['PRIMARY KEY (`id`)', ') ENGINE=InnoDB DEFAULT CHARSET=utf8'])
+      .join('\n');
 
-  connection.execute(createTable);
+    connection.execute(createTable);
 
-  connection.execute(`INSERT INTO ${table} SET ${inserts.join(',\n')}`);
+    connection.execute(`INSERT INTO ${table} SET ${inserts.join(',\n')}`);
 
-  let row;
-  let fieldData; // to lookup field types
-  connection.execute(`SELECT * FROM ${table}`, (err, rows, fields) => {
-    if (err) {
-      throw err;
-    }
-
-    row = rows[0];
-    // build a fieldName: fieldType lookup table
-    fieldData = fields.reduce((a, v) => {
-      a[v['name']] = v['type'];
-      return a;
-    }, {});
-    connection.end();
-  });
-
-  process.on('exit', () => {
-    tests.forEach((test) => {
-      // check that the column type matches the type name stored in driver.Types
-      const columnType = fieldData[test.columnName];
-      assert.equal(
-        test.columnType === driver.Types[columnType],
-        true,
-        test.columnName,
-      );
-      let expected = test.expect || test.insert;
-      let got = row[test.columnName];
-      let message;
-
-      if (expected instanceof Date) {
-        assert.equal(got instanceof Date, true, test.type);
-
-        expected = String(expected);
-        got = String(got);
-      } else if (Buffer.isBuffer(expected)) {
-        assert.equal(Buffer.isBuffer(got), true, test.type);
-
-        expected = String(Array.prototype.slice.call(expected));
-        got = String(Array.prototype.slice.call(got));
+    let row;
+    let fieldData; // to lookup field types
+    connection.execute(`SELECT * FROM ${table}`, (err, rows, fields) => {
+      if (err) {
+        throw err;
       }
 
-      if (test.deep) {
-        message = `got: "${JSON.stringify(got)}" expected: "${JSON.stringify(
-          expected,
-        )}" test: ${test.type}`;
-        assert.deepEqual(expected, got, message);
-      } else {
-        message = `got: "${got}" (${typeof got}) expected: "${expected}" (${typeof expected}) test: ${
-          test.type
-        }`;
-        assert.strictEqual(expected, got, message);
-      }
+      row = rows[0];
+      // build a fieldName: fieldType lookup table
+      fieldData = fields.reduce((a, v) => {
+        a[v['name']] = v['type'];
+        return a;
+      }, {});
+      connection.end();
+    });
+
+    process.on('exit', () => {
+      tests.forEach((test) => {
+        // check that the column type matches the type name stored in driver.Types
+        const columnType = fieldData[test.columnName];
+        assert.equal(
+          test.columnType === driver.Types[columnType],
+          true,
+          test.columnName,
+        );
+        let expected = test.expect || test.insert;
+        let got = row[test.columnName];
+        let message;
+
+        if (expected instanceof Date) {
+          assert.equal(got instanceof Date, true, test.type);
+
+          expected = String(expected);
+          got = String(got);
+        } else if (Buffer.isBuffer(expected)) {
+          assert.equal(Buffer.isBuffer(got), true, test.type);
+
+          expected = String(Array.prototype.slice.call(expected));
+          got = String(Array.prototype.slice.call(got));
+        }
+
+        if (test.deep) {
+          message = `got: "${JSON.stringify(got)}" expected: "${JSON.stringify(
+            expected,
+          )}" test: ${test.type}`;
+          assert.deepEqual(expected, got, message);
+        } else {
+          message = `got: "${got}" (${typeof got}) expected: "${expected}" (${typeof expected}) test: ${
+            test.type
+          }`;
+          assert.strictEqual(expected, got, message);
+        }
+      });
     });
   });
 });

--- a/test/integration/connection/test-type-casting.test.cjs
+++ b/test/integration/connection/test-type-casting.test.cjs
@@ -2,97 +2,99 @@
 
 const common = require('../../common.test.cjs');
 const driver = require('../../../index.js'); //needed to check driver.Types
-const { assert } = require('poku');
+const { test, assert } = require('poku');
 const { Buffer } = require('node:buffer');
 const process = require('node:process');
 
-const connection = common.createConnection();
+test(async () => {
+  const connection = common.createConnection();
 
-common.useTestDb(connection);
+  common.useTestDb(connection);
 
-connection.query('select 1', (waitConnectErr) => {
-  assert.ifError(waitConnectErr);
+  connection.query('select 1', async (waitConnectErr) => {
+    assert.ifError(waitConnectErr);
 
-  const tests = require('./type-casting-tests.test.cjs')(connection);
+    const tests = await require('./type-casting-tests.test.cjs')(connection);
 
-  const table = 'type_casting';
+    const table = 'type_casting';
 
-  const schema = [];
-  const inserts = [];
+    const schema = [];
+    const inserts = [];
 
-  tests.forEach((test, index) => {
-    const escaped = test.insertRaw || connection.escape(test.insert);
+    tests.forEach((test, index) => {
+      const escaped = test.insertRaw || connection.escape(test.insert);
 
-    test.columnName = `${test.type}_${index}`;
+      test.columnName = `${test.type}_${index}`;
 
-    schema.push(`\`${test.columnName}\` ${test.type},`);
-    inserts.push(`\`${test.columnName}\` = ${escaped}`);
-  });
+      schema.push(`\`${test.columnName}\` ${test.type},`);
+      inserts.push(`\`${test.columnName}\` = ${escaped}`);
+    });
 
-  const createTable = [
-    `CREATE TEMPORARY TABLE \`${table}\` (`,
-    '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
-  ]
-    .concat(schema)
-    .concat(['PRIMARY KEY (`id`)', ') ENGINE=InnoDB DEFAULT CHARSET=utf8'])
-    .join('\n');
+    const createTable = [
+      `CREATE TEMPORARY TABLE \`${table}\` (`,
+      '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
+    ]
+      .concat(schema)
+      .concat(['PRIMARY KEY (`id`)', ') ENGINE=InnoDB DEFAULT CHARSET=utf8'])
+      .join('\n');
 
-  connection.query(createTable);
+    connection.query(createTable);
 
-  connection.query(`INSERT INTO ${table} SET${inserts.join(',\n')}`);
+    connection.query(`INSERT INTO ${table} SET${inserts.join(',\n')}`);
 
-  let row;
-  let fieldData; // to lookup field types
-  connection.query(`SELECT * FROM ${table}`, (err, rows, fields) => {
-    if (err) {
-      throw err;
-    }
-
-    row = rows[0];
-    // build a fieldName: fieldType lookup table
-    fieldData = fields.reduce((a, v) => {
-      a[v['name']] = v['type'];
-      return a;
-    }, {});
-    connection.end();
-  });
-
-  process.on('exit', () => {
-    tests.forEach((test) => {
-      // check that the column type matches the type name stored in driver.Types
-      const columnType = fieldData[test.columnName];
-      assert.equal(
-        test.columnType === driver.Types[columnType],
-        true,
-        test.columnName,
-      );
-      let expected = test.expect || test.insert;
-      let got = row[test.columnName];
-      let message;
-
-      if (expected instanceof Date) {
-        assert.equal(got instanceof Date, true, test.type);
-
-        expected = String(expected);
-        got = String(got);
-      } else if (Buffer.isBuffer(expected)) {
-        assert.equal(Buffer.isBuffer(got), true, test.type);
-
-        expected = String(Array.prototype.slice.call(expected));
-        got = String(Array.prototype.slice.call(got));
+    let row;
+    let fieldData; // to lookup field types
+    connection.query(`SELECT * FROM ${table}`, (err, rows, fields) => {
+      if (err) {
+        throw err;
       }
 
-      if (test.deep) {
-        message = `got: "${JSON.stringify(got)}" expected: "${JSON.stringify(
-          expected,
-        )}" test: ${test.type}`;
-        assert.deepEqual(expected, got, message);
-      } else {
-        message = `got: "${got}" (${typeof got}) expected: "${expected}" (${typeof expected}) test: ${
-          test.type
-        }`;
-        assert.strictEqual(expected, got, message);
-      }
+      row = rows[0];
+      // build a fieldName: fieldType lookup table
+      fieldData = fields.reduce((a, v) => {
+        a[v['name']] = v['type'];
+        return a;
+      }, {});
+      connection.end();
+    });
+
+    process.on('exit', () => {
+      tests.forEach((test) => {
+        // check that the column type matches the type name stored in driver.Types
+        const columnType = fieldData[test.columnName];
+        assert.equal(
+          test.columnType === driver.Types[columnType],
+          true,
+          test.columnName,
+        );
+        let expected = test.expect || test.insert;
+        let got = row[test.columnName];
+        let message;
+
+        if (expected instanceof Date) {
+          assert.equal(got instanceof Date, true, test.type);
+
+          expected = String(expected);
+          got = String(got);
+        } else if (Buffer.isBuffer(expected)) {
+          assert.equal(Buffer.isBuffer(got), true, test.type);
+
+          expected = String(Array.prototype.slice.call(expected));
+          got = String(Array.prototype.slice.call(got));
+        }
+
+        if (test.deep) {
+          message = `got: "${JSON.stringify(got)}" expected: "${JSON.stringify(
+            expected,
+          )}" test: ${test.type}`;
+          assert.deepEqual(expected, got, message);
+        } else {
+          message = `got: "${got}" (${typeof got}) expected: "${expected}" (${typeof expected}) test: ${
+            test.type
+          }`;
+          assert.strictEqual(expected, got, message);
+        }
+      });
     });
   });
 });

--- a/test/integration/connection/test-typecast-geometry-execute.test.cjs
+++ b/test/integration/connection/test-typecast-geometry-execute.test.cjs
@@ -1,48 +1,50 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const { assert } = require('poku');
+const { test, assert } = require('poku');
 const { Buffer } = require('node:buffer');
 
-const connection = common.createConnection();
+test(async () => {
+  const connection = common.createConnection();
+  const mySQLVersion = await common.getMysqlVersion(connection);
 
-connection.execute('select 1', () => {
-  const serverVersion = connection._handshakePacket.serverVersion;
-  // mysql8 renamed some standard functions
-  // see https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html
-  const stPrefix = serverVersion[0] === '8' ? 'ST_' : '';
+  connection.execute('select 1', () => {
+    // mysql8 renamed some standard functions
+    // see https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html
+    const stPrefix = mySQLVersion.major >= 8 ? 'ST_' : '';
 
-  connection.execute(
-    {
-      sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
-      typeCast: function (field, next) {
-        if (field.type === 'GEOMETRY') {
-          return field.geometry();
-        }
-        return next();
+    connection.execute(
+      {
+        sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
+        typeCast: function (field, next) {
+          if (field.type === 'GEOMETRY') {
+            return field.geometry();
+          }
+          return next();
+        },
       },
-    },
-    (err, res) => {
-      assert.ifError(err);
-      assert.deepEqual(res[0].foo, { x: 11, y: 0 });
-    },
-  );
-
-  connection.execute(
-    {
-      sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
-      typeCast: function (field, next) {
-        if (field.type === 'GEOMETRY') {
-          return field.buffer();
-        }
-        return next();
+      (err, res) => {
+        assert.ifError(err);
+        assert.deepEqual(res[0].foo, { x: 11, y: 0 });
       },
-    },
-    (err, res) => {
-      assert.ifError(err);
-      assert.equal(Buffer.isBuffer(res[0].foo), true);
-    },
-  );
+    );
 
-  connection.end();
+    connection.execute(
+      {
+        sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
+        typeCast: function (field, next) {
+          if (field.type === 'GEOMETRY') {
+            return field.buffer();
+          }
+          return next();
+        },
+      },
+      (err, res) => {
+        assert.ifError(err);
+        assert.equal(Buffer.isBuffer(res[0].foo), true);
+      },
+    );
+
+    connection.end();
+  });
 });

--- a/test/integration/connection/test-typecast-geometry.test.cjs
+++ b/test/integration/connection/test-typecast-geometry.test.cjs
@@ -1,48 +1,50 @@
 'use strict';
 
 const common = require('../../common.test.cjs');
-const { assert } = require('poku');
+const { test, assert } = require('poku');
 const { Buffer } = require('node:buffer');
 
-const connection = common.createConnection();
+test(async () => {
+  const connection = common.createConnection();
+  const mySQLVersion = await common.getMysqlVersion(connection);
 
-connection.query('select 1', () => {
-  const serverVersion = connection._handshakePacket.serverVersion;
-  // mysql8 renamed some standard functions
-  // see https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html
-  const stPrefix = serverVersion[0] === '8' ? 'ST_' : '';
+  connection.query('select 1', () => {
+    // mysql8 renamed some standard functions
+    // see https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html
+    const stPrefix = mySQLVersion.major >= 8 ? 'ST_' : '';
 
-  connection.query(
-    {
-      sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
-      typeCast: function (field, next) {
-        if (field.type === 'GEOMETRY') {
-          return field.geometry();
-        }
-        return next();
+    connection.query(
+      {
+        sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
+        typeCast: function (field, next) {
+          if (field.type === 'GEOMETRY') {
+            return field.geometry();
+          }
+          return next();
+        },
       },
-    },
-    (err, res) => {
-      assert.ifError(err);
-      assert.deepEqual(res[0].foo, { x: 11, y: 0 });
-    },
-  );
-
-  connection.query(
-    {
-      sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
-      typeCast: function (field, next) {
-        if (field.type === 'GEOMETRY') {
-          return field.buffer();
-        }
-        return next();
+      (err, res) => {
+        assert.ifError(err);
+        assert.deepEqual(res[0].foo, { x: 11, y: 0 });
       },
-    },
-    (err, res) => {
-      assert.ifError(err);
-      assert.equal(Buffer.isBuffer(res[0].foo), true);
-    },
-  );
+    );
 
-  connection.end();
+    connection.query(
+      {
+        sql: `select ${stPrefix}GeomFromText('POINT(11 0)') as foo`,
+        typeCast: function (field, next) {
+          if (field.type === 'GEOMETRY') {
+            return field.buffer();
+          }
+          return next();
+        },
+      },
+      (err, res) => {
+        assert.ifError(err);
+        assert.equal(Buffer.isBuffer(res[0].foo), true);
+      },
+    );
+
+    connection.end();
+  });
 });

--- a/test/integration/connection/type-casting-tests.test.cjs
+++ b/test/integration/connection/type-casting-tests.test.cjs
@@ -1,12 +1,14 @@
 'use strict';
 
 const { Buffer } = require('node:buffer');
+const common = require('../../common.test.cjs');
 
-module.exports = function (connection) {
-  const serverVersion = connection._handshakePacket.serverVersion;
+module.exports = async function (connection) {
+  const mySQLVersion = await common.getMysqlVersion(connection);
+
   // mysql8 renamed some standard functions
   // see https://dev.mysql.com/doc/refman/8.0/en/gis-wkb-functions.html
-  const stPrefix = serverVersion[0] === '8' ? 'ST_' : '';
+  const stPrefix = mySQLVersion.major >= 8 ? 'ST_' : '';
 
   return [
     { type: 'decimal(4,3)', insert: '1.234', columnType: 'NEWDECIMAL' },


### PR DESCRIPTION
Some tests statically check for **MySQL Server** `v8`, where otherwise they understood it as `v5`.

These adjustments ensure that the tests dynamically check for **MySQL Server** versions.
