### PR TITLE
fix(types): accept Record types in query and execute values

### DIFF
--- a/test/tsc-build/strict-checks/values.test.ts
+++ b/test/tsc-build/strict-checks/values.test.ts
@@ -1,0 +1,35 @@
+/**
+ * This test strictly validates the accepted shapes of the `values` parameter.
+ * See https://github.com/sidorares/node-mysql2/issues/4275.
+ */
+
+import { mysql, mysqlp } from '../index.test.js';
+import { access, sqlPS } from '../promise/baseConnection.test.js';
+
+// Callbacks
+{
+  const conn = mysql.createConnection(access);
+  const params: Record<string, unknown> = { id: 1, name: 'alice' };
+  const jsonValue: Record<string, unknown> = { hello: 'world' };
+
+  conn.execute(sqlPS, params, () => {});
+  conn.query(sqlPS, params, () => {});
+
+  conn.execute(sqlPS, [1], () => {});
+  conn.query(sqlPS, [1, 'x', null], () => {});
+
+  conn.execute('INSERT INTO data VALUES (?)', [jsonValue], () => {});
+  conn.query('INSERT INTO data VALUES (?)', [jsonValue], () => {});
+
+  // @ts-expect-error: undefined is not a valid execute bind parameter
+  conn.execute(sqlPS, [undefined], () => {});
+}
+
+// Promise
+(async () => {
+  const conn = await mysqlp.createConnection(access);
+  const params: Record<string, unknown> = { id: 1, name: 'alice' };
+
+  await conn.execute(sqlPS, params);
+  await conn.query(sqlPS, params);
+})();

--- a/typings/mysql/lib/protocol/sequences/Query.d.ts
+++ b/typings/mysql/lib/protocol/sequences/Query.d.ts
@@ -15,7 +15,7 @@ export type ExecuteValues =
   | Buffer
   | Uint8Array
   | ExecuteValues[]
-  | { [key: string]: ExecuteValues };
+  | { [key: string]: unknown };
 
 export type QueryValues =
   | string
@@ -30,7 +30,7 @@ export type QueryValues =
   | Uint8Array
   | Raw
   | ({} | null | undefined)[]
-  | { [key: string]: QueryValues };
+  | { [key: string]: unknown };
 
 export interface QueryOptions {
   /**

--- a/website/docs/documentation/typescript-examples.mdx
+++ b/website/docs/documentation/typescript-examples.mdx
@@ -381,11 +381,11 @@ For `ProcedureCallPacket<RowDataPacket[]>`, please see the following examples.
 
 <hr />
 
-### QueryValues
+### QueryValues and ExecuteValues
 
 <Stability level={2} />
 
-The `QueryValues` type represents the allowed types for query parameter values:
+The types for the `values` argument to `.query()` and `.execute()` respectively:
 
 ```ts
 import mysql, { RowDataPacket, QueryValues } from 'mysql2';
@@ -406,7 +406,7 @@ conn.query<RowDataPacket[]>(
 );
 ```
 
-The `QueryValues` type includes the following types:
+`QueryValues` accepts:
 
 - `string`
 - `number`
@@ -414,10 +414,23 @@ The `QueryValues` type includes the following types:
 - `boolean`
 - `Date`
 - `null`
+- `undefined`
 - `Blob`
 - `Buffer`
-- `({} | null)[]` (array of values)
-- `{ [key: string]: QueryValues }` (named placeholders)
+- `Uint8Array`
+- `Raw` (raw SQL fragments, from `sql-escaper`)
+- `({} | null | undefined)[]` (array of values)
+- `{ [key: string]: unknown }` (named placeholders)
+
+`ExecuteValues` accepts the same types with these exceptions:
+
+- No `undefined`. Passing `undefined` as a bind parameter throws `TypeError: Bind parameters must not contain undefined. To pass SQL NULL specify JS null`.
+- No `Raw`. Prepared statements send values separately from the SQL text, so raw fragments can't be spliced in.
+- Nested arrays use `ExecuteValues[]` rather than `({} | null | undefined)[]`.
+
+:::note
+`.query()` substitutes `undefined` as `NULL` in the generated SQL, while `.execute()` throws. Prefer explicit `null` to keep behavior consistent between the two.
+:::
 
 <hr />
 


### PR DESCRIPTION
## Closes #4275

- Loosen the object branch on both types to `{ [key: string]: unknown }`. Top-level and array-branch strictness stay intact, so `undefined` inside an `execute` values array is still rejected at compile time.
- Adds a type-level regression test at `test/tsc-build/strict-checks/values.test.ts` covering top-level and nested `Record<string, unknown>` for both callback and promise APIs.
- Updates the `QueryValues` docs section to cover `ExecuteValues`, fix stale type signatures from before #4133, and document the `undefined` behavior difference between `.query()` and `.execute()`.

