### PR TITLE
feat: add `Symbol.dispose` and `Symbol.asyncDispose` support for Connections, Pools, and Pool Clusters

### DIFF
--- a/lib/base/connection.js
+++ b/lib/base/connection.js
@@ -926,6 +926,12 @@ class BaseConnection extends EventEmitter {
     return this.addCommand(new Commands.ServerHandshake(args));
   }
 
+  [Symbol.dispose]() {
+    if (!this._closing) {
+      this.end();
+    }
+  }
+
   // ===============================================================
   end(callback) {
     if (this.config.isServer) {

--- a/lib/base/pool.js
+++ b/lib/base/pool.js
@@ -108,6 +108,12 @@ class BasePool extends EventEmitter {
     }
   }
 
+  [Symbol.dispose]() {
+    if (!this._closed) {
+      this.end();
+    }
+  }
+
   end(cb) {
     this._closed = true;
     clearTimeout(this._removeIdleTimeoutConnectionsTimer);

--- a/lib/base/pool_connection.js
+++ b/lib/base/pool_connection.js
@@ -29,6 +29,10 @@ class BasePoolConnection extends BaseConnection {
     this._pool.releaseConnection(this);
   }
 
+  [Symbol.dispose]() {
+    this.release();
+  }
+
   end(callback) {
     if (this.config.gracefulEnd) {
       this._removeFromPool();

--- a/lib/pool_cluster.js
+++ b/lib/pool_cluster.js
@@ -229,6 +229,12 @@ class PoolCluster extends EventEmitter {
     namespace.getConnection(cb);
   }
 
+  [Symbol.dispose]() {
+    if (!this._closed) {
+      this.end();
+    }
+  }
+
   end(callback) {
     const cb =
       callback !== undefined

--- a/lib/promise/connection.js
+++ b/lib/promise/connection.js
@@ -66,6 +66,12 @@ class PromiseConnection extends EventEmitter {
     });
   }
 
+  async [Symbol.asyncDispose]() {
+    if (!this.connection._closing) {
+      await this.end();
+    }
+  }
+
   beginTransaction() {
     const c = this.connection;
     const localErr = new Error();

--- a/lib/promise/pool.js
+++ b/lib/promise/pool.js
@@ -85,6 +85,12 @@ class PromisePool extends EventEmitter {
       });
     });
   }
+
+  async [Symbol.asyncDispose]() {
+    if (!this.pool._closed) {
+      await this.end();
+    }
+  }
 }
 
 (function (functionsToWrap) {

--- a/lib/promise/pool_connection.js
+++ b/lib/promise/pool_connection.js
@@ -14,6 +14,10 @@ class PromisePoolConnection extends PromiseConnection {
       arguments
     );
   }
+
+  async [Symbol.asyncDispose]() {
+    this.release();
+  }
 }
 
 module.exports = PromisePoolConnection;

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -65,6 +65,8 @@ export interface Connection extends QueryableAndExecutableBase {
 
   end(options?: any): Promise<void>;
 
+  [Symbol.asyncDispose](): Promise<void>;
+
   destroy(): void;
 
   pause(): void;
@@ -82,6 +84,7 @@ export interface Connection extends QueryableAndExecutableBase {
 export interface PoolConnection extends Connection {
   release(): void;
   connection: Connection;
+  [Symbol.asyncDispose](): Promise<void>;
 }
 
 export interface Pool extends Connection {

--- a/promise.d.ts
+++ b/promise.d.ts
@@ -115,6 +115,8 @@ export interface PoolCluster extends EventEmitter {
 
   end(): Promise<void>;
 
+  [Symbol.asyncDispose](): Promise<void>;
+
   getConnection(): Promise<PoolConnection>;
   getConnection(group: string): Promise<PoolConnection>;
   getConnection(group: string, selector: string): Promise<PoolConnection>;

--- a/promise.js
+++ b/promise.js
@@ -134,6 +134,12 @@ class PromisePoolCluster extends EventEmitter {
       });
     });
   }
