### PR TITLE
fix: bound `null`-terminated string read to packet end

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -406,8 +406,8 @@ class Packet {
   readNullTerminatedString(encoding) {
     const start = this.offset;
     let end = this.offset;
-    while (this.buffer[end]) {
-      end = end + 1; // TODO: handle OOB check
+    while (end < this.end && this.buffer[end] !== 0x00) {
+      end = end + 1;
     }
     this.offset = end + 1;
     return StringParser.decode(this.buffer, encoding, start, end);

--- a/test/unit/packets/test-read-null-terminated-string-oob.test.mts
+++ b/test/unit/packets/test-read-null-terminated-string-oob.test.mts
@@ -1,0 +1,58 @@
+import { describe, it, strict } from 'poku';
+import Packet from '../../../lib/packets/packet.js';
+
+describe('readNullTerminatedString: Logical Boundary Check', () => {
+  it('should stop at null terminator within bounds', () => {
+    const buffer = Buffer.from([
+      0x00,
+      0x00,
+      0x00,
+      0x00, // header
+      0x68,
+      0x65,
+      0x6c,
+      0x6c,
+      0x6f, // "hello"
+      0x00, // null terminator
+    ]);
+    const packet = new Packet(0, buffer, 0, buffer.length);
+    const result = packet.readNullTerminatedString('utf8');
+
+    strict.strictEqual(result, 'hello');
+  });
+
+  it('should not read beyond logical packet boundary (this.end)', () => {
+    const buffer = Buffer.from([
+      0x00,
+      0x00,
+      0x00,
+      0x00, // header
+      0x41,
+      0x42, // "AB" — this packet
+      0x58,
+      0x59, // "XY" — adjacent packet data
+      0x00, // null terminator outside boundary
+    ]);
+    const packetEnd = 6;
+    const packet = new Packet(0, buffer, 0, packetEnd);
+    const result = packet.readNullTerminatedString('utf8');
+
+    strict.strictEqual(result, 'AB', 'should not leak adjacent packet data');
+  });
+
+  it('should return empty string when packet boundary is at offset', () => {
+    const buffer = Buffer.from([
+      0x00,
+      0x00,
+      0x00,
+      0x00, // header
+      0x41,
+      0x42, // data outside boundary
+    ]);
+    const packetEnd = 4;
+    const packet = new Packet(0, buffer, 0, packetEnd);
+    const result = packet.readNullTerminatedString('utf8');
+
+    strict.strictEqual(result, '', 'no data within packet boundary');
+  });
+});


### PR DESCRIPTION
Previously, the `null` byte scan could read beyond the current packet into adjacent data in the same backing Buffer. `readNullTerminatedString` now stops at the logical packet boundary.

**Credits:** The fix used was totally made by @peaktwilight:

```js
while (end < this.end && this.buffer[end] !== 0x00) {
  end = end + 1;
}
```

- My work here was basically confirming the bug and creating tests to reproduce the behaviors and cover it.