### PR TITLE
docs(lib): fix typos in comments

### DIFF
--- a/lib/base/connection.js
+++ b/lib/base/connection.js
@@ -186,7 +186,7 @@ class BaseConnection extends EventEmitter {
         });
       }
     }
-    // in case there was no initial handshake but we need to read sting, assume it utf-8
+    // in case there was no initial handshake but we need to read string, assume it utf-8
     // most common example: "Too many connections" error ( packet is sent immediately on connection attempt, we don't know server encoding yet)
     // will be overwritten with actual encoding value as soon as server handshake packet is received
     this.serverEncoding = 'utf8';
@@ -285,7 +285,7 @@ class BaseConnection extends EventEmitter {
         bubbleErrorToConnection = true;
       }
     }
-    // notify connection if some comands in the queue did not have callbacks
+    // notify connection if some commands in the queue did not have callbacks
     // or if this is pool connection ( so it can be removed from pool )
     if (bubbleErrorToConnection || this._pool) {
       this.emit('error', err);

--- a/lib/commands/client_handshake.js
+++ b/lib/commands/client_handshake.js
@@ -1,5 +1,5 @@
 // This file was modified by Oracle on June 17, 2021.
-// Handshake errors are now maked as fatal and the corresponding events are
+// Handshake errors are now marked as fatal and the corresponding events are
 // emitted in the command instance itself.
 // Modifications copyright (c) 2021, Oracle and/or its affiliates.
 

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -72,7 +72,7 @@ class Execute extends Command {
     // disabling for now, but would be great to find reliable way to parse fields only once
     // fields reported by prepare can be empty at all or just incorrect - see #169
     //
-    // perfomance optimisation: if we already have this field parsed in statement header, use one from header
+    // performance optimisation: if we already have this field parsed in statement header, use one from header
     // const field = this.statement.columns.length == this._fieldCount ?
     //  this.statement.columns[this._receivedFieldsCount] : new Packets.ColumnDefinition(packet);
     const field = new Packets.ColumnDefinition(

--- a/lib/commands/ping.js
+++ b/lib/commands/ping.js
@@ -5,7 +5,7 @@ const CommandCode = require('../constants/commands');
 const Packet = require('../packets/packet');
 
 // TODO: time statistics?
-// usefull for queue size and network latency monitoring
+// useful for queue size and network latency monitoring
 // store created,sent,reply timestamps
 class Ping extends Command {
   constructor(callback) {

--- a/lib/packets/binary_row.js
+++ b/lib/packets/binary_row.js
@@ -12,7 +12,7 @@ class BinaryRow {
 
   static toPacket(columns, encoding) {
     // throw new Error('Not implemented');
-    const sequenceId = 0; // TODO remove, this is calculated now in connecton
+    const sequenceId = 0; // TODO remove, this is calculated now in connection
     let length = 0;
     columns.forEach((val) => {
       if (val === null || typeof val === 'undefined') {
@@ -82,7 +82,7 @@ binaryReader[2] = Packet.prototype.readInt16; // short
 binaryReader[3] = Packet.prototype.readInt32; // long
 binaryReader[4] = Packet.prototype.readFloat; // float
 binaryReader[5] = Packet.prototype.readDouble; // double
-binaryReader[6] = Packet.prototype.assertInvalid; // null, should be skipped vie null bitmap
+binaryReader[6] = Packet.prototype.assertInvalid; // null, should be skipped via null bitmap
 binaryReader[7] = Packet.prototype.readTimestamp; // timestamp, http://dev.mysql.com/doc/internals/en/prepared-statements.html#packet-ProtocolBinary::MYSQL_TYPE_TIMESTAMP
 binaryReader[8] = Packet.prototype.readInt64; // long long
 binaryReader[9] = Packet.prototype.readInt32; // int24

--- a/lib/packets/binlog_query_statusvars.js
+++ b/lib/packets/binlog_query_statusvars.js
@@ -31,7 +31,7 @@ module.exports = function parseStatusVars(buffer) {
         offset += 4;
         break;
       case keys.SQL_MODE:
-        // value is 8 bytes, but all dcumented flags are in first 4 bytes
+        // value is 8 bytes, but all documented flags are in first 4 bytes
         result.sqlMode = buffer.readUInt32LE(offset);
         offset += 8;
         break;

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -32,8 +32,8 @@ function leftPad(num, value) {
 // In my benchmarks the difference is ~25M 8-digit numbers per second vs
 // 4.5 M using Number(packet.readLengthCodedString())
 // not used when size is close to max precision as series of *10 accumulate error
-// and approximate result mihgt be diffreent from (approximate as well) Number(bigNumStringValue))
-// In the futire node version if speed difference is smaller parse* functions might be removed
+// and approximate result might be different from (approximate as well) Number(bigNumStringValue))
+// In the future node version if speed difference is smaller parse* functions might be removed
 // don't consider them as Packet public API
 
 const minus = '-'.charCodeAt(0);

--- a/lib/packets/resultset_header.js
+++ b/lib/packets/resultset_header.js
@@ -65,7 +65,7 @@ class ResultSetHeader {
             if (key === 'character_set_client') {
               const charsetNumber = EncodingToCharset[val];
               // TODO - better api for driver users to handle unknown encodings?
-              // maybe custom coverter in the config?
+              // maybe custom converter in the config?
               // For now just ignore character_set_client command if there is
               // no known mapping from reported encoding to a charset code
               if (typeof charsetNumber !== 'undefined') {

--- a/lib/packets/text_row.js
+++ b/lib/packets/text_row.js
@@ -17,7 +17,7 @@ class TextRow {
   }
 
   static toPacket(columns, encoding) {
-    const sequenceId = 0; // TODO remove, this is calculated now in connecton
+    const sequenceId = 0; // TODO remove, this is calculated now in connection
     let length = 0;
     columns.forEach((val) => {
       if (val === null || typeof val === 'undefined') {


### PR DESCRIPTION
  - Fix typos in comments under `lib/`
  - No runtime behavior changes