### PR TITLE
ci: temp remove Deno canary from matrix

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -115,7 +115,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        deno-version: [v1.x, canary]
+        deno-version: [
+            v1.x,
+            # v2.x,
+            # canary
+          ]
         mysql-version: ['mysql:8.0.33']
         use-compression: [0, 1]
         # TODO: investigate error when using SSL (1)


### PR DESCRIPTION
Although `TCP.setNoDelay` was implemented in https://github.com/denoland/deno/pull/26263, the latest release on **GitHub Actions** doesn't seem to have included this fix.

To prevent CI blocking, I'm temporarily removing the canary version until the problem is resolved 🙋🏻‍♂️

Related:

- https://github.com/denoland/deno/issues/26177
