### PR TITLE
perf: defer Error object creation to error handlers in promise wrappers

### DIFF
--- a/lib/promise/connection.js
+++ b/lib/promise/connection.js
@@ -26,14 +26,13 @@ class PromiseConnection extends EventEmitter {
 
   query(query, params) {
     const c = this.connection;
-    const localErr = new Error();
     if (typeof params === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       if (params !== undefined) {
         c.query(query, params, done);
       } else {
@@ -44,14 +43,13 @@ class PromiseConnection extends EventEmitter {
 
   execute(query, params) {
     const c = this.connection;
-    const localErr = new Error();
     if (typeof params === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       if (params !== undefined) {
         c.execute(query, params, done);
       } else {
@@ -74,37 +72,34 @@ class PromiseConnection extends EventEmitter {
 
   beginTransaction() {
     const c = this.connection;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       c.beginTransaction(done);
     });
   }
 
   commit() {
     const c = this.connection;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       c.commit(done);
     });
   }
 
   rollback() {
     const c = this.connection;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       c.rollback(done);
     });
   }
 
   ping() {
     const c = this.connection;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       c.ping((err) => {
         if (err) {
+          const localErr = new Error();
           localErr.message = err.message;
           localErr.code = err.code;
           localErr.errno = err.errno;
@@ -120,10 +115,10 @@ class PromiseConnection extends EventEmitter {
 
   reset() {
     const c = this.connection;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       c.reset((err) => {
         if (err) {
+          const localErr = new Error();
           localErr.message = err.message;
           localErr.code = err.code;
           localErr.errno = err.errno;
@@ -139,10 +134,10 @@ class PromiseConnection extends EventEmitter {
 
   connect() {
     const c = this.connection;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       c.connect((err, param) => {
         if (err) {
+          const localErr = new Error();
           localErr.message = err.message;
           localErr.code = err.code;
           localErr.errno = err.errno;
@@ -159,10 +154,10 @@ class PromiseConnection extends EventEmitter {
   prepare(options) {
     const c = this.connection;
     const promiseImpl = this.Promise;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       c.prepare(options, (err, statement) => {
         if (err) {
+          const localErr = new Error();
           localErr.message = err.message;
           localErr.code = err.code;
           localErr.errno = err.errno;
@@ -182,10 +177,10 @@ class PromiseConnection extends EventEmitter {
 
   changeUser(options) {
     const c = this.connection;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       c.changeUser(options, (err) => {
         if (err) {
+          const localErr = new Error();
           localErr.message = err.message;
           localErr.code = err.code;
           localErr.errno = err.errno;

--- a/lib/promise/make_done_cb.js
+++ b/lib/promise/make_done_cb.js
@@ -1,8 +1,9 @@
 'use strict';
 
-function makeDoneCb(resolve, reject, localErr) {
+function makeDoneCb(resolve, reject) {
   return function (err, rows, fields) {
     if (err) {
+      const localErr = new Error();
       localErr.message = err.message;
       localErr.code = err.code;
       localErr.errno = err.errno;

--- a/lib/promise/pool.js
+++ b/lib/promise/pool.js
@@ -33,14 +33,13 @@ class PromisePool extends EventEmitter {
 
   query(sql, args) {
     const corePool = this.pool;
-    const localErr = new Error();
     if (typeof args === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       if (args !== undefined) {
         corePool.query(sql, args, done);
       } else {
@@ -51,14 +50,13 @@ class PromisePool extends EventEmitter {
 
   execute(sql, args) {
     const corePool = this.pool;
-    const localErr = new Error();
     if (typeof args === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       if (args) {
         corePool.execute(sql, args, done);
       } else {
@@ -69,10 +67,10 @@ class PromisePool extends EventEmitter {
 
   end() {
     const corePool = this.pool;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       corePool.end((err) => {
         if (err) {
+          const localErr = new Error();
           localErr.message = err.message;
           localErr.code = err.code;
           localErr.errno = err.errno;

--- a/lib/promise/pool_cluster.js
+++ b/lib/promise/pool_cluster.js
@@ -24,28 +24,26 @@ class PromisePoolNamespace {
 
   query(sql, values) {
     const corePoolNamespace = this.poolNamespace;
-    const localErr = new Error();
     if (typeof values === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       corePoolNamespace.query(sql, values, done);
     });
   }
 
   execute(sql, values) {
     const corePoolNamespace = this.poolNamespace;
-    const localErr = new Error();
     if (typeof values === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       corePoolNamespace.execute(sql, values, done);
     });
   }

--- a/lib/promise/prepared_statement_info.js
+++ b/lib/promise/prepared_statement_info.js
@@ -10,9 +10,8 @@ class PromisePreparedStatementInfo {
 
   execute(parameters) {
     const s = this.statement;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       if (parameters) {
         s.execute(parameters, done);
       } else {

--- a/promise.js
+++ b/promise.js
@@ -16,7 +16,6 @@ const PromisePoolNamespace = require('./lib/promise/pool_cluster');
 
 function createConnectionPromise(opts) {
   const coreConnection = createConnection(opts);
-  const createConnectionErr = new Error();
   const thePromise = opts.Promise || Promise;
   if (!thePromise) {
     throw new Error(
@@ -30,6 +29,7 @@ function createConnectionPromise(opts) {
       resolve(new PromiseConnection(coreConnection, thePromise));
     });
     coreConnection.once('error', (err) => {
+      const createConnectionErr = new Error();
       createConnectionErr.message = err.message;
       createConnectionErr.code = err.code;
       createConnectionErr.errno = err.errno;
@@ -83,28 +83,26 @@ class PromisePoolCluster extends EventEmitter {
 
   query(sql, args) {
     const corePoolCluster = this.poolCluster;
-    const localErr = new Error();
     if (typeof args === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       corePoolCluster.query(sql, args, done);
     });
   }
 
   execute(sql, args) {
     const corePoolCluster = this.poolCluster;
-    const localErr = new Error();
     if (typeof args === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
       );
     }
     return new this.Promise((resolve, reject) => {
-      const done = makeDoneCb(resolve, reject, localErr);
+      const done = makeDoneCb(resolve, reject);
       corePoolCluster.execute(sql, args, done);
     });
   }
@@ -118,10 +116,10 @@ class PromisePoolCluster extends EventEmitter {
 
   end() {
     const corePoolCluster = this.poolCluster;
-    const localErr = new Error();
     return new this.Promise((resolve, reject) => {
       corePoolCluster.end((err) => {
         if (err) {
+          const localErr = new Error();
           localErr.message = err.message;
           localErr.code = err.code;
           localErr.errno = err.errno;

--- a/test/integration/promise-wrappers/test-async-stack.test.mts
+++ b/test/integration/promise-wrappers/test-async-stack.test.mts
@@ -1,6 +1,5 @@
 import type { ConnectionOptions } from '../../../index.js';
 import process from 'node:process';
-import ErrorStackParser from 'error-stack-parser';
 import { describe, it, skip, strict } from 'poku';
 import { createConnection as promiseCreateConnection } from '../../../promise.js';
 import { config } from '../../common.test.mjs';
@@ -15,34 +14,27 @@ await describe('Async stack traces', async () => {
     return promiseCreateConnection({ ...config, ...args });
   };
 
-  // TODO: investigate why connection is still open after ENETUNREACH
-  await it('should include caller stack in connection error', async () => {
-    let e1: Error;
+  await it('should propagate connection error with code and message', async () => {
     try {
-      e1 = new Error();
-      // expected not to connect
       await createConnection({ host: '127.0.0.1', port: 33066 });
+      strict(false, 'Expected connection to fail');
     } catch (err) {
-      const stack = ErrorStackParser.parse(err as Error);
-      const stackExpected = ErrorStackParser.parse(e1!);
-      strict(
-        stack[2].getLineNumber() === (stackExpected[0].getLineNumber() ?? 0) + 2
-      );
+      strict(err instanceof Error);
+      strict((err as Error & { code?: string }).code === 'ECONNREFUSED');
+      strict(typeof (err as Error).stack === 'string');
     }
   });
 
-  await it('should include caller stack in query error', async () => {
+  await it('should propagate query error with code and message', async () => {
     const conn = await createConnection();
-    let e2: Error;
     try {
-      e2 = new Error();
-      await Promise.all([conn.query('select 1+1'), conn.query('syntax error')]);
+      await conn.query('syntax error');
+      strict(false, 'Expected query to fail');
     } catch (err) {
-      const stack = ErrorStackParser.parse(err as Error);
-      const stackExpected = ErrorStackParser.parse(e2!);
-      strict(
-        stack[1].getLineNumber() === (stackExpected[0].getLineNumber() ?? 0) + 1
-      );
+      strict(err instanceof Error);
+      strict((err as Error & { code?: string }).code === 'ER_PARSE_ERROR');
+      strict(typeof (err as Error).message === 'string');
+      strict(typeof (err as Error).stack === 'string');
     } finally {
       await conn.end();
     }


### PR DESCRIPTION
## Summary

- Moves `new Error()` instantiation from function scope into error handling blocks across all promise wrapper modules, so Error objects are only created when actual errors occur
- Eliminates unnecessary CPU and GC overhead from stack trace capture on every successful call in high-throughput scenarios
- Updates `test-async-stack` to verify error propagation without asserting on caller-frame line numbers (which are no longer captured at the call site)

### Trade-off

The previous pattern captured a stack trace at the call site on *every* invocation so that, on error, the rejected Error would include the caller's frame. This is useful for debugging but expensive: in benchmarks over 280k calls the eager `new Error()` was a measurable CPU hot-spot. After this change, stack traces on errors still exist but originate from the internal callback rather than the caller.

### Changes

| File | Change |
|---|---|
| `lib/promise/make_done_cb.js` | Remove `localErr` parameter; create `Error` inside `if (err)` |
| `lib/promise/connection.js` | Remove eager `new Error()` from all 10 methods |
| `lib/promise/pool.js` | Same for `query`, `execute`, `end` |
| `lib/promise/pool_cluster.js` | Same for `query`, `execute` |
| `lib/promise/prepared_statement_info.js` | Same for `execute` |
| `promise.js` | Same for `createConnectionPromise`, `PromisePoolCluster` methods |
| `test/…/test-async-stack.test.mts` | Assert error propagation (code, message, stack presence) instead of caller-frame line offsets |

Continues #3169 — rebased onto the current modular codebase.

Co-authored-by: gunman <gunman@neowiz.com>

## Test plan

- [x] `npm run lint` — passes
- [x] `act` CI Build (typecheck + circular imports) — passes
- [x] `act` CI Linux (Node 22, mysql:8.3, SSL=0, Compression=0) — 205/205 tests pass