### PR TITLE
chore: fix repository url for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/sidorares/node-mysql2"
+    "url": "git+https://github.com/sidorares/node-mysql2.git"
   },
   "homepage": "https://sidorares.github.io/node-mysql2/docs",
   "keywords": [


### PR DESCRIPTION
Just fixing a warning from **npm** when publishing:

```
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "repository.url" was normalized to "git+https://github.com/sidorares/node-mysql2.git"
```

- Not related to https://github.com/sidorares/node-mysql2/pull/3377#issuecomment-2635170534.