### PR TITLE
ci: fix benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,7 @@ name: Benchmark
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
   workflow_dispatch:
 
@@ -55,7 +55,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark
+          key: ${{ runner.os }}-benchmark-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-benchmark-
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -63,9 +65,9 @@ jobs:
           tool: 'benchmarkjs'
           output-file-path: output.txt
           external-data-json-path: ./cache/benchmark-data.json
-          fail-on-alert: false
+          fail-on-alert: true
           auto-push: false
-          alert-threshold: '150%'
+          alert-threshold: '110%'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
           alert-comment-cc-users: '@sidorares'


### PR DESCRIPTION
Tis _PR_ ensures that the benchmark runs on the `master` branch. This makes benchmarks
executed in _PRs_ compare directly against `HEAD`.

Also, the **150%** margin for triggering an alert has a compounding degradation problem:

1. If a benchmark detects **149%**, it doesn't notify and the test passes normally.
2. If the next benchmark also has a **149%** loss, that loss is on top of the "new **100%**", resulting in **~222%** (`1.49 × 1.49`) accumulated performance loss between two distinct _PRs_, for example.

The margin was reduced to **110%** _(for now)_, limiting this silent drift.