### PR TITLE
fix(deps): include `@types/node` as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,9 @@
       },
       "engines": {
         "node": ">= 8.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">= 8"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "named-placeholders": "^1.1.6",
     "sql-escaper": "^1.3.3"
   },
+  "peerDependencies": {
+    "@types/node": ">= 8"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",


### PR DESCRIPTION
Closes #3086, Closes #3575.

Although it is documented, it's common not to install **MySQL2** using the documentation, but directly with "`npm i mysql2`". So this _PR_ ensures that **@types/node** is included as a peer dependency by installing **MySQL2**.

---

### Related

> https://github.com/sidorares/node-mysql2/blob/c4efc90aab3e9339eafba7597eb3fdf6618fdf6e/README.md#L85-L91
> https://github.com/sidorares/node-mysql2/blob/c4efc90aab3e9339eafba7597eb3fdf6618fdf6e/website/docs/documentation/typescript-examples.mdx#L4-L17