### PR TITLE
Fix for SET NAMES utf8 causing an unknown encoding error

### DIFF
--- a/lib/constants/encoding_charset.js
+++ b/lib/constants/encoding_charset.js
@@ -46,4 +46,5 @@ module.exports = {
   cp932: 95,
   eucjpms: 97,
   gb18030: 248,
+  utf8mb3: 192,
 };

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -64,7 +64,13 @@ class ResultSetHeader {
             stateChanges.systemVariables[key] = val;
             if (key === 'character_set_client') {
               const charsetNumber = EncodingToCharset[val];
-              connection.config.charsetNumber = charsetNumber;
+              // TODO - better api for driver users to handle unknown encodings?
+              // maybe custom coverter in the config?
+              // For now just ignore character_set_client command if there is
+              // no known mapping from reported encoding to a charset code
+              if (typeof charsetNumber !== 'undefined') {
+                connection.config.charsetNumber = charsetNumber;
+              }
             }
           } else if (type === sessionInfoTypes.SCHEMA) {
             key = packet.readLengthCodedString(encoding);


### PR DESCRIPTION
`query("SET NAMES utf8;");` command returns instruction from the server "please use utf8mb3 client character set"

2 issues we had:
- we did not have utf8mb3 in the `EncodingToCharset` map
- in case of encoding name is not recognised we set `undefined` to connection config `charsetNumber`, and next command fails

Fixes #3338