### PR TITLE
fix(stream): resume connection when stream errors or is destroyed

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -290,7 +290,6 @@ class Query extends Command {
         this.removeListener('end', onEnd);
         this.removeListener('error', onError);
         this.removeListener('error', onError);
-
         /* eslint-enable no-use-before-define */
 
         cb(err);

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -271,33 +271,51 @@ class Query extends Command {
   }
 
   stream(options) {
-    options = options || {};
+    options = options || Object.create(null);
     options.objectMode = true;
-    const stream = new Readable(options);
-    stream._read = () => {
-      this._connection && this._connection.resume();
-    };
-    this.on('result', (row, resultSetIndex) => {
-      if (!stream.push(row)) {
-        this._connection.pause();
-      }
-      stream.emit('result', row, resultSetIndex); // replicate old emitter
+
+    const stream = new Readable({
+      ...options,
+      read: () => {
+        this._connection && this._connection.resume();
+      },
+      destroy: (err, cb) => {
+        this._connection && this._connection.resume();
+
+        cb(err); // Pass on any errors
+      },
     });
-    this.on('error', (err) => {
-      stream.emit('error', err); // Pass on any errors
-    });
-    this.on('end', () => {
-      stream.push(null); // pushing null, indicating EOF
-    });
-    this.on('fields', (fields) => {
-      stream.emit('fields', fields); // replicate old emitter
-    });
-    stream.on('end', () => {
+
+    stream.once('end', () => {
       stream.emit('close');
     });
-    stream.on('error', () => {
-      this._connection && this._connection.destroy();
+
+    this.on('result', (row, index) => {
+      if (stream.destroyed) return;
+
+      if (!stream.push(row)) {
+        this._connection && this._connection.pause();
+      }
+
+      stream.emit('result', row, index); // replicate old emitter
     });
+
+    this.on('fields', (fields) => {
+      if (stream.destroyed) return;
+
+      stream.emit('fields', fields); // replicate old emitter
+    });
+
+    this.on('end', () => {
+      if (stream.destroyed) return;
+
+      stream.push(null); // pushing null, indicating EOF
+    });
+
+    this.on('error', (err) => {
+      stream.destroy(err);
+    });
+
     return stream;
   }
 

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -282,6 +282,13 @@ class Query extends Command {
       destroy: (err, cb) => {
         this._connection && this._connection.resume();
 
+        /* eslint-disable no-use-before-define */
+        this.removeListener('result', onResult);
+        this.removeListener('fields', onFields);
+        this.removeListener('end', onEnd);
+        this.removeListener('error', onError);
+        /* eslint-enable no-use-before-define */
+
         cb(err); // Pass on any errors
       },
     });
@@ -290,7 +297,7 @@ class Query extends Command {
       stream.emit('close');
     });
 
-    this.on('result', (row, index) => {
+    const onResult = (row, index) => {
       if (stream.destroyed) return;
 
       if (!stream.push(row)) {
@@ -298,23 +305,28 @@ class Query extends Command {
       }
 
       stream.emit('result', row, index); // replicate old emitter
-    });
+    };
 
-    this.on('fields', (fields) => {
+    const onFields = (fields) => {
       if (stream.destroyed) return;
 
       stream.emit('fields', fields); // replicate old emitter
-    });
+    };
 
-    this.on('end', () => {
+    const onEnd = () => {
       if (stream.destroyed) return;
 
       stream.push(null); // pushing null, indicating EOF
-    });
+    };
 
-    this.on('error', (err) => {
+    const onError = (err) => {
       stream.destroy(err);
-    });
+    };
+
+    this.on('result', onResult);
+    this.on('fields', onFields);
+    this.on('end', onEnd);
+    this.on('error', onError);
 
     return stream;
   }

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -281,18 +281,6 @@ class Query extends Command {
       read: () => {
         this._connection && this._connection.resume();
       },
-      destroy: (err, cb) => {
-        this._connection && this._connection.resume();
-
-        /* eslint-disable no-use-before-define */
-        this.removeListener('result', onResult);
-        this.removeListener('fields', onFields);
-        this.removeListener('end', onEnd);
-        this.removeListener('error', onError);
-        /* eslint-enable no-use-before-define */
-
-        cb(err); // Pass on any errors
-      },
     });
 
     // Prevent a breaking change for users that rely on `end` event
@@ -326,6 +314,17 @@ class Query extends Command {
 
     const onError = (err) => {
       stream.destroy(err);
+    };
+
+    stream._destroy = (err, cb) => {
+      this._connection && this._connection.resume();
+
+      this.removeListener('result', onResult);
+      this.removeListener('fields', onFields);
+      this.removeListener('end', onEnd);
+      this.removeListener('error', onError);
+
+      cb(err); // Pass on any errors
     };
 
     this.on('result', onResult);

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -276,6 +276,8 @@ class Query extends Command {
 
     const stream = new Readable({
       ...options,
+      emitClose: true,
+      autoDestroy: true,
       read: () => {
         this._connection && this._connection.resume();
       },
@@ -283,22 +285,22 @@ class Query extends Command {
         this._connection && this._connection.resume();
 
         /* eslint-disable no-use-before-define */
-        stream.removeListener('end', onceEnd);
-
         this.removeListener('result', onResult);
         this.removeListener('fields', onFields);
         this.removeListener('end', onEnd);
         this.removeListener('error', onError);
-        this.removeListener('error', onError);
         /* eslint-enable no-use-before-define */
 
-        cb(err);
+        cb(err); // Pass on any errors
       },
     });
 
-    const onceEnd = () => {
-      stream.emit('close');
-    };
+    // Prevent a breaking change for users that rely on `end` event
+    stream.once('close', () => {
+      if (!stream.readableEnded) {
+        stream.emit('end');
+      }
+    });
 
     const onResult = (row, index) => {
       if (stream.destroyed) return;
@@ -323,11 +325,8 @@ class Query extends Command {
     };
 
     const onError = (err) => {
-      stream.emit('error', err); // Pass on any errors
       stream.destroy(err);
     };
-
-    stream.once('end', onceEnd);
 
     this.on('result', onResult);
     this.on('fields', onFields);

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -283,19 +283,23 @@ class Query extends Command {
         this._connection && this._connection.resume();
 
         /* eslint-disable no-use-before-define */
+        stream.removeListener('end', onceEnd);
+
         this.removeListener('result', onResult);
         this.removeListener('fields', onFields);
         this.removeListener('end', onEnd);
         this.removeListener('error', onError);
+        this.removeListener('error', onError);
+
         /* eslint-enable no-use-before-define */
 
         cb(err); // Pass on any errors
       },
     });
 
-    stream.once('end', () => {
+    const onceEnd = () => {
       stream.emit('close');
-    });
+    };
 
     const onResult = (row, index) => {
       if (stream.destroyed) return;
@@ -322,6 +326,8 @@ class Query extends Command {
     const onError = (err) => {
       stream.destroy(err);
     };
+
+    stream.once('end', onceEnd);
 
     this.on('result', onResult);
     this.on('fields', onFields);

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -293,7 +293,7 @@ class Query extends Command {
 
         /* eslint-enable no-use-before-define */
 
-        cb(err); // Pass on any errors
+        cb(err);
       },
     });
 
@@ -324,6 +324,7 @@ class Query extends Command {
     };
 
     const onError = (err) => {
+      stream.emit('error', err); // Pass on any errors
       stream.destroy(err);
     };
 

--- a/test/integration/connection/test-stream-error-destroy-connection.test.cjs
+++ b/test/integration/connection/test-stream-error-destroy-connection.test.cjs
@@ -1,10 +1,9 @@
 'use strict';
 
-const process = require('node:process');
-const { test, skip } = require('poku');
+const { test } = require('poku');
 const common = require('../../common.test.cjs');
 
-if (process.env.MYSQL_USE_TLS === '1') skip('Skipping for SSL=1');
+// if (process.env.MYSQL_USE_TLS === '1') skip('Skipping for SSL=1');
 
 test('Ensure stream ends in case of error', async () => {
   const connection = common.createConnection();

--- a/test/integration/connection/test-stream-error-destroy-connection.test.cjs
+++ b/test/integration/connection/test-stream-error-destroy-connection.test.cjs
@@ -3,8 +3,6 @@
 const { test } = require('poku');
 const common = require('../../common.test.cjs');
 
-// if (process.env.MYSQL_USE_TLS === '1') skip('Skipping for SSL=1');
-
 test('Ensure stream ends in case of error', async () => {
   const connection = common.createConnection();
 

--- a/test/integration/connection/test-stream-error-destroy-connection.test.cjs
+++ b/test/integration/connection/test-stream-error-destroy-connection.test.cjs
@@ -32,11 +32,7 @@ test('Ensure stream ends in case of error', async () => {
   const rows = connection.query('SELECT * FROM items').stream();
 
   // eslint-disable-next-line no-unused-vars
-  for await (const _ of rows) break;
-
-  setTimeout(() => {
-    throw new Error('Connection remains open after stream error');
-  }, 1000).unref();
+  for await (const _ of rows) break; // forces return () -> destroy()
 
   connection.end();
 });

--- a/test/integration/connection/test-stream-error-destroy-connection.test.cjs
+++ b/test/integration/connection/test-stream-error-destroy-connection.test.cjs
@@ -1,38 +1,92 @@
 'use strict';
 
-const { test } = require('poku');
+const { assert, describe, test } = require('poku');
 const common = require('../../common.test.cjs');
 
-test('Ensure stream ends in case of error', async () => {
+describe(async () => {
   const connection = common.createConnection();
 
-  connection.query(
-    [
-      'CREATE TEMPORARY TABLE `items` (',
-      '`id` int(11) NOT NULL AUTO_INCREMENT,',
-      '`text` varchar(255) DEFAULT NULL,',
-      'PRIMARY KEY (`id`)',
-      ') ENGINE=InnoDB DEFAULT CHARSET=utf8',
-    ].join('\n'),
-    (err) => {
-      if (err) {
-        throw err;
+  await test('Ensure stream ends in case of error', async () => {
+    connection.query(
+      [
+        'CREATE TEMPORARY TABLE `items` (',
+        '`id` int(11) NOT NULL AUTO_INCREMENT,',
+        '`text` varchar(255) DEFAULT NULL,',
+        'PRIMARY KEY (`id`)',
+        ') ENGINE=InnoDB DEFAULT CHARSET=utf8',
+      ].join('\n'),
+      (err) => {
+        if (err) {
+          throw err;
+        }
       }
+    );
+
+    for (let i = 0; i < 100; i++) {
+      connection.execute(
+        'INSERT INTO items(text) VALUES(?)',
+        ['test'],
+        (err) => {
+          if (err) {
+            throw err;
+          }
+        }
+      );
     }
-  );
 
-  for (let i = 0; i < 100; i++) {
-    connection.execute('INSERT INTO items(text) VALUES(?)', ['test'], (err) => {
-      if (err) {
-        throw err;
-      }
+    const rows = connection.query('SELECT * FROM items').stream();
+
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of rows) break; // forces return () -> destroy()
+  });
+
+  await test('end: Ensure stream emits error then close on server-side query error', async () => {
+    let uncaughtExceptionError;
+
+    const stream = connection
+      .query('SELECT invalid_column FROM invalid_table')
+      .stream();
+
+    stream.on('error', (error) => {
+      uncaughtExceptionError = error;
     });
-  }
 
-  const rows = connection.query('SELECT * FROM items').stream();
+    await new Promise((resolve) => stream.on('end', resolve));
 
-  // eslint-disable-next-line no-unused-vars
-  for await (const _ of rows) break; // forces return () -> destroy()
+    assert(
+      uncaughtExceptionError instanceof Error,
+      'Expected an uncaught exception error'
+    );
+
+    assert.equal(
+      uncaughtExceptionError.message,
+      "Table 'test.invalid_table' doesn't exist"
+    );
+  });
+
+  await test('close: Ensure stream emits error then close on server-side query error', async () => {
+    let uncaughtExceptionError;
+
+    const stream = connection
+      .query('SELECT invalid_column FROM invalid_table')
+      .stream();
+
+    stream.on('error', (error) => {
+      uncaughtExceptionError = error;
+    });
+
+    await new Promise((resolve) => stream.on('close', resolve));
+
+    assert(
+      uncaughtExceptionError instanceof Error,
+      'Expected an uncaught exception error'
+    );
+
+    assert.equal(
+      uncaughtExceptionError.message,
+      "Table 'test.invalid_table' doesn't exist"
+    );
+  });
 
   connection.end();
 });


### PR DESCRIPTION
This _PR_ continues #3769 work and fixes #3596. It also seems to resolve #1847 and resolve #1168, ensuring that `destroy` and error events are properly issued (not using _`try-catch`_, but _`stream.on('error', () => {})`_ approach, which is the expected pattern for callbacks).

---

In #3769, it destroys the connection on error to ensure that the stack is not blocked, but this approach can be aggressive, as a query error shouldn't destroy the connection.

In this _PR_, the approach is to destroy the current stream itself on error and emits the appropriate events, ensuring its functionality and allowing users to catch errors that were not previously emitted, as reported in #1847.

---

### Before this _PR_

The test that checks the events is not reached and the script is silently ended prematurely:

<img width="699" height="97" alt="Screenshot 2025-08-27 at 05 37 42" src="https://github.com/user-attachments/assets/6cbbd794-b2cb-4272-a03b-6674818800da" />

### After this _PR_

Now all tests are reached:

<img width="699" height="175" alt="Screenshot 2025-08-27 at 05 35 54" src="https://github.com/user-attachments/assets/6401b102-2a6a-4882-855b-70c03d3a0008" />

---

> [!NOTE]
>
> Thanks @fenichelar, @CarlOlson, and @dsech. Your examples and solutions helped us achieve a better understanding of the error 🤝