### PR TITLE
fix: handle malformed geometry payloads

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -559,6 +559,9 @@ class Packet {
             ? buffer.readUInt32LE(offset)
             : buffer.readUInt32BE(offset);
           offset += 4;
+          if (numPoints > (bufferLength - offset) / 16) {
+            return null;
+          }
           result = [];
           for (i = numPoints; i > 0; i--) {
             if (offset + 16 > bufferLength) {
@@ -583,6 +586,9 @@ class Packet {
             ? buffer.readUInt32LE(offset)
             : buffer.readUInt32BE(offset);
           offset += 4;
+          if (numRings > (bufferLength - offset) / 4) {
+            return null;
+          }
           result = [];
           for (i = numRings; i > 0; i--) {
             if (offset + 4 > bufferLength) {
@@ -621,6 +627,9 @@ class Packet {
             ? buffer.readUInt32LE(offset)
             : buffer.readUInt32BE(offset);
           offset += 4;
+          if (num > (bufferLength - offset) / 9) {
+            return null;
+          }
           result = [];
           for (i = num; i > 0; i--) {
             result.push(parseGeometry());

--- a/test/unit/packets/test-parse-geometry-range-error-values.test.mts
+++ b/test/unit/packets/test-parse-geometry-range-error-values.test.mts
@@ -188,6 +188,30 @@ describe('parseGeometryValue: Malformed Payload Handling', () => {
     strict.strictEqual(packet.parseGeometryValue(), null);
   });
 
+  it('should return null for WKBMultiPoint with malformed count', () => {
+    const payload = buildWKBMultiPoint(0xffffffff, Buffer.alloc(0));
+    const { buffer, start, end } = buildGeometryPacket(payload);
+    const packet = new Packet(0, buffer, start, end);
+
+    strict.strictEqual(packet.parseGeometryValue(), null);
+  });
+
+  it('should return null for WKBLineString with malformed numPoints', () => {
+    const payload = buildWKBLineString(0xffffffff, Buffer.alloc(0));
+    const { buffer, start, end } = buildGeometryPacket(payload);
+    const packet = new Packet(0, buffer, start, end);
+
+    strict.strictEqual(packet.parseGeometryValue(), null);
+  });
+
+  it('should return null for WKBPolygon with malformed numRings', () => {
+    const payload = buildWKBPolygon(0xffffffff, Buffer.alloc(0));
+    const { buffer, start, end } = buildGeometryPacket(payload);
+    const packet = new Packet(0, buffer, start, end);
+
+    strict.strictEqual(packet.parseGeometryValue(), null);
+  });
+
   it('should return valid result for well-formed WKBLineString', () => {
     const pointData = Buffer.alloc(16);
     pointData.writeDoubleLE(1.0, 0);


### PR DESCRIPTION
Now `parseGeometryValue` validates counts against remaining buffer bytes before entering loops from malformed geometry payloads.

Related:

- https://github.com/sidorares/node-mysql2/pull/4162#issuecomment-4021495280

> cc @peaktwilight