### PR TITLE
ci(dependabot): group dependency updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,21 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
   - package-ecosystem: 'npm'
     directory: '/website'
     schedule:
       interval: 'daily'
     groups:
+      docusaurus:
+        patterns:
+          - '@docusaurus/*'
+          - 'docusaurus-*'
       react:
         patterns:
           - 'react'
           - 'react-dom'
+      website-dev-dependencies:
+        dependency-type: 'development'


### PR DESCRIPTION
## Summary

- Adds broader grouping rules to `.github/dependabot.yml` to reduce the number of Dependabot PRs.
- Follows up on #4246 which grouped only `react` + `react-dom`.

### Groups added

| Directory | Group | What it captures |
|-----------|-------|-----------------|
| `/` | `dev-dependencies` | All dev dependencies (eslint, prettier, typescript, rollup, @types/node, etc.) |
| `/website` | `docusaurus` | `@docusaurus/*`, `docusaurus-*` (released in lockstep) |
| `/website` | `react` | `react` + `react-dom` (already present, must be same version) |
| `/website` | `website-dev-dependencies` | All website dev dependencies (biome, @types/node, tsx, etc.) |

Production dependencies for the root package (the published library) are intentionally left ungrouped so each update gets individual review.

### Impact

Using today's open PRs as an example, this would collapse:
- 4 separate Docusaurus PRs → **1 PR**
- 3 separate root dev-dep PRs (prettier, @eslint/markdown, @types/node) → **1 PR**
- Website dev deps (biome, @types/node, etc.) → **1 PR**

## References

- [Dependabot grouped version updates docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)