### PR TITLE
fix: fix sha256_password to work correctly over a TLS connection

### DIFF
--- a/lib/auth_plugins/sha256_password.js
+++ b/lib/auth_plugins/sha256_password.js
@@ -3,7 +3,7 @@
 const PLUGIN_NAME = 'sha256_password';
 const crypto = require('crypto');
 const { xorRotating } = require('../auth_41');
-const tls = require('tls');
+const Tls = require('tls');
 
 const REQUEST_SERVER_KEY_PACKET = Buffer.from([1]);
 
@@ -34,7 +34,7 @@ module.exports =
       switch (state) {
         case STATE_INITIAL:
           if (
-            connection.stream instanceof tls.TLSSocket &&
+            connection.stream instanceof Tls.TLSSocket &&
             connection.stream.encrypted === true
           ) {
             // We don't need to encrypt passwords over TLS connection


### PR DESCRIPTION
After reading the MySQL documentation, I understood that the `sha256_password` plugin works partially correctly, but it did not account for the fact that manual encryption is not required when connecting via TLS.

[documentation](https://dev.mysql.com/doc/refman/8.4/en/sha256-pluggable-authentication.html#:~:text=If%20the%20connection%20is%20secure%2C%20an%20RSA%20key%20pair%20is%20unnecessary%20and%20is%20not%20used.%20This%20applies%20to%20connections%20encrypted%20using%20TLS.%20The%20password%20is%20sent%20as%20cleartext%20but%20cannot%20be%20snooped%20because%20the%20connection%20is%20secure.)

Follow up for https://github.com/sidorares/node-mysql2/issues/2888