### PR TITLE
ci: temp disable Node.js 22.x from matrix

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x]
         mysql-version: ['mysql:8.0.33']
         use-compression: [0, 1]
         use-tls: [0, 1]


### PR DESCRIPTION
Currently, **GitHub Actions** uses **Node.js** `v22.5.0`, that brings an error for _CLI_ dependencies (`<command> not found`).

This bug has been fixed in **Node.js** `v22.5.1`, but I'm deactivating it from the matrix for now in order not to block the _CI_ workflows.

### References

- https://github.com/nodejs/node/issues/53902#issuecomment-2240584024
