### PR TITLE
fix(pool): handle all read-only errors during Aurora failover

### DIFF
--- a/lib/base/pool.js
+++ b/lib/base/pool.js
@@ -8,6 +8,21 @@ const Queue = require('denque');
 const BaseConnection = require('./connection.js');
 const Errors = require('../constants/errors.js');
 
+// Source: https://github.com/go-sql-driver/mysql/blob/76c00e35a8d48f8f70f0e7dffe584692bd3fa612/packets.go#L598-L613
+function isReadOnlyError(err) {
+  if (!err || !err.errno) {
+    return false;
+  }
+  // 1792: ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION
+  // 1290: ER_OPTION_PREVENTS_STATEMENT (returned by Aurora during failover)
+  // 1836: ER_READ_ONLY_MODE
+  return (
+    err.errno === Errors.ER_OPTION_PREVENTS_STATEMENT ||
+    err.errno === Errors.ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION ||
+    err.errno === Errors.ER_READ_ONLY_MODE
+  );
+}
+
 function spliceConnection(queue, connection) {
   const len = queue.length;
   for (let i = 0; i < len; i++) {
@@ -160,10 +175,7 @@ class BasePool extends EventEmitter {
           });
         }
         conn.query(cmdQuery).once('end', () => {
-          if (
-            queryError &&
-            queryError.errno === Errors.ER_OPTION_PREVENTS_STATEMENT
-          ) {
+          if (isReadOnlyError(queryError)) {
             conn.destroy();
           } else {
             conn.release();
@@ -191,7 +203,7 @@ class BasePool extends EventEmitter {
       try {
         conn
           .execute(sql, values, (err, rows, fields) => {
-            if (err && err.errno === Errors.ER_OPTION_PREVENTS_STATEMENT) {
+            if (isReadOnlyError(err)) {
               conn.destroy();
             }
             cb(err, rows, fields);


### PR DESCRIPTION
Continue with the work of #4075 by extending error `1290` handling to also cover errors `1792` and `1836`, matching **Go-MySQL-Driver** implementation for **Aurora** failover.

For reference:

- https://github.com/go-sql-driver/mysql/blob/76c00e35a8d48f8f70f0e7dffe584692bd3fa612/packets.go#L598-L613