### PR TITLE
Add support for utf8mb3

### DIFF
--- a/lib/constants/encoding_charset.js
+++ b/lib/constants/encoding_charset.js
@@ -45,5 +45,6 @@ module.exports = {
   geostd8: 92,
   cp932: 95,
   eucjpms: 97,
+  utf8mb3: 192,
   gb18030: 248
 };

--- a/tools/generate-charset-mapping.js
+++ b/tools/generate-charset-mapping.js
@@ -22,6 +22,7 @@ const charsets = [];
 const mysql2iconv = {
   utf8: 'cesu8',
   utf8mb4: 'utf8',
+  utf8mb3: 'utf8',
   utf16le: 'utf16-le',
   ujis: 'eucjp',
   // need to check that this is correct mapping


### PR DESCRIPTION
Yes, it's an old encoding that mysql is phasing out. However, some DBs out there still use it and this library shouldn't crash in unexpected ways. Some servers (like ours) have some default connection settings that are still set to utf8mb3 even though all our columns / tables are in utf8mb4.

Ironically, if you run a query that has *no results* (REPLACE, DELETE, ...) then the metadata in the empty resultset is set to the server's default charset. If that happens to be `utf8mb3`, this library crashes.

Closes #1398 

Co-Author @davidrans