### PR TITLE
chore(website): remove deprecated `Sass` resources

### DIFF
--- a/website/src/css/_history.scss
+++ b/website/src/css/_history.scss
@@ -1,3 +1,5 @@
+@use 'mixins' as *;
+
 details {
   &.history {
     // Reset Docusaurus styles

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -1,4 +1,5 @@
-@import 'mixins';
+@use 'sass:meta' as *;
+@use 'mixins' as *;
 
 :root {
   --ifm-color-primary: #45aaf2;
@@ -93,7 +94,7 @@ pre[class*='language-'] {
 }
 
 // Components
-@import './loading';
-@import './history';
-@import './stability/main';
-@import './faq';
+@include load-css('loading');
+@include load-css('history');
+@include load-css('stability/main');
+@include load-css('faq');

--- a/website/src/css/stability/_main.scss
+++ b/website/src/css/stability/_main.scss
@@ -1,3 +1,6 @@
+@use 'sass:meta' as *;
+@use '../mixins' as *;
+
 section {
   &.stability {
     @include flex(column);
@@ -55,5 +58,5 @@ section {
 }
 
 // Themes
-@import 'light';
-@import 'dark';
+@include load-css('light');
+@include load-css('dark');


### PR DESCRIPTION
This _PR_ just remove the noise warnings when working in the website due to deprecated **Sass** resources.

**Related:**

- https://github.com/sass/sass/issues/3513.