+
+  async [Symbol.asyncDispose]() {
+    if (!this.poolCluster._closed) {
+      await this.end();
+    }
+  }
 }
 
 /**

--- a/test/integration/dispose/async-dispose.test.mts
+++ b/test/integration/dispose/async-dispose.test.mts
@@ -1,0 +1,139 @@
+import type { RowDataPacket } from '../../../index.js';
+import type { PoolConnection } from '../../../promise.js';
+import { assert, describe, it, skip } from 'poku';
+import { createConnection, createPool } from '../../../promise.js';
+import { config } from '../../common.test.mjs';
+
+if (!('asyncDispose' in Symbol)) {
+  skip('Symbol.asyncDispose is not supported in this runtime');
+}
+
+await describe('PromisePoolConnection should implement Symbol.asyncDispose', async () => {
+  await using pool = createPool({ ...config, connectionLimit: 1 });
+  await using conn: PoolConnection = await pool.getConnection();
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof conn[Symbol.asyncDispose], 'function');
+  });
+});
+
+await describe('PromiseConnection should implement Symbol.asyncDispose', async () => {
+  await using conn = await createConnection(config);
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof conn[Symbol.asyncDispose], 'function');
+  });
+});
+
+await describe('PromisePool should implement Symbol.asyncDispose', async () => {
+  await using pool = createPool({ ...config, connectionLimit: 1 });
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof pool[Symbol.asyncDispose], 'function');
+  });
+});
+
+await describe('await using should release the connection back to the pool', async () => {
+  await using pool = createPool({ ...config, connectionLimit: 1 });
+
+  await it('should use and dispose the connection', async () => {
+    await using conn: PoolConnection = await pool.getConnection();
+
+    const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have returned the connection to the free pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool.pool._freeConnections.length, 1);
+  });
+});
+
+await describe('Pool should serve a new connection after await using releases the previous one', async () => {
+  await using pool = createPool({ ...config, connectionLimit: 1 });
+
+  await it('should use and dispose the first connection', async () => {
+    await using conn: PoolConnection = await pool.getConnection();
+
+    const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  await it('should use and dispose the second connection', async () => {
+    await using conn: PoolConnection = await pool.getConnection();
+
+    const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have served both connections with a single pool slot', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool.pool._allConnections.length, 1);
+  });
+});
+
+await describe('asyncDispose should end the connection', async () => {
+  const conn = await createConnection(config);
+  const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+  assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  await conn[Symbol.asyncDispose]();
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn.connection._closing, true);
+  });
+});
+
+await describe('asyncDispose should end the pool', async () => {
+  const pool = createPool({ ...config, connectionLimit: 1 });
+  const [rows] = await pool.query<RowDataPacket[]>('SELECT 1');
+  assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  await pool[Symbol.asyncDispose]();
+
+  it('should have closed the pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool.pool._closed, true);
+  });
+});
+
+await describe('asyncDispose should handle end before asyncDispose on pool', async () => {
+  const pool = createPool({ ...config, connectionLimit: 1 });
+  await pool.end();
+  await pool[Symbol.asyncDispose]();
+
+  it('should have closed the pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool.pool._closed, true);
+  });
+});
+
+await describe('await using should handle manual `destroy` before automatic dispose on pool connection', async () => {
+  await using pool = createPool({ ...config, connectionLimit: 1 });
+
+  await it('should not error when connection is destroyed within await using', async () => {
+    await using conn: PoolConnection = await pool.getConnection();
+
+    const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+    conn.destroy();
+  });
+
+  it('should have removed the destroyed connection from the pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool.pool._allConnections.length, 0);
+  });
+});
+
+await describe('force await using should handle manual `destroy` before automatic dispose on connection', async () => {
+  const conn = await createConnection(config);
+  const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+  assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  conn.destroy();
+  await conn[Symbol.asyncDispose]();
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn.connection._closing, true);
+  });
+});

--- a/test/integration/dispose/async/connection.test.mts
+++ b/test/integration/dispose/async/connection.test.mts
@@ -1,0 +1,49 @@
+import type { RowDataPacket } from '../../../../index.js';
+import { assert, describe, it, skip } from 'poku';
+import { createConnection } from '../../../../promise.js';
+import { config } from '../../../common.test.mjs';
+
+if (!('asyncDispose' in Symbol)) {
+  skip('Symbol.asyncDispose is not supported in this runtime');
+}
+
+await describe('PromiseConnection should implement Symbol.asyncDispose', async () => {
+  await using conn = await createConnection(config);
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof conn[Symbol.asyncDispose], 'function');
+  });
+});
+
+await describe('asyncDispose should end the connection', async () => {
+  const conn = await createConnection(config);
+  const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+
+  await conn[Symbol.asyncDispose]();
+
+  it('should have received the query result', () => {
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn.connection._closing, true);
+  });
+});
+
+await describe('asyncDispose should handle destroy before asyncDispose on connection', async () => {
+  const conn = await createConnection(config);
+  const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
+
+  conn.destroy();
+  await conn[Symbol.asyncDispose]();
+
+  it('should have received the query result', () => {
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn.connection._closing, true);
+  });
+});

--- a/test/integration/dispose/async/connection.test.mts
+++ b/test/integration/dispose/async/connection.test.mts
@@ -16,7 +16,7 @@ await describe('PromiseConnection should implement Symbol.asyncDispose', async (
 });
 
 await describe('asyncDispose should end the connection', async () => {
-  const conn = await createConnection(config);
+  await using conn = await createConnection(config);
   const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
 
   await conn[Symbol.asyncDispose]();
@@ -31,8 +31,8 @@ await describe('asyncDispose should end the connection', async () => {
   });
 });
 
-await describe('asyncDispose should handle destroy before asyncDispose on connection', async () => {
-  const conn = await createConnection(config);
+await describe('asyncDispose should handle manual destroy before asyncDispose on connection', async () => {
+  await using conn = await createConnection(config);
   const [rows] = await conn.query<RowDataPacket[]>('SELECT 1');
 
   conn.destroy();

--- a/test/integration/dispose/async/pool-cluster.test.mts
+++ b/test/integration/dispose/async/pool-cluster.test.mts
@@ -8,19 +8,17 @@ if (!('asyncDispose' in Symbol)) {
 }
 
 await describe('PromisePoolCluster should implement Symbol.asyncDispose', async () => {
-  const cluster = createPoolCluster();
+  await using cluster = createPoolCluster();
 
   cluster.add('MASTER', config);
 
   it('should be a function', () => {
     assert.strictEqual(typeof cluster[Symbol.asyncDispose], 'function');
   });
-
-  await cluster[Symbol.asyncDispose]();
 });
 
 await describe('asyncDispose should end the pool cluster', async () => {
-  const cluster = createPoolCluster();
+  await using cluster = createPoolCluster();
 
   cluster.add('MASTER', config);
 
@@ -38,8 +36,8 @@ await describe('asyncDispose should end the pool cluster', async () => {
   });
 });
 
-await describe('asyncDispose should handle end before asyncDispose on pool cluster', async () => {
-  const cluster = createPoolCluster();
+await describe('asyncDispose should handle manual end before asyncDispose on pool cluster', async () => {
+  await using cluster = createPoolCluster();
 
   cluster.add('MASTER', config);
   await cluster.end();

--- a/test/integration/dispose/async/pool-cluster.test.mts
+++ b/test/integration/dispose/async/pool-cluster.test.mts
@@ -1,0 +1,52 @@
+import type { RowDataPacket } from '../../../../index.js';
+import { assert, describe, it, skip } from 'poku';
+import { createPoolCluster } from '../../../../promise.js';
+import { config } from '../../../common.test.mjs';
+
+if (!('asyncDispose' in Symbol)) {
+  skip('Symbol.asyncDispose is not supported in this runtime');
+}
+
+await describe('PromisePoolCluster should implement Symbol.asyncDispose', async () => {
+  const cluster = createPoolCluster();
+
+  cluster.add('MASTER', config);
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof cluster[Symbol.asyncDispose], 'function');
+  });
+
+  await cluster[Symbol.asyncDispose]();
+});
+
+await describe('asyncDispose should end the pool cluster', async () => {
+  const cluster = createPoolCluster();
+
+  cluster.add('MASTER', config);
+
+  const [rows] = await cluster.of('*').query<RowDataPacket[]>('SELECT 1');
+
+  await cluster[Symbol.asyncDispose]();
+
+  it('should have received the query result', () => {
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have closed the pool cluster', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(cluster.poolCluster._closed, true);
+  });
+});
+
+await describe('asyncDispose should handle end before asyncDispose on pool cluster', async () => {
+  const cluster = createPoolCluster();
+
+  cluster.add('MASTER', config);
+  await cluster.end();
+  await cluster[Symbol.asyncDispose]();
+
+  it('should have closed the pool cluster', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(cluster.poolCluster._closed, true);
+  });
+});

--- a/test/integration/dispose/async/pool.test.mts
+++ b/test/integration/dispose/async/pool.test.mts
@@ -68,7 +68,7 @@ await describe('Pool should serve a new connection after await using releases th
 });
 
 await describe('asyncDispose should end the pool', async () => {
-  const pool = createPool({ ...config, connectionLimit: 1 });
+  await using pool = createPool({ ...config, connectionLimit: 1 });
   const [rows] = await pool.query<RowDataPacket[]>('SELECT 1');
 
   await pool[Symbol.asyncDispose]();
@@ -83,8 +83,8 @@ await describe('asyncDispose should end the pool', async () => {
   });
 });
 
-await describe('asyncDispose should handle end before asyncDispose on pool', async () => {
-  const pool = createPool({ ...config, connectionLimit: 1 });
+await describe('asyncDispose should handle manual end before asyncDispose on pool', async () => {
+  await using pool = createPool({ ...config, connectionLimit: 1 });
 
   await pool.end();
   await pool[Symbol.asyncDispose]();

--- a/test/integration/dispose/dispose.test.mts
+++ b/test/integration/dispose/dispose.test.mts
@@ -1,0 +1,187 @@
+import type {
+  Connection,
+  Pool,
+  PoolConnection,
+  RowDataPacket,
+} from '../../../index.js';
+import { assert, describe, it, skip } from 'poku';
+import { createConnection, createPool } from '../../common.test.mjs';
+
+if (!('dispose' in Symbol)) {
+  skip('Symbol.dispose is not supported in this runtime');
+}
+
+const getConnection = (pool: Pool) =>
+  new Promise<PoolConnection>((resolve, reject) => {
+    pool.getConnection((err, conn) => {
+      if (err) return reject(err);
+      resolve(conn);
+    });
+  });
+
+const query = (conn: Connection, sql: string) =>
+  new Promise<RowDataPacket[]>((resolve, reject) => {
+    conn.query<RowDataPacket[]>(sql, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+
+await describe('PoolConnection should implement Symbol.dispose', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+  const conn = await getConnection(pool);
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof conn[Symbol.dispose], 'function');
+  });
+
+  conn.release();
+  await pool.promise().end();
+});
+
+await describe('using should release the connection back to the pool', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+
+  await it('should use and dispose the connection', async () => {
+    using conn = await getConnection(pool);
+
+    const rows = await query(conn, 'SELECT 1');
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have returned the connection to the free pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool._freeConnections.length, 1);
+  });
+
+  await pool.promise().end();
+});
+
+await describe('Pool should serve a new connection after using releases the previous one', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+
+  await it('should use and dispose the first connection', async () => {
+    using conn = await getConnection(pool);
+
+    const rows = await query(conn, 'SELECT 1');
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  await it('should use and dispose the second connection', async () => {
+    using conn = await getConnection(pool);
+
+    const rows = await query(conn, 'SELECT 1');
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have served both connections with a single pool slot', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool._allConnections.length, 1);
+  });
+
+  await pool.promise().end();
+});
+
+await describe('dispose should release the connection', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+  const conn = await getConnection(pool);
+  const rows = await query(conn, 'SELECT 1');
+  assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  conn[Symbol.dispose]();
+
+  it('should have returned the connection to the free pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool._freeConnections.length, 1);
+  });
+
+  await pool.promise().end();
+});
+
+await describe('using should handle manual `destroy` before automatic dispose', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+
+  await it('should not error when connection is destroyed within using', async () => {
+    using conn = await getConnection(pool);
+
+    const rows = await query(conn, 'SELECT 1');
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+    conn.destroy();
+  });
+
+  it('should have removed the destroyed connection from the pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool._allConnections.length, 0);
+  });
+
+  await pool.promise().end();
+});
+
+await describe('Connection should implement Symbol.dispose', async () => {
+  const conn = createConnection();
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof conn[Symbol.dispose], 'function');
+  });
+
+  conn.end();
+});
+
+await describe('dispose should end the connection', async () => {
+  const conn = createConnection();
+  const rows = await query(conn, 'SELECT 1');
+  assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  conn[Symbol.dispose]();
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn._closing, true);
+  });
+});
+
+await describe('dispose should handle destroy before dispose on connection', async () => {
+  const conn = createConnection();
+  const rows = await query(conn, 'SELECT 1');
+  assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  conn.destroy();
+  conn[Symbol.dispose]();
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn._closing, true);
+  });
+});
+
+await describe('Pool should implement Symbol.dispose', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof pool[Symbol.dispose], 'function');
+  });
+
+  await pool.promise().end();
+});
+
+await describe('dispose should end the pool', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+  const conn = await getConnection(pool);
+  const rows = await query(conn, 'SELECT 1');
+  assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  conn.release();
+  pool[Symbol.dispose]();
+
+  it('should have closed the pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool._closed, true);
+  });
+});
+
+await describe('dispose should handle end before dispose on pool', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+  await pool.promise().end();
+  pool[Symbol.dispose]();
+
+  it('should have closed the pool', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(pool._closed, true);
+  });
+});

--- a/test/integration/dispose/sync/connection.test.mts
+++ b/test/integration/dispose/sync/connection.test.mts
@@ -1,0 +1,58 @@
+import type { Connection, RowDataPacket } from '../../../../index.js';
+import { assert, describe, it, skip } from 'poku';
+import { createConnection } from '../../../common.test.mjs';
+
+if (!('dispose' in Symbol)) {
+  skip('Symbol.dispose is not supported in this runtime');
+}
+
+const query = (conn: Connection, sql: string) =>
+  new Promise<RowDataPacket[]>((resolve, reject) => {
+    conn.query<RowDataPacket[]>(sql, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+
+await describe('Connection should implement Symbol.dispose', async () => {
+  const conn = createConnection();
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof conn[Symbol.dispose], 'function');
+  });
+
+  conn.end();
+});
+
+await describe('dispose should end the connection', async () => {
+  const conn = createConnection();
+  const rows = await query(conn, 'SELECT 1');
+
+  conn[Symbol.dispose]();
+
+  it('should have received the query result', () => {
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn._closing, true);
+  });
+});
+
+await describe('dispose should handle destroy before dispose on connection', async () => {
+  const conn = createConnection();
+  const rows = await query(conn, 'SELECT 1');
+
+  conn.destroy();
+  conn[Symbol.dispose]();
+
+  it('should have received the query result', () => {
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have closed the connection', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(conn._closing, true);
+  });
+});

--- a/test/integration/dispose/sync/connection.test.mts
+++ b/test/integration/dispose/sync/connection.test.mts
@@ -15,17 +15,15 @@ const query = (conn: Connection, sql: string) =>
   });
 
 await describe('Connection should implement Symbol.dispose', async () => {
-  const conn = createConnection();
+  using conn = createConnection();
 
   it('should be a function', () => {
     assert.strictEqual(typeof conn[Symbol.dispose], 'function');
   });
-
-  conn.end();
 });
 
 await describe('dispose should end the connection', async () => {
-  const conn = createConnection();
+  using conn = createConnection();
   const rows = await query(conn, 'SELECT 1');
 
   conn[Symbol.dispose]();
@@ -40,8 +38,8 @@ await describe('dispose should end the connection', async () => {
   });
 });
 
-await describe('dispose should handle destroy before dispose on connection', async () => {
-  const conn = createConnection();
+await describe('dispose should handle manual destroy before dispose on connection', async () => {
+  using conn = createConnection();
   const rows = await query(conn, 'SELECT 1');
 
   conn.destroy();

--- a/test/integration/dispose/sync/pool-cluster.test.mts
+++ b/test/integration/dispose/sync/pool-cluster.test.mts
@@ -15,19 +15,17 @@ const clusterQuery = (cluster: PoolCluster, sql: string) =>
   });
 
 await describe('PoolCluster should implement Symbol.dispose', async () => {
-  const cluster = createPoolCluster();
+  using cluster = createPoolCluster();
 
   cluster.add('MASTER', getConfig());
 
   it('should be a function', () => {
     assert.strictEqual(typeof cluster[Symbol.dispose], 'function');
   });
-
-  cluster[Symbol.dispose]();
 });
 
 await describe('dispose should end the pool cluster', async () => {
-  const cluster = createPoolCluster();
+  using cluster = createPoolCluster();
 
   cluster.add('MASTER', getConfig());
 
@@ -45,8 +43,8 @@ await describe('dispose should end the pool cluster', async () => {
   });
 });
 
-await describe('dispose should handle end before dispose on pool cluster', async () => {
-  const cluster = createPoolCluster();
+await describe('dispose should handle manual end before dispose on pool cluster', async () => {
+  using cluster = createPoolCluster();
 
   cluster.add('MASTER', getConfig());
 

--- a/test/integration/dispose/sync/pool-cluster.test.mts
+++ b/test/integration/dispose/sync/pool-cluster.test.mts
@@ -1,0 +1,63 @@
+import type { PoolCluster, RowDataPacket } from '../../../../index.js';
+import { assert, describe, it, skip } from 'poku';
+import { createPoolCluster, getConfig } from '../../../common.test.mjs';
+
+if (!('dispose' in Symbol)) {
+  skip('Symbol.dispose is not supported in this runtime');
+}
+
+const clusterQuery = (cluster: PoolCluster, sql: string) =>
+  new Promise<RowDataPacket[]>((resolve, reject) => {
+    cluster.of('*').query<RowDataPacket[]>(sql, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+
+await describe('PoolCluster should implement Symbol.dispose', async () => {
+  const cluster = createPoolCluster();
+
+  cluster.add('MASTER', getConfig());
+
+  it('should be a function', () => {
+    assert.strictEqual(typeof cluster[Symbol.dispose], 'function');
+  });
+
+  cluster[Symbol.dispose]();
+});
+
+await describe('dispose should end the pool cluster', async () => {
+  const cluster = createPoolCluster();
+
+  cluster.add('MASTER', getConfig());
+
+  const rows = await clusterQuery(cluster, 'SELECT 1');
+
+  cluster[Symbol.dispose]();
+
+  it('should have received the query result', () => {
+    assert.deepStrictEqual(rows, [{ 1: 1 }]);
+  });
+
+  it('should have closed the pool cluster', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(cluster._closed, true);
+  });
+});
+
+await describe('dispose should handle end before dispose on pool cluster', async () => {
+  const cluster = createPoolCluster();
+
+  cluster.add('MASTER', getConfig());
+
+  await new Promise<void>((resolve, reject) => {
+    cluster.end((err) => (err ? reject(err) : resolve()));
+  });
+
+  cluster[Symbol.dispose]();
+
+  it('should have closed the pool cluster', () => {
+    // @ts-expect-error: internal access
+    assert.strictEqual(cluster._closed, true);
+  });
+});

--- a/typings/mysql/lib/Connection.d.ts
+++ b/typings/mysql/lib/Connection.d.ts
@@ -393,6 +393,8 @@ declare class Connection extends QueryableBase(ExecutableBase(EventEmitter)) {
   end(callback?: (err: QueryError | null) => void): void;
   end(options: any, callback?: (err: QueryError | null) => void): void;
 
+  [Symbol.dispose](): void;
+
   destroy(): void;
 
   pause(): void;

--- a/typings/mysql/lib/Pool.d.ts
+++ b/typings/mysql/lib/Pool.d.ts
@@ -53,6 +53,8 @@ declare class Pool extends QueryableBase(ExecutableBase(EventEmitter)) {
     callback?: (err: NodeJS.ErrnoException | null, ...args: any[]) => any
   ): void;
 
+  [Symbol.dispose](): void;
+
   on(event: string, listener: (...args: any[]) => void): this;
   on(event: 'connection', listener: (connection: PoolConnection) => any): this;
   on(event: 'acquire', listener: (connection: PoolConnection) => any): this;

--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -56,6 +56,8 @@ declare class PoolCluster extends EventEmitter {
 
   end(callback?: (err: NodeJS.ErrnoException | null) => void): void;
 
+  [Symbol.dispose](): void;
+
   getConnection(
     callback: (
       err: NodeJS.ErrnoException | null,

--- a/typings/mysql/lib/PoolConnection.d.ts
+++ b/typings/mysql/lib/PoolConnection.d.ts
@@ -4,6 +4,7 @@ import { Pool as PromisePool } from '../../../promise.js';
 declare class PoolConnection extends Connection {
   connection: Connection;
   release(): void;
+  [Symbol.dispose](): void;
   promise(promiseImpl?: PromiseConstructor): PromisePool;
 }
 

--- a/website/docs/documentation/promise-wrapper.mdx
+++ b/website/docs/documentation/promise-wrapper.mdx
@@ -55,6 +55,53 @@ async function example2() {
 }
 ```
 
+## Explicit Resource Management (`await using`)
+
+With [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management), connections and pools are automatically cleaned up when they go out of scope — no need to manually call `.end()` or `.release()`.
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  await using conn = await mysql.createConnection({ database: test });
+  const [rows, fields] = await conn.execute('select ?+? as sum', [2, 2]);
+  // conn.end() is called automatically when leaving the scope
+}
+```
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  await using pool = mysql.createPool({ database: test });
+
+  // execute in parallel, next console.log in 3 seconds
+  await Promise.all([
+    pool.query('select sleep(2)'),
+    pool.query('select sleep(3)'),
+  ]);
+  console.log('3 seconds after');
+  // pool.end() is called automatically when leaving the scope
+}
+```
+
+```ts
+import mysql from 'mysql2/promise';
+
+const pool = mysql.createPool({});
+
+{
+  await using conn = await pool.getConnection();
+  const res = await conn.query('select foo from bar');
+  console.log(res[0][0].foo);
+  // conn.release() is called automatically when leaving the scope
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
 ## With [CO](https://github.com/tj/co)
 
 ```js

--- a/website/docs/examples/connections/create-connection.mdx
+++ b/website/docs/examples/connections/create-connection.mdx
@@ -30,6 +30,11 @@ try {
     'mysql://root:password@localhost:3306/test'
   );
   // highlight-end
+
+  // ... some query
+
+  // Close the connection
+  await connection.end();
 } catch (err) {
   console.log(err);
 }
@@ -41,14 +46,65 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const connection = mysql.createConnection(
   'mysql://root:password@localhost:3306/test'
 );
+// highlight-end
 
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection(
+    'mysql://root:password@localhost:3306/test'
+  );
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection(
+    'mysql://root:password@localhost:3306/test'
+  );
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
 </Tabs>
@@ -75,6 +131,11 @@ try {
     // password: '',
   });
   // highlight-end
+
+  // ... some query
+
+  // Close the connection
+  await connection.end();
 } catch (err) {
   console.log(err);
 }
@@ -86,6 +147,7 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const connection = mysql.createConnection({
   host: 'localhost',
   user: 'root',
@@ -93,11 +155,69 @@ const connection = mysql.createConnection({
   // port: 3306,
   // password: '',
 });
+// highlight-end
 
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    // port: 3306,
+    // password: '',
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    // port: 3306,
+    // password: '',
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
 </Tabs>
@@ -124,6 +244,11 @@ try {
     ),
   });
   // highlight-end
+
+  // ... some query
+
+  // Close the connection
+  await connection.end();
 } catch (err) {
   console.log(err);
 }
@@ -135,15 +260,74 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const connection = mysql.createConnection({
   // ...
   passwordSha1: Buffer.from('8bb6118f8fd6935ad0876a3be34a717d32708ffd', 'hex'),
 });
+// highlight-end
 
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection({
+    // ...
+    passwordSha1: Buffer.from(
+      '8bb6118f8fd6935ad0876a3be34a717d32708ffd',
+      'hex'
+    ),
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection({
+    // ...
+    passwordSha1: Buffer.from(
+      '8bb6118f8fd6935ad0876a3be34a717d32708ffd',
+      'hex'
+    ),
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
 </Tabs>
@@ -167,6 +351,11 @@ try {
     ssl: {},
   });
   // highlight-end
+
+  // ... some query
+
+  // Close the connection
+  await connection.end();
 } catch (err) {
   console.log(err);
 }
@@ -178,15 +367,68 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const connection = mysql.createConnection({
   // ...
   ssl: {},
 });
+// highlight-end
 
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection({
+    // ...
+    ssl: {},
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection({
+    // ...
+    ssl: {},
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
 </Tabs>
@@ -214,6 +456,11 @@ try {
     },
   });
   // highlight-end
+
+  // ... some query
+
+  // Close the connection
+  await connection.end();
 } catch (err) {
   console.log(err);
 }
@@ -225,6 +472,7 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const connection = mysql.createConnection({
   // ...
   ssl: {
@@ -233,11 +481,71 @@ const connection = mysql.createConnection({
     ca: fs.readFileSync('./certs/ca-cert.pem'),
   },
 });
+// highlight-end
 
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection({
+    // ...
+    ssl: {
+      // key: fs.readFileSync('./certs/client-key.pem'),
+      // cert: fs.readFileSync('./certs/client-cert.pem')
+      ca: fs.readFileSync('./certs/ca-cert.pem'),
+    },
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection({
+    // ...
+    ssl: {
+      // key: fs.readFileSync('./certs/client-key.pem'),
+      // cert: fs.readFileSync('./certs/client-cert.pem')
+      ca: fs.readFileSync('./certs/ca-cert.pem'),
+    },
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
   <TabItem value='certs/ca-cert.pem'>
@@ -280,6 +588,11 @@ try {
     ssl: awsCaBundle,
   });
   // highlight-end
+
+  // ... some query
+
+  // Close the connection
+  await connection.end();
 } catch (err) {
   console.log(err);
 }
@@ -311,15 +624,22 @@ try {
 const mysql = require('mysql2');
 const awsCaBundle = require('aws-ssl-profiles');
 
+// highlight-start
 const connection = mysql.createConnection({
   // ...
   host: 'db.id.ap-southeast-2.rds.amazonaws.com',
   ssl: awsCaBundle,
 });
+// highlight-end
 
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
 
 :::info
@@ -341,6 +661,64 @@ connectionquery('SHOW `status` LIKE "Ssl_cipher"', function (err, res) {
 });
 ```
 
+:::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+import awsCaBundle from 'aws-ssl-profiles';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection({
+    // ...
+    host: 'db.id.ap-southeast-2.rds.amazonaws.com',
+    ssl: awsCaBundle,
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::info
+For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
+:::
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+const awsCaBundle = require('aws-ssl-profiles');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection({
+    // ...
+    host: 'db.id.ap-southeast-2.rds.amazonaws.com',
+    ssl: awsCaBundle,
+  });
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::info
+For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
+:::
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
 :::
 
   </TabItem>
@@ -369,6 +747,11 @@ const connection = mysql.createConnection({
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
 
   </TabItem>
@@ -390,6 +773,11 @@ const connection = mysql.createConnection({
 connection.addListener('error', (err) => {
   console.log(err);
 });
+
+// ... some query
+
+// Close the connection
+connection.end();
 ```
 
   </TabItem>

--- a/website/docs/examples/connections/create-pool.mdx
+++ b/website/docs/examples/connections/create-pool.mdx
@@ -33,33 +33,13 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool
+  await pool.end();
 } catch (err) {
   console.log(err);
 }
 ```
-
-  </TabItem>
-  <TabItem value='callback.js'>
-
-```js
-const mysql = require('mysql2');
-
-const pool = mysql.createPool('mysql://root:password@localhost:3306/test');
-
-pool.getConnection(function (err, connection) {
-  if (err instanceof Error) {
-    console.log(err);
-    return;
-  }
-
-  // ... some query
-
-  connection.release();
-});
-```
-
-  </TabItem>
-</Tabs>
 
 :::warning
 
@@ -69,6 +49,97 @@ Don't forget to release the connection when finished by using:
 - `connection.release()`
 
 :::
+
+  </TabItem>
+  <TabItem value='callback.js'>
+
+```js
+const mysql = require('mysql2');
+
+// highlight-start
+const pool = mysql.createPool('mysql://root:password@localhost:3306/test');
+// highlight-end
+
+pool.getConnection(function (err, connection) {
+  if (err instanceof Error) {
+    console.log(err);
+    return;
+  }
+
+  // ... some query
+
+  // highlight-next-line
+  connection.release();
+
+  // Close the pool
+  pool.end();
+});
+```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `pool.releaseConnection(connection)`
+- `connection.release()`
+
+:::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  await using pool = mysql.createPool(
+    'mysql://root:password@localhost:3306/test'
+  );
+  // .release() is called automatically when leaving the scope
+  await using connection = await pool.getConnection();
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-next-line
+  using pool = mysql.createPool('mysql://root:password@localhost:3306/test');
+
+  pool.getConnection(function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -97,39 +168,13 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool
+  await pool.end();
 } catch (err) {
   console.log(err);
 }
 ```
-
-  </TabItem>
-  <TabItem value='callback.js'>
-
-```js
-const mysql = require('mysql2');
-
-const pool = mysql.createPool({
-  host: 'localhost',
-  user: 'root',
-  database: 'test',
-  // port: 3306,
-  // password: '',
-});
-
-pool.getConnection(function (err, connection) {
-  if (err instanceof Error) {
-    console.log(err);
-    return;
-  }
-
-  // ... some query
-
-  connection.release();
-});
-```
-
-  </TabItem>
-</Tabs>
 
 :::warning
 
@@ -139,6 +184,113 @@ Don't forget to release the connection when finished by using:
 - `connection.release()`
 
 :::
+
+  </TabItem>
+  <TabItem value='callback.js'>
+
+```js
+const mysql = require('mysql2');
+
+// highlight-start
+const pool = mysql.createPool({
+  host: 'localhost',
+  user: 'root',
+  database: 'test',
+  // port: 3306,
+  // password: '',
+});
+// highlight-end
+
+pool.getConnection(function (err, connection) {
+  if (err instanceof Error) {
+    console.log(err);
+    return;
+  }
+
+  // ... some query
+
+  // highlight-next-line
+  connection.release();
+
+  // Close the pool
+  pool.end();
+});
+```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `pool.releaseConnection(connection)`
+- `connection.release()`
+
+:::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  await using pool = mysql.createPool({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    // port: 3306,
+    // password: '',
+  });
+  // .release() is called automatically when leaving the scope
+  await using connection = await pool.getConnection();
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-next-line
+  using pool = mysql.createPool({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    // port: 3306,
+    // password: '',
+  });
+
+  pool.getConnection(function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -167,36 +319,13 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool
+  await pool.end();
 } catch (err) {
   console.log(err);
 }
 ```
-
-  </TabItem>
-  <TabItem value='callback.js'>
-
-```js
-const mysql = require('mysql2');
-
-const pool = mysql.createPool({
-  // ...
-  passwordSha1: Buffer.from('8bb6118f8fd6935ad0876a3be34a717d32708ffd', 'hex'),
-});
-
-pool.getConnection(function (err, connection) {
-  if (err instanceof Error) {
-    console.log(err);
-    return;
-  }
-
-  // ... some query
-
-  connection.release();
-});
-```
-
-  </TabItem>
-</Tabs>
 
 :::warning
 
@@ -206,6 +335,110 @@ Don't forget to release the connection when finished by using:
 - `connection.release()`
 
 :::
+
+  </TabItem>
+  <TabItem value='callback.js'>
+
+```js
+const mysql = require('mysql2');
+
+// highlight-start
+const pool = mysql.createPool({
+  // ...
+  passwordSha1: Buffer.from('8bb6118f8fd6935ad0876a3be34a717d32708ffd', 'hex'),
+});
+// highlight-end
+
+pool.getConnection(function (err, connection) {
+  if (err instanceof Error) {
+    console.log(err);
+    return;
+  }
+
+  // ... some query
+
+  // highlight-next-line
+  connection.release();
+
+  // Close the pool
+  pool.end();
+});
+```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `pool.releaseConnection(connection)`
+- `connection.release()`
+
+:::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  await using pool = mysql.createPool({
+    // ...
+    passwordSha1: Buffer.from(
+      '8bb6118f8fd6935ad0876a3be34a717d32708ffd',
+      'hex'
+    ),
+  });
+  // .release() is called automatically when leaving the scope
+  await using connection = await pool.getConnection();
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-next-line
+  using pool = mysql.createPool({
+    // ...
+    passwordSha1: Buffer.from(
+      '8bb6118f8fd6935ad0876a3be34a717d32708ffd',
+      'hex'
+    ),
+  });
+
+  pool.getConnection(function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -235,10 +468,22 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool
+  await pool.end();
 } catch (err) {
   console.log(err);
 }
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `pool.releaseConnection(connection)`
+- `connection.release()`
+
+:::
 
   </TabItem>
   <TabItem value='callback.js'>
@@ -246,6 +491,7 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const pool = mysql.createPool({
   // ...
   ssl: {
@@ -254,6 +500,7 @@ const pool = mysql.createPool({
     ca: fs.readFileSync('./certs/ca-cert.pem'),
   },
 });
+// highlight-end
 
 pool.getConnection(function (err, connection) {
   if (err instanceof Error) {
@@ -263,9 +510,87 @@ pool.getConnection(function (err, connection) {
 
   // ... some query
 
+  // highlight-next-line
   connection.release();
+
+  // Close the pool
+  pool.end();
 });
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `pool.releaseConnection(connection)`
+- `connection.release()`
+
+:::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  await using pool = mysql.createPool({
+    // ...
+    ssl: {
+      // key: fs.readFileSync('./certs/client-key.pem'),
+      // cert: fs.readFileSync('./certs/client-cert.pem')
+      ca: fs.readFileSync('./certs/ca-cert.pem'),
+    },
+  });
+  // .release() is called automatically when leaving the scope
+  await using connection = await pool.getConnection();
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-next-line
+  using pool = mysql.createPool({
+    // ...
+    ssl: {
+      // key: fs.readFileSync('./certs/client-key.pem'),
+      // cert: fs.readFileSync('./certs/client-cert.pem')
+      ca: fs.readFileSync('./certs/ca-cert.pem'),
+    },
+  });
+
+  pool.getConnection(function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
     <TabItem value='certs/ca-cert.pem'>
@@ -278,15 +603,6 @@ pool.getConnection(function (err, connection) {
 
   </TabItem>
 </Tabs>
-
-:::warning
-
-Don't forget to release the connection when finished by using:
-
-- `pool.releaseConnection(connection)`
-- `connection.release()`
-
-:::
 
 <hr />
 
@@ -322,6 +638,9 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool
+  await pool.end();
 } catch (err) {
   console.log(err);
 }
@@ -329,6 +648,15 @@ try {
 
 :::info
 For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
+:::
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `pool.releaseConnection(connection)`
+- `connection.release()`
+
 :::
 
 :::tip Testing
@@ -353,11 +681,13 @@ try {
 const mysql = require('mysql2');
 const awsCaBundle = require('aws-ssl-profiles');
 
+// highlight-start
 const pool = mysql.createPool({
   // ...
   host: 'db.id.ap-southeast-2.rds.amazonaws.com',
   ssl: awsCaBundle,
 });
+// highlight-end
 
 pool.getConnection(function (err, connection) {
   if (err instanceof Error) {
@@ -367,12 +697,25 @@ pool.getConnection(function (err, connection) {
 
   // ... some query
 
+  // highlight-next-line
   connection.release();
+
+  // Close the pool
+  pool.end();
 });
 ```
 
 :::info
 For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
+:::
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `pool.releaseConnection(connection)`
+- `connection.release()`
+
 :::
 
 :::tip Testing
@@ -393,16 +736,76 @@ connectionquery('SHOW `status` LIKE "Ssl_cipher"', function (err, res) {
 :::
 
   </TabItem>
-</Tabs>
+  <TabItem value='await using'>
 
-:::warning
+```ts
+import mysql from 'mysql2/promise';
+import awsCaBundle from 'aws-ssl-profiles';
 
-Don't forget to release the connection when finished by using:
+{
+  // highlight-start
+  await using pool = mysql.createPool({
+    // ...
+    host: 'db.id.ap-southeast-2.rds.amazonaws.com',
+    ssl: awsCaBundle,
+  });
+  // .release() is called automatically when leaving the scope
+  await using connection = await pool.getConnection();
+  // highlight-end
 
-- `pool.releaseConnection(connection)`
-- `connection.release()`
+  // ... some query
+}
+```
 
+:::info
+For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
 :::
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+const awsCaBundle = require('aws-ssl-profiles');
+
+{
+  // highlight-next-line
+  using pool = mysql.createPool({
+    // ...
+    host: 'db.id.ap-southeast-2.rds.amazonaws.com',
+    ssl: awsCaBundle,
+  });
+
+  pool.getConnection(function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::info
+For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
+:::
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -423,6 +826,9 @@ const pool = mysql.createPool({
   stream: socksProxy,
 });
 // highlight-end
+
+// Close the pool
+pool.end();
 ```
 
   </TabItem>
@@ -440,6 +846,9 @@ const pool = mysql.createPool({
   },
 });
 // highlight-end
+
+// Close the pool
+pool.end();
 ```
 
   </TabItem>

--- a/website/docs/examples/connections/createPoolCluster.mdx
+++ b/website/docs/examples/connections/createPoolCluster.mdx
@@ -37,10 +37,21 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  await poolCluster.end();
 } catch (err) {
   console.log(err);
 }
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `connection.release()`
+
+:::
 
   </TabItem>
   <TabItem value='callback.js'>
@@ -48,10 +59,12 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const poolCluster = mysql.createPoolCluster();
 
 poolCluster.add('clusterA', 'mysql://root:password@localhost:3306/test');
 // poolCluster.add('clusterB', '...');
+// highlight-end
 
 poolCluster.getConnection('clusterA', function (err, connection) {
   if (err instanceof Error) {
@@ -61,12 +74,13 @@ poolCluster.getConnection('clusterA', function (err, connection) {
 
   // ... some query
 
+  // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  poolCluster.end();
 });
 ```
-
-  </TabItem>
-</Tabs>
 
 :::warning
 
@@ -75,6 +89,70 @@ Don't forget to release the connection when finished by using:
 - `connection.release()`
 
 :::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', 'mysql://root:password@localhost:3306/test');
+  // poolCluster.add('clusterB', '...');
+
+  // .release() is called automatically when leaving the scope
+  await using connection = await poolCluster.getConnection('clusterA');
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', 'mysql://root:password@localhost:3306/test');
+  // poolCluster.add('clusterB', '...');
+  // highlight-end
+
+  poolCluster.getConnection('clusterA', function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -107,10 +185,21 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  await poolCluster.end();
 } catch (err) {
   console.log(err);
 }
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `connection.release()`
+
+:::
 
   </TabItem>
   <TabItem value='callback.js'>
@@ -118,6 +207,7 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const poolCluster = mysql.createPoolCluster();
 
 poolCluster.add('clusterA', {
@@ -128,6 +218,7 @@ poolCluster.add('clusterA', {
   // password: '',
 });
 // poolCluster.add('clusterB', '...');
+// highlight-end
 
 poolCluster.getConnection('clusterA', function (err, connection) {
   if (err instanceof Error) {
@@ -137,12 +228,13 @@ poolCluster.getConnection('clusterA', function (err, connection) {
 
   // ... some query
 
+  // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  poolCluster.end();
 });
 ```
-
-  </TabItem>
-</Tabs>
 
 :::warning
 
@@ -151,6 +243,82 @@ Don't forget to release the connection when finished by using:
 - `connection.release()`
 
 :::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', {
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    // port: 3306,
+    // password: '',
+  });
+  // poolCluster.add('clusterB', '...');
+
+  // .release() is called automatically when leaving the scope
+  await using connection = await poolCluster.getConnection('clusterA');
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', {
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    // port: 3306,
+    // password: '',
+  });
+  // poolCluster.add('clusterB', '...');
+  // highlight-end
+
+  poolCluster.getConnection('clusterA', function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -183,10 +351,21 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  await poolCluster.end();
 } catch (err) {
   console.log(err);
 }
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `connection.release()`
+
+:::
 
   </TabItem>
   <TabItem value='callback.js'>
@@ -194,6 +373,7 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const poolCluster = mysql.createPoolCluster();
 
 poolCluster.add('clusterA', {
@@ -201,6 +381,7 @@ poolCluster.add('clusterA', {
   passwordSha1: Buffer.from('8bb6118f8fd6935ad0876a3be34a717d32708ffd', 'hex'),
 });
 // poolCluster.add('clusterB', '...');
+// highlight-end
 
 poolCluster.getConnection('clusterA', function (err, connection) {
   if (err instanceof Error) {
@@ -210,12 +391,13 @@ poolCluster.getConnection('clusterA', function (err, connection) {
 
   // ... some query
 
+  // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  poolCluster.end();
 });
 ```
-
-  </TabItem>
-</Tabs>
 
 :::warning
 
@@ -224,6 +406,82 @@ Don't forget to release the connection when finished by using:
 - `connection.release()`
 
 :::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', {
+    // ...
+    passwordSha1: Buffer.from(
+      '8bb6118f8fd6935ad0876a3be34a717d32708ffd',
+      'hex'
+    ),
+  });
+  // poolCluster.add('clusterB', '...');
+
+  // .release() is called automatically when leaving the scope
+  await using connection = await poolCluster.getConnection('clusterA');
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', {
+    // ...
+    passwordSha1: Buffer.from(
+      '8bb6118f8fd6935ad0876a3be34a717d32708ffd',
+      'hex'
+    ),
+  });
+  // poolCluster.add('clusterB', '...');
+  // highlight-end
+
+  poolCluster.getConnection('clusterA', function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -257,10 +515,21 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  await poolCluster.end();
 } catch (err) {
   console.log(err);
 }
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `connection.release()`
+
+:::
 
   </TabItem>
   <TabItem value='callback.js'>
@@ -268,6 +537,7 @@ try {
 ```js
 const mysql = require('mysql2');
 
+// highlight-start
 const poolCluster = mysql.createPoolCluster();
 
 poolCluster.add('clusterA', {
@@ -279,6 +549,7 @@ poolCluster.add('clusterA', {
   },
 });
 // poolCluster.add('clusterB', '...');
+// highlight-end
 
 poolCluster.getConnection('clusterA', function (err, connection) {
   if (err instanceof Error) {
@@ -288,9 +559,96 @@ poolCluster.getConnection('clusterA', function (err, connection) {
 
   // ... some query
 
+  // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  poolCluster.end();
 });
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `connection.release()`
+
+:::
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', {
+    // ...
+    ssl: {
+      // key: fs.readFileSync('./certs/client-key.pem'),
+      // cert: fs.readFileSync('./certs/client-cert.pem')
+      ca: fs.readFileSync('./certs/ca-cert.pem'),
+    },
+  });
+  // poolCluster.add('clusterB', '...');
+
+  // .release() is called automatically when leaving the scope
+  await using connection = await poolCluster.getConnection('clusterA');
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', {
+    // ...
+    ssl: {
+      // key: fs.readFileSync('./certs/client-key.pem'),
+      // cert: fs.readFileSync('./certs/client-cert.pem')
+      ca: fs.readFileSync('./certs/ca-cert.pem'),
+    },
+  });
+  // poolCluster.add('clusterB', '...');
+  // highlight-end
+
+  poolCluster.getConnection('clusterA', function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
     <TabItem value='certs/ca-cert.pem'>
@@ -303,14 +661,6 @@ poolCluster.getConnection('clusterA', function (err, connection) {
 
   </TabItem>
 </Tabs>
-
-:::warning
-
-Don't forget to release the connection when finished by using:
-
-- `connection.release()`
-
-:::
 
 <hr />
 
@@ -350,10 +700,21 @@ try {
 
   // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  await poolCluster.end();
 } catch (err) {
   console.log(err);
 }
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `connection.release()`
+
+:::
 
 :::info
 For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
@@ -381,6 +742,7 @@ try {
 const mysql = require('mysql2');
 const awsCaBundle = require('aws-ssl-profiles');
 
+// highlight-start
 const poolCluster = mysql.createPoolCluster();
 
 poolCluster.add('clusterA', {
@@ -389,6 +751,7 @@ poolCluster.add('clusterA', {
   ssl: awsCaBundle,
 });
 // poolCluster.add('clusterB', '...');
+// highlight-end
 
 poolCluster.getConnection('clusterA', function (err, connection) {
   if (err instanceof Error) {
@@ -398,9 +761,21 @@ poolCluster.getConnection('clusterA', function (err, connection) {
 
   // ... some query
 
+  // highlight-next-line
   connection.release();
+
+  // Close the pool cluster
+  poolCluster.end();
 });
 ```
+
+:::warning
+
+Don't forget to release the connection when finished by using:
+
+- `connection.release()`
+
+:::
 
 :::info
 For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
@@ -424,15 +799,86 @@ connectionquery('SHOW `status` LIKE "Ssl_cipher"', function (err, res) {
 :::
 
   </TabItem>
-</Tabs>
+  <TabItem value='await using'>
 
-:::warning
+```ts
+import mysql from 'mysql2/promise';
+import awsCaBundle from 'aws-ssl-profiles';
 
-Don't forget to release the connection when finished by using:
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  await using poolCluster = mysql.createPoolCluster();
 
-- `connection.release()`
+  poolCluster.add('clusterA', {
+    // ...
+    host: 'db.id.ap-southeast-2.rds.amazonaws.com',
+    ssl: awsCaBundle,
+  });
+  // poolCluster.add('clusterB', '...');
 
+  // .release() is called automatically when leaving the scope
+  await using connection = await poolCluster.getConnection('clusterA');
+  // highlight-end
+
+  // ... some query
+}
+```
+
+:::info
+For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
 :::
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+const awsCaBundle = require('aws-ssl-profiles');
+
+{
+  // highlight-start
+  // .end() is called automatically when leaving the scope
+  using poolCluster = mysql.createPoolCluster();
+
+  poolCluster.add('clusterA', {
+    // ...
+    host: 'db.id.ap-southeast-2.rds.amazonaws.com',
+    ssl: awsCaBundle,
+  });
+  // poolCluster.add('clusterB', '...');
+  // highlight-end
+
+  poolCluster.getConnection('clusterA', function (err, _connection) {
+    if (err instanceof Error) {
+      console.log(err);
+      return;
+    }
+
+    // highlight-start
+    // .release() is called automatically when leaving the scope
+    using connection = _connection;
+    // highlight-end
+
+    // ... some query
+  });
+}
+```
+
+:::info
+For detailed instructions, please follow the [**AWS SSL Profiles documentation**](https://github.com/mysqljs/aws-ssl-profiles?tab=readme-ov-file#readme).
+:::
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
 
 <hr />
 
@@ -458,6 +904,9 @@ poolCluster.add('clusterA', {
 
 const poolNamespace = poolCluster.of('clusterA');
 // highlight-end
+
+// Close the pool cluster
+poolCluster.end();
 ```
 
   </TabItem>
@@ -480,6 +929,9 @@ poolCluster.add('clusterA', {
 
 const poolNamespace = poolCluster.of('clusterA');
 // highlight-end
+
+// Close the pool cluster
+poolCluster.end();
 ```
 
   </TabItem>

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -105,6 +105,9 @@ try {
 } catch (err) {
   console.log(err);
 }
+
+// Close the connection
+await connection.end();
 ```
 
   </TabItem>
@@ -136,11 +139,88 @@ connection.query(
   ['Page', 45],
   function (err, results) {
     console.log(results);
+
+    // Close the connection
+    connection.end();
   }
 );
 ```
 
-</TabItem>
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+  });
+
+  // A simple SELECT query
+  const [results, fields] = await connection.query(
+    'SELECT * FROM `table` WHERE `name` = "Page" AND `age` > 45'
+  );
+
+  console.log(results); // results contains rows returned by server
+  console.log(fields); // fields contains extra meta data about results, if available
+
+  // Using placeholders
+  const [results2] = await connection.query(
+    'SELECT * FROM `table` WHERE `name` = ? AND `age` > ?',
+    ['Page', 45]
+  );
+
+  console.log(results2);
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+import mysql from 'mysql2';
+
+{
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+  });
+
+  // A simple SELECT query
+  connection.query(
+    'SELECT * FROM `table` WHERE `name` = "Page" AND `age` > 45',
+    function (err, results, fields) {
+      console.log(results); // results contains rows returned by server
+      console.log(fields); // fields contains extra meta data about results, if available
+    }
+  );
+
+  // Using placeholders
+  connection.query(
+    'SELECT * FROM `table` WHERE `name` = ? AND `age` > ?',
+    ['Page', 45],
+    function (err, results) {
+      console.log(results);
+    }
+  );
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
 </Tabs>
 
 <hr />
@@ -180,6 +260,9 @@ try {
 } catch (err) {
   console.log(err);
 }
+
+// Close the connection
+await connection.end();
 ```
 
   </TabItem>
@@ -202,9 +285,73 @@ connection.execute(
   function (err, results, fields) {
     console.log(results); // results contains rows returned by server
     console.log(fields); // fields contains extra meta data about results, if available
+
+    // Close the connection
+    connection.end();
   }
 );
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // create the connection to database
+  // .end() is called automatically when leaving the scope
+  await using connection = await mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+  });
+
+  // execute will internally call prepare and query
+  const [results, fields] = await connection.execute(
+    'SELECT * FROM `table` WHERE `name` = ? AND `age` > ?',
+    ['Rick C-137', 53]
+  );
+
+  console.log(results); // results contains rows returned by server
+  console.log(fields); // fields contains extra meta data about results, if available
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+const mysql = require('mysql2');
+
+{
+  // create the connection to database
+  // .end() is called automatically when leaving the scope
+  using connection = mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+  });
+
+  // execute will internally call prepare and query
+  connection.execute(
+    'SELECT * FROM `table` WHERE `name` = ? AND `age` > ?',
+    ['Rick C-137', 53],
+    function (err, results, fields) {
+      console.log(results); // results contains rows returned by server
+      console.log(fields); // fields contains extra meta data about results, if available
+    }
+  );
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
 </Tabs>
@@ -242,6 +389,11 @@ const pool = mysql.createPool({
   enableKeepAlive: true,
   keepAliveInitialDelay: 0,
 });
+
+// ... some query
+
+// Close the pool
+await pool.end();
 ```
 
     </TabItem>
@@ -263,7 +415,70 @@ const pool = mysql.createPool({
   enableKeepAlive: true,
   keepAliveInitialDelay: 0,
 });
+
+// ... some query
+
+// Close the pool
+pool.end();
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // pool.end() is called automatically when leaving the scope
+  await using pool = mysql.createPool({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    waitForConnections: true,
+    connectionLimit: 10,
+    maxIdle: 10, // max idle connections, the default value is the same as `connectionLimit`
+    idleTimeout: 60000, // idle connections timeout, in milliseconds, the default value 60000
+    queueLimit: 0,
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 0,
+  });
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+import mysql from 'mysql2';
+
+{
+  // pool.end() is called automatically when leaving the scope
+  using pool = mysql.createPool({
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+    waitForConnections: true,
+    connectionLimit: 10,
+    maxIdle: 10, // max idle connections, the default value is the same as `connectionLimit`
+    idleTimeout: 60000, // idle connections timeout, in milliseconds, the default value 60000
+    queueLimit: 0,
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 0,
+  });
+
+  // ... some query
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
 
   </TabItem>
 </Tabs>
@@ -318,6 +533,12 @@ await conn.query(/* ... */);
 pool.releaseConnection(conn);
 ```
 
+- Additionally, directly release the connection using the `connection` object:
+
+```js
+conn.release();
+```
+
   </TabItem>
   <TabItem value='Callback'>
 
@@ -332,14 +553,147 @@ pool.getConnection(function (err, conn) {
 });
 ```
 
