### PR TITLE
ci: revert "ci: temp disable Node.js 22.x from matrix (#2870)"

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
         mysql-version: ['mysql:8.0.33']
         use-compression: [0, 1]
         use-tls: [0, 1]


### PR DESCRIPTION
This reverts commit 8c8d44f95bdfec4bb876fd60c18bc1e55c33da55.

---

Checking if **GitHub Actions** has updated **Node.js** to post `v22.5.0`.