### PR TITLE
fix(types): ensure optional params in `query` and `execute` methods

### DIFF
--- a/test/unit/parsers/support-big-numbers-binary-sanitization.test.mts
+++ b/test/unit/parsers/support-big-numbers-binary-sanitization.test.mts
@@ -27,9 +27,9 @@ await describe('Binary Parser: supportBigNumbers Sanitization', async () => {
 
   for (const [supportBigNumbers, expectedType, label] of cases) {
     await it(label, async () => {
-      // @ts-expect-error: TODO: implement typings
       const [results] = await connection.execute<TotalRow[]>({
         sql,
+        // @ts-expect-error: TODO: implement typings
         supportBigNumbers,
       });
 

--- a/test/unit/parsers/support-big-numbers-text-sanitization.test.mts
+++ b/test/unit/parsers/support-big-numbers-text-sanitization.test.mts
@@ -27,9 +27,9 @@ await describe('Text Parser: supportBigNumbers Sanitization', async () => {
 
   for (const [supportBigNumbers, expectedType, label] of cases) {
     await it(label, async () => {
-      // @ts-expect-error: TODO: implement typings
       const [results] = await connection.query<TotalRow[]>({
         sql,
+        // @ts-expect-error: TODO: implement typings
         supportBigNumbers,
       });
 

--- a/test/unit/parsers/timezone-binary-sanitization.test.mts
+++ b/test/unit/parsers/timezone-binary-sanitization.test.mts
@@ -8,9 +8,9 @@ await describe('Binary Parser: timezone Sanitization', async () => {
   await it(async () => {
     process.env.TEST_ENV_VALUE = 'secure';
 
-    // @ts-expect-error: TODO: implement typings
     await connection.execute({
       sql: 'SELECT NOW()',
+      // @ts-expect-error: TODO: implement typings
       timezone: `'); process.env.TEST_ENV_VALUE = "not so much"; //`,
     });
 

--- a/test/unit/parsers/timezone-text-sanitization.test.mts
+++ b/test/unit/parsers/timezone-text-sanitization.test.mts
@@ -8,9 +8,9 @@ await describe('Text Parser: timezone Sanitization', async () => {
   await it(async () => {
     process.env.TEST_ENV_VALUE = 'secure';
 
-    // @ts-expect-error: TODO: implement typings
     await connection.query({
       sql: 'SELECT NOW()',
+      // @ts-expect-error: TODO: implement typings
       timezone: `'); process.env.TEST_ENV_VALUE = "not so much"; //`,
     });
 

--- a/typings/mysql/lib/protocol/sequences/promise/ExecutableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/promise/ExecutableBase.d.ts
@@ -8,14 +8,14 @@ export declare function ExecutableBase<T extends QueryableConstructor>(
     execute<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
     execute<T extends QueryResult>(
       sql: string,
-      values: QueryValues
+      values?: QueryValues
     ): Promise<[T, FieldPacket[]]>;
     execute<T extends QueryResult>(
       options: QueryOptions
     ): Promise<[T, FieldPacket[]]>;
     execute<T extends QueryResult>(
       options: QueryOptions,
-      values: QueryValues
+      values?: QueryValues
     ): Promise<[T, FieldPacket[]]>;
   };
 } & T;

--- a/typings/mysql/lib/protocol/sequences/promise/QueryableBase.d.ts
+++ b/typings/mysql/lib/protocol/sequences/promise/QueryableBase.d.ts
@@ -8,14 +8,14 @@ export declare function QueryableBase<T extends QueryableConstructor>(
     query<T extends QueryResult>(sql: string): Promise<[T, FieldPacket[]]>;
     query<T extends QueryResult>(
       sql: string,
-      values: any
+      values?: any
     ): Promise<[T, FieldPacket[]]>;
     query<T extends QueryResult>(
       options: QueryOptions
     ): Promise<[T, FieldPacket[]]>;
     query<T extends QueryResult>(
       options: QueryOptions,
-      values: any
+      values?: any
     ): Promise<[T, FieldPacket[]]>;
   };
 } & T;


### PR DESCRIPTION
Fixes #4122.