### PR TITLE
fix: distinguish delimiters in queries from SQL comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "lru.min": "^1.1.3",
         "named-placeholders": "^1.1.6",
         "seq-queue": "^0.0.5",
-        "sql-escaper": "^1.3.2"
+        "sql-escaper": "^1.3.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
@@ -3432,9 +3432,9 @@
       }
     },
     "node_modules/sql-escaper": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.2.tgz",
-      "integrity": "sha512-lp+ZDVfSjHt+qAK1jXBTIXBNYnbo7gnaAGwoYTH9bE89kNkXwcu6g0WjJGRsdTKVpY1z70u3Y0IgmnBOoRybHw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lru.min": "^1.1.3",
     "named-placeholders": "^1.1.6",
     "seq-queue": "^0.0.5",
-    "sql-escaper": "^1.3.2"
+    "sql-escaper": "^1.3.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",


### PR DESCRIPTION
Resolve #4083, already fixed from sql-escaper side in https://github.com/mysqljs/sql-escaper/pull/22.