### PR TITLE
fix(types): restrict StreamOptions.objectMode to true (#3686)

### DIFF
--- a/typings/mysql/lib/protocol/sequences/Query.d.ts
+++ b/typings/mysql/lib/protocol/sequences/Query.d.ts
@@ -94,7 +94,7 @@ export interface StreamOptions {
   /**
    * The object mode of the stream (Default: true)
    */
-  objectMode?: any;
+  objectMode?: true;
 }
 
 export interface QueryError extends NodeJS.ErrnoException {


### PR DESCRIPTION
fix(types): restrict StreamOptions.objectMode to true

As discussed in #3686, `objectMode` is always forced to true internally, so the current `any` type is misleading. This change updates the definition to `true` to better reflect the actual behavior.

Closes #3686