### PR TITLE
ci: improve workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22]
         mysql-version: ["mysql:8.0.18"]
         use-compression: [0]
         use-tls: [0]

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -50,7 +50,7 @@ jobs:
         if: steps.check_commit.outputs.publish == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '22.x'
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache dependencies

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x]
-        mysql-version: ['mysql:5.7', 'mysql:8.0', 'mysql:9.0']
+        mysql-version: ['mysql:5.7', 'mysql:8.0', 'mysql:9.1']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
-        mysql-version: ['mysql:5.7', 'mysql:8.0']
+        node-version: [22]
+        mysql-version: ['mysql:5.7', 'mysql:8.0', 'mysql:9.0']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x]
-        mysql-version: ['mysql:5.7', 'mysql:8.0.33']
+        mysql-version: ['mysql:5.7', 'mysql:8.0', 'mysql:9.0']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x]
-        mysql-version: ['mysql:5.7', 'mysql:8.0', 'mysql:9.1']
+        mysql-version: ['mysql:5.7', 'mysql:8.0', 'mysql:9.2']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [20.x]
-        mysql-version: ['mysql:5.7', 'mysql:8.0', 'mysql:9.2']
+        mysql-version: ['mysql:5.7', 'mysql:8.0']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 23.x]
-        mysql-version: ['mysql:8.0.33']
+        node-version: [18, 20, 22, 23]
+        mysql-version: ['mysql:8.3']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         bun-version: [latest, canary]
-        mysql-version: ['mysql:8.0.33']
+        mysql-version: ['mysql:8.0']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         deno-version: [v1.x]
-        mysql-version: ['mysql:8.0.33']
+        mysql-version: ['mysql:8.0']
         use-compression: [0, 1]
         static-parser: [0, 1]
         # TODO: investigate error when using SSL (1)
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         deno-version: [v2.x, canary]
-        mysql-version: ['mysql:8.0.33']
+        mysql-version: ['mysql:8.0']
         use-compression: [0, 1]
         static-parser: [0, 1]
         # TODO: investigate error when using SSL (1)
@@ -209,7 +209,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       matrix:
         bun-version: [latest, canary]
-        mysql-version: ['mysql:8.0']
+        mysql-version: ['mysql:8.3']
         use-compression: [0, 1]
         use-tls: [0, 1]
         static-parser: [0, 1]
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         deno-version: [v1.x]
-        mysql-version: ['mysql:8.0']
+        mysql-version: ['mysql:8.3']
         use-compression: [0, 1]
         static-parser: [0, 1]
         # TODO: investigate error when using SSL (1)
@@ -181,7 +181,7 @@ jobs:
       fail-fast: false
       matrix:
         deno-version: [v2.x, canary]
-        mysql-version: ['mysql:8.0']
+        mysql-version: ['mysql:8.3']
         use-compression: [0, 1]
         static-parser: [0, 1]
         # TODO: investigate error when using SSL (1)

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -22,15 +22,14 @@ jobs:
         mysql-version: ['mysql:8.3']
         use-compression: [0, 1]
         use-tls: [0, 1]
-        static-parser: [0, 1]
         mysql_connection_url_key: ['']
+        # static-parser: [0, 1]  # Already tested in "ci-coverage"
         # TODO - add mariadb to the matrix. currently few tests are broken due to mariadb incompatibilities
 
     env:
       MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}
-      STATIC_PARSER: ${{ matrix.static-parser }}
 
-    name: Node.js ${{ matrix.node-version }} - DB ${{ matrix.mysql-version }}${{ matrix.mysql_connection_url_key }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}} Static Parser=${{matrix.static-parser}}
+    name: Node.js ${{ matrix.node-version }} - DB ${{ matrix.mysql-version }}${{ matrix.mysql_connection_url_key }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -28,7 +28,7 @@ jobs:
             # 'mysql:8.4', # TODO: Tests never end
             'mysql:9.0',
             'mysql:9.1',
-            # 'mysql:9.2', # Already tested in "ci-coverage"
+            'mysql:9.2',
           ]
         mysql_connection_url_key: ['']
         include:

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -30,16 +30,20 @@ jobs:
             'mysql:9.1',
             'mysql:9.2',
           ]
+        use-compression: [0, 1]
+        use-tls: [0, 1]
         mysql_connection_url_key: ['']
         include:
           ## MySQL 5.1: A number of tests does not work due to old sql syntax, just testing basic connection
           - filter: 'test-select-1'
             mysql-version: 'datagrip/mysql:5.1'
+            use-compression: 0
+            use-tls: 0
 
     env:
       MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}
 
-    name: ${{ matrix.mysql-version }}${{ matrix.mysql_connection_url_key }}
+    name: ${{ matrix.mysql-version }}${{ matrix.mysql_connection_url_key }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -17,29 +17,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x] # LTS
+        node-version: [22]
         mysql-version:
           [
-            'mysql:5.7',
-            'mysql:8.0.18',
-            'mysql:8.0.22',
-            'mysql:8.0.33',
-            'mysql:9.0.1',
-            'mysql:latest',
+            # 'mysql:5.7', # Already tested in "ci-coverage"
+            # 'mysql:8.0', # Already tested in "ci-linux"
+            'mysql:8.1',
+            'mysql:8.2',
+            # 'mysql:8.3', # Already tested in "ci-coverage"
+            'mysql:8.4',
+            # 'mysql:9.0', # Already tested in "ci-coverage"
+            'mysql:9.1',
+            'mysql:9.2',
           ]
