### PR TITLE
test: add SQL formatting tests

### DIFF
--- a/test/esm/unit/parsers/stringify-objects-as-false.test.mjs
+++ b/test/esm/unit/parsers/stringify-objects-as-false.test.mjs
@@ -14,6 +14,8 @@ const connection = driver
 
 const format = (sql, values) => connection.connection.format(sql, values);
 
+await connection.end();
+
 describe('SELECT without values', () => {
   it('should return the query unchanged', () => {
     const query = format('SELECT * FROM users', []);
@@ -124,5 +126,3 @@ describe('SELECT and INSERT with Date parameter', () => {
     );
   });
 });
-
-await connection.end();

--- a/test/esm/unit/parsers/stringify-objects-as-true.test.mjs
+++ b/test/esm/unit/parsers/stringify-objects-as-true.test.mjs
@@ -14,6 +14,8 @@ const connection = driver
 
 const format = (sql, values) => connection.connection.format(sql, values);
 
+await connection.end();
+
 describe('SELECT without values', () => {
   it('should return the query unchanged', () => {
     const query = format('SELECT * FROM users', []);
@@ -118,5 +120,3 @@ describe('SELECT and INSERT with Date parameter', () => {
     );
   });
 });
-
-await connection.end();


### PR DESCRIPTION
Closes #1247.

~In **sqlstring**, [it skips formatting for `null` params in `values`, but proceeds with the logic for `undefined`](https://github.com/mysqljs/sqlstring/blob/cd528556b4b6bcf300c3db515026935dedf7cfa1/lib/SqlString.js#L77-L79).~

~This _PR_ skips the formatting for `undefined` in the `values` parameter.~

**Edit:** I just noticed the double operator for `null` (`(undefined == null) === true`).

---

#4051 mentions a blog that shows a potential vulnerability that can be resolved by a workaround, forcing the `stringifyObjects` option to `true`.

The new test proves this and also confirms that #1247 has been resolved over time.

> [!NOTE]
> 
> This _PR_ doesn't cover the bug reported in #4051, but it serves as a precursor by recognizing the reported error and preparing tests for the subsequent fix for this matter.