### PR TITLE
Add basic vector type

### DIFF
--- a/lib/constants/types.js
+++ b/lib/constants/types.js
@@ -51,6 +51,7 @@ module.exports.YEAR = 0x0d; // aka YEAR, 1 byte (don't ask)
 module.exports.NEWDATE = 0x0e; // aka ?
 module.exports.VARCHAR = 0x0f; // aka VARCHAR (?)
 module.exports.BIT = 0x10; // aka BIT, 1-8 byte
+module.exports.VECTOR = 0xf2;
 module.exports.JSON = 0xf5;
 module.exports.NEWDECIMAL = 0xf6; // aka DECIMAL
 module.exports.ENUM = 0xf7; // aka ENUM

--- a/typings/mysql/lib/constants/Types.d.ts
+++ b/typings/mysql/lib/constants/Types.d.ts
@@ -16,6 +16,7 @@ interface Types {
   0x0e: string;
   0x0f: string;
   0x10: string;
+  0xf2: string;
   0xf5: string;
   0xf6: string;
   0xf7: string;
@@ -45,6 +46,7 @@ interface Types {
   NEWDATE: number;
   VARCHAR: number;
   BIT: number;
+  VECTOR: number;
   JSON: number;
   NEWDECIMAL: number;
   ENUM: number;

--- a/typings/mysql/lib/parsers/typeCast.d.ts
+++ b/typings/mysql/lib/parsers/typeCast.d.ts
@@ -25,6 +25,7 @@ export type Type = {
     | 'NEWDATE'
     | 'VARCHAR'
     | 'BIT'
+    | 'VECTOR'
     | 'JSON'
     | 'NEWDECIMAL'
     | 'ENUM'


### PR DESCRIPTION
This adds the new MySQL 9.0 vector type. It can still be handled like a binary blob for now I think. Maybe it's worth in the future to directly decode / parse it into an array of floats here?