### PR TITLE
test: fix typos in test comments

### DIFF
--- a/test/integration/connection/test-null.test.mts
+++ b/test/integration/connection/test-null.test.mts
@@ -26,7 +26,7 @@ await describe('Null', async () => {
     });
 
     strict.deepEqual(castRows, [{ cast_result: null }]);
-    // strict.equal(fields[0].columnType, 253); // depeding on the server type could be 253 or 3, disabling this check for now
+    // strict.equal(fields[0].columnType, 253); // depending on the server, the type could be 253 or 3, disabling this check for now
     strict.deepEqual(rows1, [{ i: null }]);
     strict.equal(fields1[0].columnType, 3);
   });

--- a/test/unit/test-packet-parser.test.mts
+++ b/test/unit/test-packet-parser.test.mts
@@ -106,7 +106,7 @@ describe('PacketParser', () => {
   });
 
   it('should parse packets larger than 65536 bytes', () => {
-    // test packet > 65536 lengt
+    // test packet > 65536 length
     // TODO combine with "execute" function
 
     const length = 123000;


### PR DESCRIPTION
  - Fix typos in comments under `test/`
  - No test behavior changes