### PR TITLE
fix(query): support `VECTOR` packets in static parser

### DIFF
--- a/lib/parsers/static_text_parser.js
+++ b/lib/parsers/static_text_parser.js
@@ -56,6 +56,8 @@ function readField({ packet, type, charset, encoding, config, options }) {
       return packet.readLengthCodedString('ascii');
     case Types.GEOMETRY:
       return packet.parseGeometryValue();
+    case Types.VECTOR:
+      return packet.parseVector();
     case Types.JSON:
       // Since for JSON columns mysql always returns charset 63 (BINARY),
       // we have to handle it according to JSON specs and use "utf8",


### PR DESCRIPTION
The support for `VECTOR` packets (**MySQL 9+**) has not been included with the static text parser in #3365. This _PR_ just fixes it.
