### PR TITLE
ci: remove workaround in Bun tests

### DIFF
--- a/test/integration/connection/test-select-1.test.cjs
+++ b/test/integration/connection/test-select-1.test.cjs
@@ -2,7 +2,6 @@
 
 const { assert } = require('poku');
 const common = require('../../common.test.cjs');
-const process = require('node:process');
 
 const connection = common.createConnection();
 
@@ -18,7 +17,6 @@ connection.query('SELECT 1 as result', (err, rows, fields) => {
 
     connection.end((err) => {
       assert.ifError(err);
-      process.exit(0);
     });
   });
 });

--- a/test/integration/connection/test-select-ssl.test.cjs
+++ b/test/integration/connection/test-select-ssl.test.cjs
@@ -24,7 +24,6 @@ connection.query(`SHOW STATUS LIKE 'Ssl_cipher'`, (err, rows) => {
 
     connection.end((err) => {
       assert.ifError(err);
-      process.exit(0);
     });
   });
 });


### PR DESCRIPTION
After https://github.com/oven-sh/bun/pull/13212 and https://github.com/oven-sh/bun/pull/13412, conflicts related to `net` that didn't allow processes to terminate have been fixed.

If these two tests pass, we can run the entire test suite for `Bun` too 🧑🏻‍🔬
