### PR TITLE
fix: expand object params after `ON DUPLICATE KEY UPDATE` preceded by `SET`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "lru.min": "^1.1.3",
         "named-placeholders": "^1.1.6",
         "seq-queue": "^0.0.5",
-        "sql-escaper": "^1.3.1"
+        "sql-escaper": "^1.3.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
@@ -3432,9 +3432,9 @@
       }
     },
     "node_modules/sql-escaper": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.1.tgz",
-      "integrity": "sha512-GLMJGWKzrr7BS5E5+8Prix6RGfBd4UokKMxkPSg313X0TvUyjdJU3Xg7FAhhcba4dHnLy81t4YeHETKLGVsDow==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.2.tgz",
+      "integrity": "sha512-lp+ZDVfSjHt+qAK1jXBTIXBNYnbo7gnaAGwoYTH9bE89kNkXwcu6g0WjJGRsdTKVpY1z70u3Y0IgmnBOoRybHw==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lru.min": "^1.1.3",
     "named-placeholders": "^1.1.6",
     "seq-queue": "^0.0.5",
-    "sql-escaper": "^1.3.1"
+    "sql-escaper": "^1.3.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",


### PR DESCRIPTION
Resolve #4074, already fixed from **sql-escaper** side in https://github.com/mysqljs/sql-escaper/pull/19.