### PR TITLE
fix(pool): reject queued requests on end

### DIFF
--- a/lib/base/pool.js
+++ b/lib/base/pool.js
@@ -185,6 +185,10 @@ class BasePool extends EventEmitter {
         }
       };
     }
+    while (this._connectionQueue.length > 0) {
+      const queuedCallback = this._connectionQueue.shift();
+      process.nextTick(() => queuedCallback(new Error('Pool is closed.')));
+    }
     let calledBack = false;
     let closedConnections = 0;
     let connection;

--- a/test/integration/test-pool-end.test.mts
+++ b/test/integration/test-pool-end.test.mts
@@ -1,6 +1,17 @@
 import { describe, it, strict } from 'poku';
 import { createPool } from '../common.test.mjs';
 
+function timeoutAfter(ms: number, message: string): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(message)), ms);
+  });
+}
+
+function getConnectionQueueLength(pool: unknown): number {
+  // @ts-expect-error: internal access
+  return pool.pool._connectionQueue.length;
+}
+
 await describe('Pool End', async () => {
   const pool = createPool();
 
@@ -51,5 +62,75 @@ await describe('Pool end should close all connections and mark as closed', async
 
     // @ts-expect-error: internal access
     strict(pool._closed === true, 'pool should be closed');
+  });
+});
+
+await describe('Promise Pool End', async () => {
+  await it('should reject queued queries when ending a saturated pool', async () => {
+    const pool = createPool({
+      connectionLimit: 2,
+      gracefulEnd: true,
+    }).promise();
+
+    const warmedConnections = await Promise.all([
+      pool.getConnection(),
+      pool.getConnection(),
+    ]);
+
+    for (const conn of warmedConnections) {
+      conn.release();
+    }
+
+    let enqueued = 0;
+    const waitForQueuedQueries = new Promise<void>((resolve) => {
+      pool.on('enqueue', () => {
+        enqueued++;
+
+        if (enqueued === 2) {
+          process.nextTick(resolve);
+        }
+      });
+    });
+
+    const queries = [
+      pool.query('SELECT SLEEP(2)'),
+      pool.query('SELECT SLEEP(2)'),
+      pool.query('SELECT SLEEP(2)'),
+      pool.query('SELECT SLEEP(2)'),
+    ];
+    const activeResultsPromise = Promise.allSettled(queries.slice(0, 2));
+    const queuedResultsPromise = Promise.allSettled(queries.slice(2));
+
+    await waitForQueuedQueries;
+
+    strict.equal(getConnectionQueueLength(pool), 2);
+
+    const endPromise = pool.end();
+
+    const queuedResults = await Promise.race([
+      queuedResultsPromise,
+      timeoutAfter(
+        1000,
+        `timed out waiting for queued queries to settle; queue length=${getConnectionQueueLength(pool)}`
+      ),
+    ]);
+
+    for (const result of queuedResults) {
+      strict.equal(result.status, 'rejected');
+
+      if (result.status === 'rejected') {
+        strict.equal(result.reason.message, 'Pool is closed.');
+      }
+    }
+
+    strict.equal(getConnectionQueueLength(pool), 0);
+
+    const activeResults = await activeResultsPromise;
+
+    for (const result of activeResults) {
+      strict.equal(result.status, 'fulfilled');
+    }
+
+    await endPromise;
   });
 });


### PR DESCRIPTION
## What changed

Reject connection requests that are already queued in `BasePool._connectionQueue` when `pool.end()` closes the pool.

## Why

When a promise pool is saturated and additional `pool.query()` calls are waiting for a connection, calling `pool.end()` marks the pool as closed and closes the active connections, but the queued callbacks are never invoked. The promise wrappers for those queued queries can stay pending forever.

This makes queued requests behave consistently with new `getConnection()` calls after pool closure, which already receive `Pool is closed.`.

## Validation

- Added an integration regression test that saturates a promise pool, waits until two queries are queued, calls `pool.end()`, and asserts the queued queries reject with `Pool is closed.` instead of timing out.
- Verified the new test fails before the fix with `timed out waiting for queued queries to settle; queue length=2`.
- `CI=1 MYSQL_PASSWORD=root MYSQL_DATABASE=mysql node --import tsx test/integration/test-pool-end.test.mts`
- `npm run lint`
