### PR TITLE
ci(benchmark): upgrade actions/cache to v4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
         run:  node benchmarks/benchmark.js | tee output.txt
 
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark


### PR DESCRIPTION
The old `actions/cache` version is no longer supported.