### PR TITLE
ci: resolve issue where some unit tests were hard coding the database name when it is meant to be configurable

### DIFF
--- a/test/esm/integration/connection/test-column-inspect.test.mjs
+++ b/test/esm/integration/connection/test-column-inspect.test.mjs
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const common = require('../../../common.test.cjs');
+const { database: currentDatabase } = common.config;
 
 await describe('Custom inspect for column definition', async () => {
   let connection;
@@ -95,7 +96,7 @@ await describe('Custom inspect for column definition', async () => {
         inspectResults,
         util.inspect({
           catalog: 'def',
-          schema: 'test',
+          schema: currentDatabase,
           name: 'decimal13_10',
           orgName: 'decimal13_10',
           table: 'test_fields2',

--- a/test/integration/connection/test-stream-error-destroy-connection.test.cjs
+++ b/test/integration/connection/test-stream-error-destroy-connection.test.cjs
@@ -3,6 +3,8 @@
 const { assert, describe, beforeEach, afterEach, it } = require('poku');
 const common = require('../../common.test.cjs');
 
+const { database: currentDatabase } = common.config;
+
 describe('test stream error destroy connection:', async () => {
   let connection;
 
@@ -66,7 +68,7 @@ describe('test stream error destroy connection:', async () => {
 
     assert.equal(
       uncaughtExceptionError.message,
-      "Table 'test.invalid_table' doesn't exist"
+      `Table '${currentDatabase}.invalid_table' doesn't exist`
     );
   });
 
@@ -90,7 +92,7 @@ describe('test stream error destroy connection:', async () => {
 
     assert.equal(
       uncaughtExceptionError.message,
-      "Table 'test.invalid_table' doesn't exist"
+      `Table '${currentDatabase}.invalid_table' doesn't exist`
     );
   });
 });


### PR DESCRIPTION
Resolves https://github.com/sidorares/node-mysql2/issues/4022, I honestly thought there were a lot more but there were only two unit tests that had this kind of check hard coded.