### PR TITLE
Resolve ESM/CJS Module import conflict by using the minified lru-cache

### DIFF
--- a/lib/parsers/parser_cache.js
+++ b/lib/parsers/parser_cache.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const LRU = require('lru-cache').default;
+const LRU = require('lru-cache/min').default;
 
 let parserCache = new LRU({
   max: 15000,

--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Iconv = require('iconv-lite');
-const LRU = require('lru-cache').default;
+const LRU = require('lru-cache/min').default;
 
 const decoderCache = new LRU({
   max: 500,


### PR DESCRIPTION
Hey,

This PR updates the imports of `lru-cache` to to the minified exports, this seems to resolve the LRU import error I get under certain context, I have run the unit and integration tests, no issues observed either.

Creating PR to run E2E Tests suite