-  </TabItem>
-</Tabs>
-
 - Additionally, directly release the connection using the `connection` object:
 
 ```js
 conn.release();
 ```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+// For pool initialization, see above
+{
+  await using conn = await pool.getConnection();
+
+  // Do something with the connection
+  await conn.query(/* ... */);
+
+  // No need to manually release — .release() is called
+  // automatically when leaving the scope
+}
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+// For pool initialization, see above
+pool.getConnection(function (err, _conn) {
+  using conn = _conn;
+
+  // Do something with the connection
+  conn.query(/* ... */);
+
+  // No need to manually release — .release() is called
+  // automatically when leaving the scope
+});
+```
+
+:::tip
+`await using` and `using` leverage [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) to automatically call `.end()` or `.release()` when the variable goes out of scope, so you never forget to clean up connections.
+:::
+
+  </TabItem>
+</Tabs>
+
+<hr />
+
+### Using Pool Clusters
+
+Pool clusters allow you to manage multiple connection pools for different database servers, enabling features like read/write splitting and load balancing.
+
+<Tabs>
+  <TabItem value='Promise' default>
+
+```js
+import mysql from 'mysql2/promise';
+
+const cluster = mysql.createPoolCluster();
+
+cluster.add('MASTER', {
+  host: 'localhost',
+  user: 'root',
+  database: 'test',
+});
+
+const [rows] = await cluster.of('*').query('SELECT * FROM users');
+console.log(rows);
+
+cluster.end();
+```
+
+  </TabItem>
+  <TabItem value='Callback'>
+
+```js
+const mysql = require('mysql2');
+
+const cluster = mysql.createPoolCluster();
+
+cluster.add('MASTER', {
+  host: 'localhost',
+  user: 'root',
+  database: 'test',
+});
+
+cluster.of('*').query('SELECT * FROM users', function (err, rows) {
+  console.log(rows);
+});
+
+cluster.end();
+```
+
+  </TabItem>
+  <TabItem value='await using'>
+
+```ts
+import mysql from 'mysql2/promise';
+
+{
+  // cluster.end() is called automatically when leaving the scope
+  await using cluster = mysql.createPoolCluster();
+
+  cluster.add('MASTER', {
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+  });
+
+  const [rows] = await cluster.of('*').query('SELECT * FROM users');
+  console.log(rows);
+}
+```
+
+  </TabItem>
+  <TabItem value='using'>
+
+```ts
+import mysql from 'mysql2';
+
+{
+  // cluster.end() is called automatically when leaving the scope
+  using cluster = mysql.createPoolCluster();
+
+  cluster.add('MASTER', {
+    host: 'localhost',
+    user: 'root',
+    database: 'test',
+  });
+
+  cluster.of('*').query('SELECT * FROM users', function (err, rows) {
+    console.log(rows);
+  });
+}
+```
+
+  </TabItem>
+</Tabs>
 
 <hr />
 


### PR DESCRIPTION
This _PR_ adds `Symbol.dispose` and `Symbol.asyncDispose` support for automatic resource cleanup via [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management).

Closes #3590 (alternative _PR_).
Indirectly, closes #2725, closes #2543, and closes #2751.

- https://v8.dev/features/explicit-resource-management

### Usage examples

> [!TIP]
> `.end()` and `.release()` are called automatically when leaving their scope for both callback and promise `createConnection`, `createPool`, `getConnection`, and `createPoolCluster` APIs.

### `mysql2/promise`: `await using`

```ts
import mysql from 'mysql2/promise';

// Connection
{
  await using conn = await mysql.createConnection({});

  const [rows] = await conn.query('SELECT * FROM users');
  console.log(rows);
}

// Pool
{
  await using pool = mysql.createPool({});
  await using conn = await pool.getConnection();

  const [rows] = await conn.query('SELECT * FROM users');
  console.log(rows);
}

// PoolCluster
{
  await using cluster = mysql.createPoolCluster();

  cluster.add('MASTER', {});

  const [rows] = await cluster.of('*').query('SELECT * FROM users');
  console.log(rows);
}
```

### `mysql2` (callback): `using`

```ts
import mysql from 'mysql2';

// Connection
{
  using conn = mysql.createConnection({});

  conn.query('SELECT * FROM users', (err, rows) => {
    console.log(rows);
  });
}

// Pool
{
  using pool = mysql.createPool({});

  pool.getConnection((err, _conn) => {
    using conn = _conn;

    conn.query('SELECT * FROM users', (err, rows) => {
      console.log(rows);
    });
  });
}

// PoolCluster
{
  using cluster = mysql.createPoolCluster();

  cluster.add('MASTER', {});

  cluster.of('*').query('SELECT * FROM users', (err, rows) => {
    console.log(rows);
  });
}
```
