### PR TITLE
fix: skip SNI for IP addresses in TLS connection

### DIFF
--- a/lib/base/connection.js
+++ b/lib/base/connection.js
@@ -345,7 +345,9 @@ class BaseConnection extends EventEmitter {
     });
     const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
     const verifyIdentity = this.config.ssl.verifyIdentity;
-    const servername = this.config.host;
+    const servername = Net.isIP(this.config.host)
+      ? undefined
+      : this.config.host;
 
     let secureEstablished = false;
     this.stream.removeAllListeners('data');


### PR DESCRIPTION
When connecting using TLS there is an optional field, `servername`, for setting the [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication) but this field only makes sense to set if we are using a hostname to connect and not an IP. Since v12 of Node.js, it's been deprecated to provide an IP address as the SNI so it will be ignored at some point anyway.

This PR prevents setting `servername` in the TLS config if the MySQL config `host` field is an IP which in turn quiets this deprecation warning:
```
(node:1) [DEP0123] DeprecationWarning: Setting the TLS ServerName to an IP address is not permitted by RFC 6066. This will be ignored in a future version.
```

The logic for setting SNI to the host was originally added in https://github.com/sidorares/node-mysql2/pull/1554.

Fixes https://github.com/sidorares/node-mysql2/issues/2588