-        use-compression: [0, 1]
-        use-tls: [0, 1]
         mysql_connection_url_key: ['']
         include:
           ## MySQL 5.1: A number of tests does not work due to old sql syntax, just testing basic connection
           - filter: 'test-select-1'
             mysql-version: 'datagrip/mysql:5.1'
-            use-compression: 0
-            use-tls: 0
+
     env:
       MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}
 
-    name: ${{ matrix.mysql-version }}${{ matrix.mysql_connection_url_key }} - SSL=${{matrix.use-tls}} Compression=${{matrix.use-compression}}
+    name: ${{ matrix.mysql-version }}${{ matrix.mysql_connection_url_key }}
 
     steps:
       - uses: actions/checkout@v4
@@ -68,4 +68,4 @@ jobs:
         run: node tools/wait-up.js
 
       - name: Run tests
-        run: FILTER=${{matrix.filter}} MYSQL_USE_TLS=${{ matrix.use-tls }} MYSQL_USE_COMPRESSION=${{ matrix.use-compression }} npm run test
+        run: FILTER=${{matrix.filter}} npm run test

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -21,13 +21,13 @@ jobs:
         mysql-version:
           [
             # 'mysql:5.7', # Already tested in "ci-coverage"
-            # 'mysql:8.0', # Already tested in "ci-linux"
+            # 'mysql:8.0', # Already tested in "ci-coverage"
             'mysql:8.1',
             'mysql:8.2',
-            # 'mysql:8.3', # Already tested in "ci-coverage"
-            'mysql:8.4',
-            # 'mysql:9.0', # Already tested in "ci-coverage"
-            'mysql:9.1',
+            # 'mysql:8.3', # Already tested in "ci-linux"
+            # 'mysql:8.4', # TODO: Tests never end
+            # 'mysql:9.0', # TODO: Tests never end
+            # 'mysql:9.1', # Already tested in "ci-coverage"
             'mysql:9.2',
           ]
         mysql_connection_url_key: ['']

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -26,7 +26,7 @@ jobs:
             'mysql:8.2',
             # 'mysql:8.3', # Already tested in "ci-linux"
             # 'mysql:8.4', # TODO: Tests never end
-            'mysql:9.0',
+            # 'mysql:9.0', # Already tested in "ci-coverage"
             'mysql:9.1',
             'mysql:9.2',
           ]

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -26,9 +26,9 @@ jobs:
             'mysql:8.2',
             # 'mysql:8.3', # Already tested in "ci-linux"
             # 'mysql:8.4', # TODO: Tests never end
-            # 'mysql:9.0', # TODO: Tests never end
-            # 'mysql:9.1', # Already tested in "ci-coverage"
-            'mysql:9.2',
+            'mysql:9.0',
+            'mysql:9.1',
+            # 'mysql:9.2', # Already tested in "ci-coverage"
           ]
         mysql_connection_url_key: ['']
         include:

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x] # LTS
+        node-version: [22] # LTS
         use-compression: [0, 1]
         use-tls: [0, 1]
 

--- a/.github/workflows/ci-osx.yml
+++ b/.github/workflows/ci-osx.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22] # LTS
+        node-version: [22]
         use-compression: [0, 1]
         use-tls: [0, 1]
 

--- a/.github/workflows/ci-tsc-build.yml
+++ b/.github/workflows/ci-tsc-build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [22]
 
     name: Node.js ${{ matrix.node-version }}
     steps:

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Actions - Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: 22
 
       - name: Cache Dependencies
         uses: actions/cache@v4

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x] # LTS
+        node-version: [22]
         mysql-version: ['8.0']
         use-compression: [0, 1]
         use-tls: [0, 1]

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Actions - Setup NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '18.x'
+          node-version: 22
 
       - name: Cache Dependencies
         uses: actions/cache@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 20.x
+  NODE_VERSION: 22
 
 jobs:
   lint-js:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-node@v4
         if: ${{ steps.release.outputs.release_created }}
         with:
-          node-version: '20.x'
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - name: Cache dependencies


### PR DESCRIPTION
This _PR_ reorganizes the tests in a way that allows reusing **MySQL** versions and variations.

Also, **MySQL 9** will also run through the coverage workflow, preventing issues like in #3379 _(and that's how I discovered the related issue)_.

Another point is that we only tested version `8.0.x`, instead of every minor versions.

Now, we test:

- `mysql:5.7`
- `mysql:8.0`
- `mysql:8.1` _(new)_
- `mysql:8.2` _(new)_ 
- `mysql:8.3` _(new)_ 
- ~`mysql:8.4`~ _(soon)_ 
- `mysql:9.0`
- `mysql:9.1` _(new)_ 
- `mysql:9.2` _(previously as `latest`)_

I've also reused it better to avoid repeated tests, reducing from **116** to **100** workflows in total.

Finally, I updated all **Node.js** `20.x` to the latest _LTS_ (`22`).

> [!NOTE]
> - If there's a specific patch version worth adding, we can also add it to [ci-mysql.yml](https://github.com/sidorares/node-mysql2/blob/master/.github/workflows/ci-mysql.yml) when needed.
> - Some tests never finish in **MySQL 8.4**, I intend to investigate this further soon.