### PR TITLE
ci(dependabot): group react and react-dom updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: '/website'
     schedule:
       interval: 'daily'
+    groups:
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'


### PR DESCRIPTION
## Summary

- Groups `react` and `react-dom` in `.github/dependabot.yml` so they are always updated together in a single PR.
- Fixes #4245 where Dependabot bumped `react` alone, causing CI to fail because `react` and `react-dom` must be the same version.

## References

- [Dependabot grouped version updates](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)