### PR TITLE
fix: destroy connection when stream errors

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -277,9 +277,6 @@ class Query extends Command {
     stream._read = () => {
       this._connection && this._connection.resume();
     };
-    stream._destroy = () => {
-      this._connection && this._connection.destroy();
-    }
     this.on('result', (row, resultSetIndex) => {
       if (!stream.push(row)) {
         this._connection.pause();
@@ -297,6 +294,9 @@ class Query extends Command {
     });
     stream.on('end', () => {
       stream.emit('close');
+    });
+    stream.on('error', () => {
+      this._connection && this._connection.destroy();
     });
     return stream;
   }

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -277,6 +277,9 @@ class Query extends Command {
     stream._read = () => {
       this._connection && this._connection.resume();
     };
+    stream._destroy = () => {
+      this._connection && this._connection.destroy();
+    }
     this.on('result', (row, resultSetIndex) => {
       if (!stream.push(row)) {
         this._connection.pause();

--- a/test/integration/connection/test-stream-error-destroy-connection.test.cjs
+++ b/test/integration/connection/test-stream-error-destroy-connection.test.cjs
@@ -35,7 +35,7 @@ async function run() {
   }
   setTimeout(() => {
     throw new Error('Connection remains open after stream error');
-  }, 5000).unref();
+  }, 1000).unref();
   connection.end();
 }
 

--- a/test/integration/connection/test-stream-error-destroy-connection.test.cjs
+++ b/test/integration/connection/test-stream-error-destroy-connection.test.cjs
@@ -1,0 +1,42 @@
+'use strict';
+
+const common = require('../../common.test.cjs');
+
+const connection = common.createConnection();
+
+connection.query(
+  [
+    'CREATE TEMPORARY TABLE `items` (',
+    '`id` int(11) NOT NULL AUTO_INCREMENT,',
+    '`text` varchar(255) DEFAULT NULL,',
+    'PRIMARY KEY (`id`)',
+    ') ENGINE=InnoDB DEFAULT CHARSET=utf8',
+  ].join('\n'),
+  (err) => {
+    if (err) {
+      throw err;
+    }
+  }
+);
+
+for (let i = 0; i < 100; i++) {
+  connection.execute('INSERT INTO items(text) VALUES(?)', ['test'], (err) => {
+    if (err) {
+      throw err;
+    }
+  });
+}
+
+async function run() {
+  const rows = connection.query('SELECT * FROM items').stream();
+  // eslint-disable-next-line no-unused-vars
+  for await (const row of rows) {
+    break;
+  }
+  setTimeout(() => {
+    throw new Error('Connection remains open after stream error');
+  }, 5000).unref();
+  connection.end();
+}
+
+run();


### PR DESCRIPTION
When a stream errors (due to break, throw, etc.) the connection can remain paused indefinitely.

To reproduce, create table `test` with 500 rows and run the below. The script will never exit.

```ts
import { createPool } from 'mysql2';

const pool = createPool({
  database: 'test',
  host: '127.0.0.1',
  port: 3306,
  user: 'user',
});

const results = pool.query('select * from test;').stream();
for await (const result of results) {
  break;
}

pool.end();
```

See https://github.com/sidorares/node-mysql2/issues/3596