### PR TITLE
fix(typings): missing callback to PoolCluster.end()

### DIFF
--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -54,7 +54,7 @@ declare class PoolCluster extends EventEmitter {
 
   remove(pattern: string): void;
 
-  end(): void;
+  end(callback?: (err: NodeJS.ErrnoException | null) => void): void;
 
   getConnection(
     callback: (


### PR DESCRIPTION
This aligns the TS type of the `PoolCluster.end()` method to match the JS implementation in [pool_cluster.js](https://github.com/sidorares/node-mysql2/blob/6bfad13a4ce98b4534acc7daae340d027db63479/lib/pool_cluster.js#L232-L265).