### PR TITLE
fix: allow resetOnRelease in connection config validation

### DIFF
--- a/lib/connection_config.js
+++ b/lib/connection_config.js
@@ -67,6 +67,7 @@ const validOptions = {
   idleTimeout: 1,
   Promise: 1,
   queueLimit: 1,
+  resetOnRelease: 1,
   waitForConnections: 1,
   jsonStrings: 1,
   gracefulEnd: 1,


### PR DESCRIPTION
Fixes #4277

## Summary

`resetOnRelease` is already supported by the pool config and pool release logic,
but it is missing from `validOptions` in `lib/connection_config.js`.

Because of that, using `resetOnRelease: true` with `createPool()` works, but still prints:

> Ignoring invalid configuration option passed to Connection: resetOnRelease

This PR adds `resetOnRelease` to `validOptions` so the runtime validation matches the actual supported pool options.