### PR TITLE
fix: prevent query param override of URL-defined connection options

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -277,7 +277,10 @@ class ConnectionConfig {
       user: decodeURIComponent(parsedUrl.username),
       password: decodeURIComponent(parsedUrl.password),
     };
-    parsedUrl.searchParams.forEach((value, key) => {
+    for (const [key, value] of parsedUrl.searchParams) {
+      if (key in options) {
+        continue;
+      }
       try {
         // Try to parse this as a JSON expression first
         options[key] = JSON.parse(value);
@@ -285,7 +288,7 @@ class ConnectionConfig {
         // Otherwise assume it is a plain string
         options[key] = value;
       }
-    });
+    }
     return options;
   }
 }

--- a/test/unit/connection/test-parseurl-option-override.test.mts
+++ b/test/unit/connection/test-parseurl-option-override.test.mts
@@ -1,0 +1,53 @@
+import { describe, it, strict } from 'poku';
+import ConnectionConfig from '../../../lib/connection_config.js';
+
+describe('parseUrl: DSN Query Parameter Override', () => {
+  it('should not allow host override via query params', () => {
+    const options = ConnectionConfig.parseUrl(
+      'mysql://user:pass@legit.db/app?host=evil.db'
+    );
+
+    strict.strictEqual(options.host, 'legit.db');
+  });
+
+  it('should not allow user override via query params', () => {
+    const options = ConnectionConfig.parseUrl(
+      'mysql://user:pass@legit.db/app?user=evil'
+    );
+
+    strict.strictEqual(options.user, 'user');
+  });
+
+  it('should not allow password override via query params', () => {
+    const options = ConnectionConfig.parseUrl(
+      'mysql://user:pass@legit.db/app?password=evil'
+    );
+
+    strict.strictEqual(options.password, 'pass');
+  });
+
+  it('should not allow port override via query params', () => {
+    const options = ConnectionConfig.parseUrl(
+      'mysql://user:pass@legit.db:3306/app?port=9999'
+    );
+    strict.strictEqual(options.port, 3306);
+  });
+
+  it('should not allow database override via query params', () => {
+    const options = ConnectionConfig.parseUrl(
+      'mysql://user:pass@legit.db/app?database=evil'
+    );
+    strict.strictEqual(options.database, 'app');
+  });
+
+  it('should still allow safe options via query params', () => {
+    const options = ConnectionConfig.parseUrl(
+      'mysql://user:pass@legit.db/app?charset=utf8mb4&dateStrings=true'
+    );
+
+    // @ts-expect-error: dynamic query param options
+    strict.strictEqual(options.charset, 'utf8mb4');
+    // @ts-expect-error: dynamic query param options
+    strict.strictEqual(options.dateStrings, true);
+  });
+});


### PR DESCRIPTION
Query parameters in `parseUrl` could override connection options already extracted from the URL structure (e.g., `host`, `port`, `user`, `password`, and `database`):

> https://github.com/sidorares/node-mysql2/blob/91c5229dff2293953635b93f753b45bff31deac4/lib/connection_config.js#L273-L279

Now, keys already present in the parsed options object are skipped during query parameter processing.

Dynamic options like `ssl`, `multipleStatements`, etc. remain configurable via query parameters since they are not part of the URL structure and can/are commonly used in **DSN** strings, it also prevent a potential breaking change to this fix, since whoever controls the **DSN**, usually already controls the host and credentials.

> cc @peaktwilight, please see also https://github.com/sidorares/node-mysql2/commit/3123b4e686e4e7c3893b20773376aff2c31840f7 🤝