### PR TITLE
Add pattern and selector to PromisePoolCluster#getConnection

### DIFF
--- a/promise.js
+++ b/promise.js
@@ -451,10 +451,10 @@ class PromisePoolCluster extends EventEmitter {
     inheritEvents(poolCluster, this, ['warn', 'remove']);
   }
 
-  getConnection() {
+  getConnection(pattern, selector) {
     const corePoolCluster = this.poolCluster;
     return new this.Promise((resolve, reject) => {
-      corePoolCluster.getConnection((err, coreConnection) => {
+      corePoolCluster.getConnection(pattern, selector, (err, coreConnection) => {
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
The implementation of `PromisePoolCluster#getConnection` does not match the capabilities of `PoolCluster#getConnection` nor the definition in `promise.d.ts`.

This change corrects this by adding the missing `pattern` and `selector` parameters which are passed through to the underlying method.

Fixes #1381 

Note: I may have missed them, but I didn't see any tests for PromisePoolCluster to update or add to with this change.