### PR TITLE
fix: add missing charset encoding for UTF8MB4_0900_BIN

### DIFF
--- a/lib/constants/charset_encodings.js
+++ b/lib/constants/charset_encodings.js
@@ -313,4 +313,5 @@ module.exports = [
   'utf8',
   'utf8',
   'utf8',
+  'utf8',
 ];


### PR DESCRIPTION
# Fix charset encoding mapping for UTF8MB4_0900_BIN

## Problem
MySQL2 throws `Encoding not recognized: 'undefined'` error when connecting to MySQL 8.0+ servers using `utf8mb4_0900_bin` collation.

## Root Cause
Mismatch between `charsets.js` and `charset_encodings.js`:
- `charsets.js` defines `UTF8MB4_0900_BIN = 309`
- `charset_encodings.js` array has length 309 (indices 0-308)
- `charset_encodings[309]` returns `undefined`
- `Iconv.getDecoder(undefined)` throws encoding error

## Solution
Add missing encoding mapping for index 309 in `charset_encodings.js`.

## Changes
- **File**: `lib/constants/charset_encodings.js`
- **Change**: Add `'utf8'` entry at index 309 for `UTF8MB4_0900_BIN`

## Impact
- Fixes connection issues with MySQL 8.0+ `utf8mb4_0900_bin` collation
- Resolves `Encoding not recognized: 'undefined'` errors
- Fix : #3856 
