### PR TITLE
fix: keep 00:00:00 time for TIMESTAMP in binary protocol with dateStrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,12 +216,12 @@ MySQL2 is a **library**, not a long-running app. Development means installing No
 
 ### Services
 
-| Service | Required? | Notes |
-| --- | --- | --- |
-| **Node.js** (≥14; CI uses 22) | Yes | `npm ci` at repo root |
-| **MySQL** | Yes for full tests | Integration/global tests need a `test` database |
-| **Docker** | Recommended | Used to run MySQL the same way as CI |
-| **Docusaurus** (`website/`) | Optional | `cd website && npm ci && npm start` → http://localhost:3000 |
+| Service                       | Required?          | Notes                                                       |
+| ----------------------------- | ------------------ | ----------------------------------------------------------- |
+| **Node.js** (≥14; CI uses 22) | Yes                | `npm ci` at repo root                                       |
+| **MySQL**                     | Yes for full tests | Integration/global tests need a `test` database             |
+| **Docker**                    | Recommended        | Used to run MySQL the same way as CI                        |
+| **Docusaurus** (`website/`)   | Optional           | `cd website && npm ci && npm start` → http://localhost:3000 |
 
 ### MySQL via Docker
 
@@ -248,12 +248,12 @@ Without `CI=1`, tests use an empty root password (matches docker-compose). With 
 
 ### Commands (see `package.json` / `Contributing.md`)
 
-| Task | Command |
-| --- | --- |
-| Lint | `npm run lint` |
-| Typecheck | `npm run typecheck` |
-| Tests | `npm test` (or `FILTER=path/to/test.mts npx poku`) |
-| Build check | `npm run test:build` |
-| Website | `cd website && npm ci && npm test` |
+| Task        | Command                                            |
+| ----------- | -------------------------------------------------- |
+| Lint        | `npm run lint`                                     |
+| Typecheck   | `npm run typecheck`                                |
+| Tests       | `npm test` (or `FILTER=path/to/test.mts npx poku`) |
+| Build check | `npm run test:build`                               |
+| Website     | `cd website && npm ci && npm test`                 |
 
 `test/global` runs sequentially and needs elevated MySQL privileges; Poku skips those files when `hasPrivileges()` fails.

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -324,7 +324,10 @@ class Packet {
         leftPad(2, M),
         leftPad(2, S),
       ].join(':')}`;
-    } else if (columnType === Types.DATETIME || columnType === Types.TIMESTAMP) {
+    } else if (
+      columnType === Types.DATETIME ||
+      columnType === Types.TIMESTAMP
+    ) {
       str += ' 00:00:00';
     }
     if (length > 10) {

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -324,7 +324,7 @@ class Packet {
         leftPad(2, M),
         leftPad(2, S),
       ].join(':')}`;
-    } else if (columnType === Types.DATETIME) {
+    } else if (columnType === Types.DATETIME || columnType === Types.TIMESTAMP) {
       str += ' 00:00:00';
     }
     if (length > 10) {

--- a/test/integration/connection/test-datestrings-binary-zero-time.test.mts
+++ b/test/integration/connection/test-datestrings-binary-zero-time.test.mts
@@ -1,0 +1,45 @@
+import type { RowDataPacket } from '../../../index.js';
+import { describe, it, strict } from 'poku';
+import { createConnection } from '../../common.test.mjs';
+
+await describe('dateStrings: binary protocol keeps the 00:00:00 time of DATETIME/TIMESTAMP', async () => {
+  const connection = createConnection({ dateStrings: true }).promise();
+
+  await connection.query("SET time_zone = '+00:00'");
+  await connection.query(`CREATE TEMPORARY TABLE midnight_dates (
+    d DATE,
+    dt DATETIME,
+    dt3 DATETIME(3),
+    ts TIMESTAMP NULL,
+    ts6 TIMESTAMP(6) NULL
+  )`);
+
+  const midnight = '2026-05-31 00:00:00';
+  await connection.query('INSERT INTO midnight_dates VALUES (?, ?, ?, ?, ?)', [
+    '2026-05-31',
+    midnight,
+    midnight,
+    midnight,
+    midnight,
+  ]);
+
+  const [rows] = await connection.execute<RowDataPacket[]>(
+    'SELECT * FROM midnight_dates'
+  );
+
+  await it('keeps 00:00:00 for TIMESTAMP at midnight', () => {
+    strict.equal(rows[0].ts, '2026-05-31 00:00:00');
+    strict.equal(rows[0].ts6, '2026-05-31 00:00:00');
+  });
+
+  await it('keeps 00:00:00 for DATETIME at midnight', () => {
+    strict.equal(rows[0].dt, '2026-05-31 00:00:00');
+    strict.equal(rows[0].dt3, '2026-05-31 00:00:00');
+  });
+
+  await it('returns DATE without a time component', () => {
+    strict.equal(rows[0].d, '2026-05-31');
+  });
+
+  await connection.end();
+});


### PR DESCRIPTION
With `dateStrings: true` and the binary protocol (execute / prepared statements), a TIMESTAMP value whose time is exactly 00:00:00 was returned as a date only — e.g. "2026-05-31" instead of "2026-05-31 00:00:00". The text protocol (query) was unaffected.

MySQL's binary protocol omits an all-zero time component and sends only the date (length === 4), so the driver rebuilds the string in `Packet.readDateTimeString()`. This is the same bug class as #1040 ("datetime fields returned as date when time is 00:00:00"), fixed in #3204 — but that fix restored " 00:00:00" for Types.DATETIME only, leaving Types.TIMESTAMP still
affected. This extends the same handling to TIMESTAMP, matching DATETIME and the text protocol.

Fixes #4321