### PR TITLE
feat: allow to override ssl servername

### DIFF
--- a/lib/base/connection.js
+++ b/lib/base/connection.js
@@ -345,7 +345,7 @@ class BaseConnection extends EventEmitter {
     });
     const rejectUnauthorized = this.config.ssl.rejectUnauthorized;
     const verifyIdentity = this.config.ssl.verifyIdentity;
-    const servername = this.config.host;
+    const servername = this.config.ssl.servername || this.config.host;
 
     let secureEstablished = false;
     this.stream.removeAllListeners('data');


### PR DESCRIPTION
Ideally, you would be able to choose the server name used for SSL verification.

Another way to fix #2588 and #3835