### PR TITLE
fix: resolve LRU conflicts, cache loss and premature engine breaking change

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -22,7 +22,7 @@ const EventEmitter = require('events').EventEmitter;
 const Readable = require('stream').Readable;
 const Queue = require('denque');
 const SqlString = require('sqlstring');
-const LRU = require('lru-cache').default;
+const { createLRU } = require('lru.min');
 
 const PacketParser = require('./packet_parser.js');
 const Packets = require('./packets/index.js');
@@ -75,7 +75,7 @@ class Connection extends EventEmitter {
     this._command = null;
     this._paused = false;
     this._paused_packets = new Queue();
-    this._statements = new LRU({
+    this._statements = createLRU({
       max: this.config.maxPreparedStatements,
       dispose: function(statement) {
         statement.close();
@@ -411,7 +411,7 @@ class Connection extends EventEmitter {
     err.code = code || 'PROTOCOL_ERROR';
     this.emit('error', err);
   }
-  
+
   get fatalError() {
     return this._fatalError;
   }
@@ -611,7 +611,7 @@ class Connection extends EventEmitter {
     const key = Connection.statementKey(options);
     const stmt = this._statements.get(key);
     if (stmt) {
-      this._statements.delete(key);
+      this._statements.del(key);
       stmt.close();
     }
     return stmt;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -77,7 +77,7 @@ class Connection extends EventEmitter {
     this._paused_packets = new Queue();
     this._statements = createLRU({
       max: this.config.maxPreparedStatements,
-      dispose: function(statement) {
+      onEviction: function(_, statement) {
         statement.close();
       }
     });
@@ -611,7 +611,7 @@ class Connection extends EventEmitter {
     const key = Connection.statementKey(options);
     const stmt = this._statements.get(key);
     if (stmt) {
-      this._statements.del(key);
+      this._statements.delete(key);
       stmt.close();
     }
     return stmt;

--- a/lib/parsers/parser_cache.js
+++ b/lib/parsers/parser_cache.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const LRU = require('lru-cache').default;
+const { createLRU } = require('lru.min');
 
-let parserCache = new LRU({
+const parserCache = createLRU({
   max: 15000,
 });
 
@@ -51,7 +51,7 @@ function getParser(type, fields, options, config, compiler) {
 }
 
 function setMaxCache(max) {
-  parserCache = new LRU({ max });
+  parserCache.resize(max);
 }
 
 function clearCache() {

--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const Iconv = require('iconv-lite');
-const LRU = require('lru-cache').default;
+const { createLRU } = require('lru.min');
 
-const decoderCache = new LRU({
+const decoderCache = createLRU({
   max: 500,
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru.min": "^0.1.0",
+        "lru.min": "^0.2.3",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
@@ -2157,9 +2157,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru.min": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.1.0.tgz",
-      "integrity": "sha512-mT46uWDX25swxbtduLmiyycUCto8u2qQLgZDDq2NR+N9pXzlgJ/ca2eKTc8hWKnAnlxNclgcAVNSc8TnrLA+2w==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.2.3.tgz",
+      "integrity": "sha512-DPmeNBgjmeymlEnxeFnG+AZFYSyP2B/Akf409HWjanYgiuIDVCgoXuuo4O2v0g9PtfWdDO+G5sxNqVUzNL0rwg==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -4952,9 +4952,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "lru.min": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.1.0.tgz",
-      "integrity": "sha512-mT46uWDX25swxbtduLmiyycUCto8u2qQLgZDDq2NR+N9pXzlgJ/ca2eKTc8hWKnAnlxNclgcAVNSc8TnrLA+2w=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.2.3.tgz",
+      "integrity": "sha512-DPmeNBgjmeymlEnxeFnG+AZFYSyP2B/Akf409HWjanYgiuIDVCgoXuuo4O2v0g9PtfWdDO+G5sxNqVUzNL0rwg=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru.min": "^0.3.2",
+        "lru.min": "^1.0.0",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
@@ -2157,9 +2157,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru.min": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.2.tgz",
-      "integrity": "sha512-u2fhvG85ThKP3yxnjoWY79FjJbSwepsDuCL5D9CgGEeHCZhZ2UY32wjYDaaXOEplC6Qow9C96ZxW/Mk7TFN8QQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.0.0.tgz",
+      "integrity": "sha512-YthLl3hdewA3lIwPrpgDLNlq6bvgbZjJQR4qr6oQ2c6lC78sCOwJkn0AkuUArbydQNQ+PjwIVz9IwZNrmLhXeg==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -4952,9 +4952,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "lru.min": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.2.tgz",
-      "integrity": "sha512-u2fhvG85ThKP3yxnjoWY79FjJbSwepsDuCL5D9CgGEeHCZhZ2UY32wjYDaaXOEplC6Qow9C96ZxW/Mk7TFN8QQ=="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.0.0.tgz",
+      "integrity": "sha512-YthLl3hdewA3lIwPrpgDLNlq6bvgbZjJQR4qr6oQ2c6lC78sCOwJkn0AkuUArbydQNQ+PjwIVz9IwZNrmLhXeg=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru.min": "^0.2.3",
+        "lru.min": "^0.3.1",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
@@ -2157,9 +2157,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru.min": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.2.3.tgz",
-      "integrity": "sha512-DPmeNBgjmeymlEnxeFnG+AZFYSyP2B/Akf409HWjanYgiuIDVCgoXuuo4O2v0g9PtfWdDO+G5sxNqVUzNL0rwg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.1.tgz",
+      "integrity": "sha512-Q0f9iCCN2qjRVDTxZ80joyr5Tv9WUAWY8nLKXFC1VnNcBxY4GJMiEutqVt0K1nuxBuVNeXhcm3Zi/ZuCP29zug==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -4952,9 +4952,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "lru.min": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.2.3.tgz",
-      "integrity": "sha512-DPmeNBgjmeymlEnxeFnG+AZFYSyP2B/Akf409HWjanYgiuIDVCgoXuuo4O2v0g9PtfWdDO+G5sxNqVUzNL0rwg=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.1.tgz",
+      "integrity": "sha512-Q0f9iCCN2qjRVDTxZ80joyr5Tv9WUAWY8nLKXFC1VnNcBxY4GJMiEutqVt0K1nuxBuVNeXhcm3Zi/ZuCP29zug=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru-cache": "^8.0.0",
+        "lru.min": "^0.1.0",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
@@ -2156,12 +2156,19 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
-    "node_modules/lru-cache": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.4.tgz",
-      "integrity": "sha512-E9FF6+Oc/uFLqZCuZwRKUzgFt5Raih6LfxknOSAVTjNkrCZkBf7DQCwJxZQgd9l4eHjIJDGR+E+1QKD1RhThPw==",
+    "node_modules/lru.min": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.1.0.tgz",
+      "integrity": "sha512-mT46uWDX25swxbtduLmiyycUCto8u2qQLgZDDq2NR+N9pXzlgJ/ca2eKTc8hWKnAnlxNclgcAVNSc8TnrLA+2w==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16.14"
+        "bun": ">=1.0.0",
+        "deno": ">=1.30.0",
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wellwelwel"
       }
     },
     "node_modules/make-dir": {
@@ -4944,10 +4951,10 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
-    "lru-cache": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.4.tgz",
-      "integrity": "sha512-E9FF6+Oc/uFLqZCuZwRKUzgFt5Raih6LfxknOSAVTjNkrCZkBf7DQCwJxZQgd9l4eHjIJDGR+E+1QKD1RhThPw=="
+    "lru.min": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.1.0.tgz",
+      "integrity": "sha512-mT46uWDX25swxbtduLmiyycUCto8u2qQLgZDDq2NR+N9pXzlgJ/ca2eKTc8hWKnAnlxNclgcAVNSc8TnrLA+2w=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "generate-function": "^2.3.1",
         "iconv-lite": "^0.6.3",
         "long": "^5.2.1",
-        "lru.min": "^0.3.1",
+        "lru.min": "^0.3.2",
         "named-placeholders": "^1.1.3",
         "seq-queue": "^0.0.5",
         "sqlstring": "^2.3.2"
@@ -2157,9 +2157,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru.min": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.1.tgz",
-      "integrity": "sha512-Q0f9iCCN2qjRVDTxZ80joyr5Tv9WUAWY8nLKXFC1VnNcBxY4GJMiEutqVt0K1nuxBuVNeXhcm3Zi/ZuCP29zug==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.2.tgz",
+      "integrity": "sha512-u2fhvG85ThKP3yxnjoWY79FjJbSwepsDuCL5D9CgGEeHCZhZ2UY32wjYDaaXOEplC6Qow9C96ZxW/Mk7TFN8QQ==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -4952,9 +4952,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "lru.min": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.1.tgz",
-      "integrity": "sha512-Q0f9iCCN2qjRVDTxZ80joyr5Tv9WUAWY8nLKXFC1VnNcBxY4GJMiEutqVt0K1nuxBuVNeXhcm3Zi/ZuCP29zug=="
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-0.3.2.tgz",
+      "integrity": "sha512-u2fhvG85ThKP3yxnjoWY79FjJbSwepsDuCL5D9CgGEeHCZhZ2UY32wjYDaaXOEplC6Qow9C96ZxW/Mk7TFN8QQ=="
     },
     "make-dir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "generate-function": "^2.3.1",
     "iconv-lite": "^0.6.3",
     "long": "^5.2.1",
-    "lru.min": "^0.3.1",
+    "lru.min": "^0.3.2",
     "named-placeholders": "^1.1.3",
     "seq-queue": "^0.0.5",
     "sqlstring": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "generate-function": "^2.3.1",
     "iconv-lite": "^0.6.3",
     "long": "^5.2.1",
-    "lru.min": "^0.3.2",
+    "lru.min": "^1.0.0",
     "named-placeholders": "^1.1.3",
     "seq-queue": "^0.0.5",
     "sqlstring": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "generate-function": "^2.3.1",
     "iconv-lite": "^0.6.3",
     "long": "^5.2.1",
-    "lru-cache": "^8.0.0",
+    "lru.min": "^0.1.0",
     "named-placeholders": "^1.1.3",
     "seq-queue": "^0.0.5",
     "sqlstring": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "generate-function": "^2.3.1",
     "iconv-lite": "^0.6.3",
     "long": "^5.2.1",
-    "lru.min": "^0.1.0",
+    "lru.min": "^0.2.3",
     "named-placeholders": "^1.1.3",
     "seq-queue": "^0.0.5",
     "sqlstring": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "generate-function": "^2.3.1",
     "iconv-lite": "^0.6.3",
     "long": "^5.2.1",
-    "lru.min": "^0.2.3",
+    "lru.min": "^0.3.1",
     "named-placeholders": "^1.1.3",
     "seq-queue": "^0.0.5",
     "sqlstring": "^2.3.2"

--- a/test/integration/connection/test-execute-cached.test.cjs
+++ b/test/integration/connection/test-execute-cached.test.cjs
@@ -28,7 +28,7 @@ connection.execute(q, [123], (err, _rows) => {
         throw err;
       }
       rows2 = _rows;
-      assert(connection._statements.stored() === 1);
+      assert(connection._statements.size === 1);
       assert(connection._statements.get(key).query === q);
       assert(connection._statements.get(key).parameters.length === 1);
       connection.end();

--- a/test/integration/connection/test-execute-cached.test.cjs
+++ b/test/integration/connection/test-execute-cached.test.cjs
@@ -28,7 +28,7 @@ connection.execute(q, [123], (err, _rows) => {
         throw err;
       }
       rows2 = _rows;
-      assert(connection._statements.size === 1);
+      assert(connection._statements.stored() === 1);
       assert(connection._statements.get(key).query === q);
       assert(connection._statements.get(key).parameters.length === 1);
       connection.end();


### PR DESCRIPTION
Fixes #1885, Fixes #1953, Fixes #1965, Fixes #1970, Fixes #2001, Fixes #2537, Fixes #2619, Fixes #2752.

---

> [!IMPORTANT]
>
> This _PR_ replaces the **lru-cache**.

- Resolves all issues related to "`LRU is not a constructor`" since it is fully compatible with both _CJS_ and _ESM_ environments, from **Node.js** 8 onwards using **zero** _pollyfill_ (it works even in older browsers).
  > [#1885](https://github.com/sidorares/node-mysql2/issues/1885), [#1965](https://github.com/sidorares/node-mysql2/issues/1965), [#1970](https://github.com/sidorares/node-mysql2/issues/1970), [#2001](https://github.com/sidorares/node-mysql2/issues/2001), [#2537](https://github.com/sidorares/node-mysql2/issues/2537), [#2619](https://github.com/sidorares/node-mysql2/issues/2619)
- The same solution above also fixes the premature breaking change, requiring users to upgrade on Node.js `16.14` (dropping runtime versions isn't a problem, but it should be done in major releases)
  > [#1953](https://github.com/sidorares/node-mysql2/issues/1953)
- When `setMaxParserCache` is used, **MySQL2** overwrites/loses all previous cache (even for a higher size). After this _PR_, the cache is dynamically resized.
  > [#2752](https://github.com/sidorares/node-mysql2/issues/2752), [#2757](https://github.com/sidorares/node-mysql2/pull/2757)

⚡️ This brings a minimally performance improvement and uses a little less _CPU_ _(but not such a significant difference)_.

---

### A quick explanation

#### The motivation 🧑🏻‍🔬

The two most used projects _(**lru-cache** and **quick-lru**)_ that offer the most complete solutions usually dropping **Node.js** versions _(and it's fine)_. But this situation requires maintainers to also release a major version or continue to use a discontinued/old version.

Based on 7 of 8 linked issues, it started to cause a cascading reaction when each different package made a different decision, causing conflicts when installing the same package in different major versions of the same root project (it's not only a **MySQL2** problem).

#### The solution 💡

I noticed that there was no need for literally ANY _pollyfill_ (even after compilation) to run a **LRU** cache with even a little more performance (specially for **Bun**), which is where I decided bringing this dependency to **MySQL2**.

---

Recognizing the importance of **MySQL2**, I will include some details about the reliability of the project in the next comment (please don't associate this with any kind of promotion).

> Since this _PR_ replaces **lru-cache**, I'll understand perfectly if you don't like it — please feel free to close it 🙋🏻‍♂️