### PR TITLE
Add RegExp support to PoolCluster

### DIFF
--- a/lib/pool_cluster.js
+++ b/lib/pool_cluster.js
@@ -37,6 +37,23 @@ const getMonotonicMilliseconds = function () {
   return Math.floor(ms);
 };
 
+const isRegExp = function (val) {
+  return typeof val === 'object'
+    && Object.prototype.toString.call(val) === '[object RegExp]';
+}
+
+const patternRegExp = function (pattern) {
+  if (isRegExp(pattern)) {
+    return pattern;
+  }
+
+  var source = pattern
+    .replace(/([.+?^=!:${}()|\[\]\/\\])/g, '\\$1')
+    .replace(/\*/g, '.*');
+
+  return new RegExp('^' + source + '$');
+}
+
 class PoolNamespace {
   constructor(cluster, pattern, selector) {
     this._cluster = cluster;
@@ -256,20 +273,12 @@ class PoolCluster extends EventEmitter {
     let currentTime = 0;
     let foundNodeIds = this._findCaches[pattern];
 
-    if (typeof this._findCaches[pattern] === 'undefined') {
-      if (pattern === '*') {
-        // all
-        foundNodeIds = this._serviceableNodeIds;
-      } else if (this._serviceableNodeIds.indexOf(pattern) !== -1) {
-        // one
-        foundNodeIds = [pattern];
-      } else {
-        // wild matching
-        const keyword = pattern.substring(pattern.length - 1, 0);
-        foundNodeIds = this._serviceableNodeIds.filter((id) =>
-          id.startsWith(keyword)
-        );
-      }
+    if (foundNodeIds === undefined) {
+      let expression = patternRegExp(pattern);
+
+      foundNodeIds = this._serviceableNodeIds.filter((id) =>
+        id.match(expression)
+      );
     }
 
     this._findCaches[pattern] = foundNodeIds;


### PR DESCRIPTION
mysqljs/mysql has been updated to support regular expressions in PoolCluster. This brings most of that code to mysql2. 

Closes #3450 
Closes #503 