### PR TITLE
fix(named-placeholders): improve handling of mixed/nested quotes in query parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "iconv-lite": "^0.7.0",
     "long": "^5.2.1",
     "lru.min": "^1.0.0",
-    "named-placeholders": "^1.1.3",
+    "named-placeholders": "^1.1.6",
     "seq-queue": "^0.0.5",
     "sqlstring": "^2.3.2"
   },


### PR DESCRIPTION
## Upgrade `named-placeholders` from version 1.1.3 to 1.1.6

We are using the `mysql2` package in our application, and currently maintain a custom patch to address the following bug:

- https://github.com/mysqljs/named-placeholders/pull/39

This issue has been resolved in `named-placeholders` version **1.1.6**. If `mysql2` is updated to use this latest version, we will be able to remove our custom patch or resolution.

This is a **patch-level upgrade** and does **not introduce any breaking changes**.
