### PR TITLE
feat: support MariaDB data types (UUID, INET4, INET6, VECTOR, JSON) via extended type metadata; run CI against MariaDB

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -29,12 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [18, 20, 22, 24]
-        mysql-version: ['mysql:8.3']
+        mysql-version: ['mysql:8.3', 'mariadb:11.8']
         use-compression: [0, 1]
         use-tls: [0, 1]
         mysql_connection_url_key: ['']
         # static-parser: [0, 1]  # Already tested in "ci-coverage"
-        # TODO - add mariadb to the matrix. currently few tests are broken due to mariadb incompatibilities
 
     env:
       MYSQL_CONNECTION_URL: ${{ secrets[matrix.mysql_connection_url_key] }}

--- a/lib/base/connection.js
+++ b/lib/base/connection.js
@@ -87,6 +87,8 @@ class BaseConnection extends EventEmitter {
       },
     });
     this.serverCapabilityFlags = 0;
+    this._isMariaDB = false;
+    this._mariadbExtendedMetadata = false;
     this.authorized = false;
     this.sequenceId = 0;
     this.compressedSequenceId = 0;

--- a/lib/commands/client_handshake.js
+++ b/lib/commands/client_handshake.js
@@ -13,6 +13,7 @@
 const Command = require('./command.js');
 const Packets = require('../packets/index.js');
 const ClientConstants = require('../constants/client.js');
+const MariaDBClientConstants = require('../constants/mariadb_client.js');
 const CharsetToEncoding = require('../constants/charset_encodings.js');
 const auth41 = require('../auth_41.js');
 const { getAuthPlugin } = require('./auth_switch.js');
@@ -35,6 +36,7 @@ class ClientHandshake extends Command {
     super();
     this.handshake = null;
     this.clientFlags = clientFlags;
+    this.mariadbExtendedClientFlags = 0;
     this.authenticationFactor = 0;
   }
 
@@ -45,7 +47,8 @@ class ClientHandshake extends Command {
   sendSSLRequest(connection) {
     const sslRequest = new Packets.SSLRequest(
       this.clientFlags,
-      connection.config.charsetNumber
+      connection.config.charsetNumber,
+      this.mariadbExtendedClientFlags
     );
     connection.writePacket(sslRequest.toPacket());
   }
@@ -130,6 +133,7 @@ class ClientHandshake extends Command {
 
     const handshakeResponse = new Packets.HandshakeResponse({
       flags: this.clientFlags,
+      mariadbExtendedClientFlags: this.mariadbExtendedClientFlags,
       user: this.user,
       database: this.database,
       password: this.password,
@@ -265,6 +269,26 @@ class ClientHandshake extends Command {
     connection.serverCapabilityFlags = this.handshake.capabilityFlags;
     connection.serverEncoding = CharsetToEncoding[this.handshake.characterSet];
     connection.connectionId = this.handshake.connectionId;
+    // MariaDB needs a few protocol deviations, e.g. it rejects the JSON
+    // parameter type in COM_STMT_EXECUTE
+    connection._isMariaDB = /mariadb/i.test(this.handshake.serverVersion);
+    // If a MariaDB server offers extended column metadata, request it so
+    // MariaDB-specific column types (UUID, INET4, INET6, VECTOR and the JSON
+    // alias) can be identified. The server only reads the extended client
+    // capability bytes when the client leaves CLIENT_MYSQL (LONG_PASSWORD)
+    // unset, mirroring the server side of the negotiation.
+    if (
+      this.handshake.mariadbExtendedCapabilityFlags &
+      MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA
+    ) {
+      this.clientFlags &= ~ClientConstants.LONG_PASSWORD;
+      this.mariadbExtendedClientFlags |=
+        MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA;
+    }
+    connection._mariadbExtendedMetadata = Boolean(
+      this.mariadbExtendedClientFlags &
+      MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA
+    );
     const serverSSLSupport =
       this.handshake.capabilityFlags & ClientConstants.SSL;
     // multi factor authentication is enabled with the

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -51,7 +51,8 @@ class Execute extends Command {
       connection.config.charsetNumber,
       connection.config.timezone,
       this._executeOptions.attributes,
-      clientFlags
+      clientFlags,
+      connection._isMariaDB
     );
     //For reasons why this try-catch is here, please see
     // https://github.com/sidorares/node-mysql2/pull/689
@@ -77,7 +78,8 @@ class Execute extends Command {
     //  this.statement.columns[this._receivedFieldsCount] : new Packets.ColumnDefinition(packet);
     const field = new Packets.ColumnDefinition(
       packet,
-      connection.clientEncoding
+      connection.clientEncoding,
+      connection._mariadbExtendedMetadata
     );
     this._receivedFieldsCount++;
     this._fields[this._resultIndex].push(field);

--- a/lib/commands/prepare.js
+++ b/lib/commands/prepare.js
@@ -87,7 +87,11 @@ class Prepare extends Command {
       }
       return this.prepareDone(connection);
     }
-    const def = new Packets.ColumnDefinition(packet, connection.clientEncoding);
+    const def = new Packets.ColumnDefinition(
+      packet,
+      connection.clientEncoding,
+      connection._mariadbExtendedMetadata
+    );
     this.parameterDefinitions.push(def);
     if (this.parameterDefinitions.length === this.parameterCount) {
       return Prepare.prototype.parametersEOF;
@@ -99,7 +103,11 @@ class Prepare extends Command {
     if (packet.isEOF()) {
       return this.prepareDone(connection);
     }
-    const def = new Packets.ColumnDefinition(packet, connection.clientEncoding);
+    const def = new Packets.ColumnDefinition(
+      packet,
+      connection.clientEncoding,
+      connection._mariadbExtendedMetadata
+    );
     this.fields.push(def);
     if (this.fields.length === this.fieldCount) {
       return Prepare.prototype.fieldsEOF;

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -199,7 +199,8 @@ class Query extends Command {
     if (this._fields[this._resultIndex].length !== this._fieldCount) {
       const field = new Packets.ColumnDefinition(
         packet,
-        connection.clientEncoding
+        connection.clientEncoding,
+        connection._mariadbExtendedMetadata
       );
       this._fields[this._resultIndex].push(field);
       if (connection.config.debug) {

--- a/lib/constants/charset_encodings.js
+++ b/lib/constants/charset_encodings.js
@@ -3,7 +3,7 @@
 // see tools/generate-charset-mapping.js
 // basicalliy result of "SHOW COLLATION" query
 
-module.exports = [
+const encodings = [
   'utf8',
   'big5',
   'latin2',
@@ -315,3 +315,27 @@ module.exports = [
   'utf8',
   'utf8',
 ];
+
+// MariaDB NO PAD collations mirror their PAD SPACE counterparts:
+// collation id = PAD SPACE collation id + 1024
+const padSpaceLength = encodings.length;
+for (let id = 1025; id < 1024 + padSpaceLength; id++) {
+  encodings[id] = encodings[id - 1024];
+}
+
+// MariaDB UCA-14.0.0 (uca1400) collations use fixed 256-id blocks
+// per character set, each covering the PAD SPACE and NO PAD variants
+const uca1400Blocks = [
+  [2048, 'cesu8'], // utf8mb3
+  [2304, 'utf8'], // utf8mb4
+  [2560, 'ucs2'], // ucs2
+  [2816, 'utf16'], // utf16
+  [3072, 'utf32'], // utf32
+];
+for (const [start, encoding] of uca1400Blocks) {
+  for (let id = start; id < start + 256; id++) {
+    encodings[id] = encoding;
+  }
+}
+
+module.exports = encodings;

--- a/lib/constants/mariadb_client.js
+++ b/lib/constants/mariadb_client.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// MariaDB-specific extended capability flags.
+//
+// MariaDB servers (10.2+) do not set the CLIENT_MYSQL (LONG_PASSWORD)
+// capability and instead use 4 reserved bytes of the initial handshake packet
+// to advertise these flags. Clients answer with their own extended
+// capabilities in the last 4 reserved bytes of the handshake response
+// (the server only reads them when the client leaves CLIENT_MYSQL unset).
+//
+// The flags below are the lower 32 bits shifted down, i.e.
+// MARIADB_CLIENT_PROGRESS is documented as 1 << 32.
+// https://mariadb.com/docs/server/reference/clientserver-protocol/1-connecting/connection
+exports.MARIADB_CLIENT_PROGRESS = 0x00000001;
+exports.MARIADB_CLIENT_COM_MULTI = 0x00000002; /* deprecated */
+exports.MARIADB_CLIENT_STMT_BULK_OPERATIONS = 0x00000004;
+exports.MARIADB_CLIENT_EXTENDED_METADATA = 0x00000008;
+exports.MARIADB_CLIENT_CACHE_METADATA = 0x00000010;
+exports.MARIADB_CLIENT_BULK_UNIT_RESULTS = 0x00000020;

--- a/lib/packets/column_definition.js
+++ b/lib/packets/column_definition.js
@@ -19,7 +19,7 @@ const fields = ['catalog', 'schema', 'table', 'orgTable', 'name', 'orgName'];
 // see https://github.com/sidorares/node-mysql2/pull/137
 //
 class ColumnDefinition {
-  constructor(packet, clientEncoding) {
+  constructor(packet, clientEncoding, mariadbExtendedMetadata) {
     this._buf = packet.buffer;
     this._clientEncoding = clientEncoding;
     this._catalogLength = packet.readLengthCodedNumber();
@@ -41,6 +41,14 @@ class ColumnDefinition {
     this._orgNameLength = packet.readLengthCodedNumber();
     this._orgNameStart = packet.offset;
     packet.offset += this._orgNameLength;
+    // MariaDB-specific column types (UUID, INET4, INET6, VECTOR and the JSON
+    // alias) are sent as standard string/blob types on the wire; the real
+    // type is only visible here, in the extended metadata block negotiated
+    // via the MARIADB_CLIENT_EXTENDED_METADATA capability (parsed out of
+    // line and with prototype defaults to keep this hot constructor small)
+    if (mariadbExtendedMetadata) {
+      this._parseMariadbExtendedMetadata(packet);
+    }
     packet.skip(1); //  length of the following fields (always 0x0c)
     this.characterSet = packet.readInt16();
     this.encoding = CharsetToEncoding[this.characterSet];
@@ -55,6 +63,27 @@ class ColumnDefinition {
     this.type = this.columnType;
     this.flags = packet.readInt16();
     this.decimals = packet.readInt8();
+  }
+
+  _parseMariadbExtendedMetadata(packet) {
+    // length-encoded block of { int<1> id, string<lenenc> value } pairs
+    const extendedMetadataLength = packet.readLengthCodedNumber() || 0;
+    const extendedMetadataEnd = Math.min(
+      packet.offset + extendedMetadataLength,
+      packet.end
+    );
+    while (packet.offset < extendedMetadataEnd) {
+      const id = packet.readInt8();
+      const value = packet.readLengthCodedString('ascii');
+      if (id === 0) {
+        this.extendedTypeName = value; // e.g. 'uuid', 'inet4', 'inet6', 'point'
+      } else if (id === 1) {
+        this.extendedFormat = value; // e.g. 'json'
+      }
+    }
+    // a malformed entry could read past the block; resynchronise so the
+    // fixed column definition fields that follow parse from the right offset
+    packet.offset = extendedMetadataEnd;
   }
 
   inspect() {
@@ -287,5 +316,10 @@ addString('schema');
 addString('table');
 addString('orgTable');
 addString('orgName');
+
+// MariaDB extended metadata defaults; instances only carry own values when
+// the server actually tagged the column
+ColumnDefinition.prototype.extendedTypeName = undefined;
+ColumnDefinition.prototype.extendedFormat = undefined;
 
 module.exports = ColumnDefinition;

--- a/lib/packets/encode_parameter.js
+++ b/lib/packets/encode_parameter.js
@@ -48,6 +48,11 @@ function toParameter(value, encoding, timezone) {
           value = JSON.stringify(value);
           type = Types.JSON;
         } else if (Buffer.isBuffer(value)) {
+          // send buffers as BLOB so servers treat the value as binary data
+          // rather than a string in the connection charset (MariaDB converts
+          // string parameters when storing into binary columns such as
+          // VECTOR, corrupting the value)
+          type = Types.BLOB;
           length = Packet.lengthCodedNumberLength(value.length) + value.length;
           writer = Packet.prototype.writeLengthCodedBuffer;
         }

--- a/lib/packets/encode_parameter.js
+++ b/lib/packets/encode_parameter.js
@@ -11,7 +11,7 @@ function isJSON(value) {
   );
 }
 
-function toParameter(value, encoding, timezone) {
+function toParameter(value, encoding, timezone, jsonAsString) {
   let type = Types.VAR_STRING;
   let length;
   let writer = function (value) {
@@ -46,7 +46,12 @@ function toParameter(value, encoding, timezone) {
           };
         } else if (isJSON(value)) {
           value = JSON.stringify(value);
-          type = Types.JSON;
+          // MariaDB rejects the JSON parameter type with "Incorrect
+          // arguments to mysqld_stmt_execute"; it expects JSON values
+          // as plain strings
+          if (!jsonAsString) {
+            type = Types.JSON;
+          }
         } else if (Buffer.isBuffer(value)) {
           // send buffers as BLOB so servers treat the value as binary data
           // rather than a string in the connection charset (MariaDB converts

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -15,7 +15,8 @@ class Execute {
     charsetNumber,
     timezone,
     attributes,
-    clientFlags
+    clientFlags,
+    jsonAsString
   ) {
     this.id = id;
     this.parameters = parameters;
@@ -23,6 +24,7 @@ class Execute {
     this.timezone = timezone;
     this.attributes = attributes;
     this.clientFlags = clientFlags || 0;
+    this.jsonAsString = jsonAsString || false;
   }
 
   static fromPacket(packet, encoding) {
@@ -123,7 +125,7 @@ class Execute {
       const bindParams =
         numParams > 0
           ? this.parameters.map((v) =>
-              toParameter(v, this.encoding, this.timezone)
+              toParameter(v, this.encoding, this.timezone, this.jsonAsString)
             )
           : [];
       const attrParams = attrNames.map((name) =>

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -34,6 +34,7 @@ class Execute {
     while (i < packet.end - 1) {
       if (
         (packet.buffer[i + 1] === Types.VAR_STRING ||
+          packet.buffer[i + 1] === Types.BLOB ||
           packet.buffer[i + 1] === Types.NULL ||
           packet.buffer[i + 1] === Types.DOUBLE ||
           packet.buffer[i + 1] === Types.TINY ||
@@ -54,6 +55,7 @@ class Execute {
     for (let i = packet.offset + 1; i < packet.end - 1; i++) {
       if (
         (packet.buffer[i] === Types.VAR_STRING ||
+          packet.buffer[i] === Types.BLOB ||
           packet.buffer[i] === Types.NULL ||
           packet.buffer[i] === Types.DOUBLE ||
           packet.buffer[i] === Types.TINY ||
@@ -72,6 +74,8 @@ class Execute {
     for (let i = 0; i < types.length; i++) {
       if (types[i] === Types.VAR_STRING) {
         values.push(packet.readLengthCodedString(encoding));
+      } else if (types[i] === Types.BLOB) {
+        values.push(packet.readLengthCodedBuffer());
       } else if (types[i] === Types.DOUBLE) {
         values.push(packet.readDouble());
       } else if (types[i] === Types.TINY) {

--- a/lib/packets/handshake.js
+++ b/lib/packets/handshake.js
@@ -16,6 +16,7 @@ class Handshake {
     this.characterSet = args.characterSet;
     this.statusFlags = args.statusFlags;
     this.authPluginName = args.authPluginName;
+    this.mariadbExtendedCapabilityFlags = args.mariadbExtendedCapabilityFlags;
   }
 
   setScrambleData(cb) {
@@ -79,9 +80,20 @@ class Handshake {
         args.authPluginDataLength = 0;
         packet.skip(1);
       }
-      packet.skip(10);
+      packet.skip(6);
+      if (args.capabilityFlags & ClientConstants.LONG_PASSWORD) {
+        // CLIENT_MYSQL (LONG_PASSWORD) set: a MySQL server, the remaining
+        // 4 reserved bytes are filler
+        packet.skip(4);
+        args.mariadbExtendedCapabilityFlags = 0;
+      } else {
+        // MariaDB servers (10.2+) leave CLIENT_MYSQL unset and use these
+        // 4 bytes to advertise MariaDB-specific capabilities
+        args.mariadbExtendedCapabilityFlags = packet.readInt32();
+      }
     } else {
       args.capabilityFlags = capabilityFlagsBuffer.readUInt16LE(0);
+      args.mariadbExtendedCapabilityFlags = 0;
     }
 
     const isSecureConnection =

--- a/lib/packets/handshake_response.js
+++ b/lib/packets/handshake_response.js
@@ -16,6 +16,7 @@ class HandshakeResponse {
     this.authPluginData2 = handshake.authPluginData2;
     this.compress = handshake.compress;
     this.clientFlags = handshake.flags;
+    this.mariadbExtendedClientFlags = handshake.mariadbExtendedClientFlags || 0;
 
     // Accept pre-calculated authToken and authPluginName from caller
     // This allows the caller to optimize by using the server's preferred auth method
@@ -69,7 +70,10 @@ class HandshakeResponse {
     packet.writeInt32(this.clientFlags);
     packet.writeInt32(0); // max packet size. todo: move to config
     packet.writeInt8(this.charsetNumber);
-    packet.skip(23);
+    // the last 4 of the 23 reserved bytes carry the MariaDB extended client
+    // capabilities (zero when not negotiated, i.e. plain filler)
+    packet.skip(19);
+    packet.writeInt32(this.mariadbExtendedClientFlags);
     const encoding = this.encoding;
     packet.writeNullTerminatedString(this.user, encoding);
     let k;

--- a/lib/packets/ssl_request.js
+++ b/lib/packets/ssl_request.js
@@ -4,9 +4,10 @@ const ClientConstants = require('../constants/client');
 const Packet = require('../packets/packet');
 
 class SSLRequest {
-  constructor(flags, charset) {
+  constructor(flags, charset, mariadbExtendedClientFlags) {
     this.clientFlags = flags | ClientConstants.SSL;
     this.charset = charset;
+    this.mariadbExtendedClientFlags = mariadbExtendedClientFlags || 0;
   }
 
   toPacket() {
@@ -18,6 +19,10 @@ class SSLRequest {
     packet.writeInt32(this.clientFlags);
     packet.writeInt32(0); // max packet size. todo: move to config
     packet.writeInt8(this.charset);
+    // the last 4 of the 23 reserved bytes carry the MariaDB extended client
+    // capabilities (zero when not negotiated, i.e. plain filler)
+    packet.skip(19);
+    packet.writeInt32(this.mariadbExtendedClientFlags);
     return packet;
   }
 }

--- a/lib/parsers/binary_parser.js
+++ b/lib/parsers/binary_parser.js
@@ -21,6 +21,13 @@ function readCodeFor(field, config, options, fieldNum) {
   const timezone = options.timezone || config.timezone;
   const dateStrings = options.dateStrings || config.dateStrings;
   const unsigned = field.flags & FieldFlags.UNSIGNED;
+  // MariaDB sends JSON values as LONGTEXT; the JSON type is only visible in
+  // the extended metadata (MARIADB_CLIENT_EXTENDED_METADATA capability)
+  if (field.extendedFormat === 'json') {
+    return config.jsonStrings
+      ? `packet.readLengthCodedString(fields[${fieldNum}].encoding)`
+      : `JSON.parse(packet.readLengthCodedString(fields[${fieldNum}].encoding));`;
+  }
   switch (field.columnType) {
     case Types.TINY:
       return unsigned ? 'packet.readInt8();' : 'packet.readSInt8();';
@@ -92,6 +99,8 @@ function compile(fields, options, config) {
   function wrap(field, packet) {
     return {
       type: typeNames[field.columnType],
+      extendedTypeName: field.extendedTypeName,
+      extendedFormat: field.extendedFormat,
       length: field.columnLength,
       db: field.schema,
       table: field.table,

--- a/lib/parsers/parser_cache.js
+++ b/lib/parsers/parser_cache.js
@@ -20,6 +20,7 @@ function keyFromFields(type, fields, options, config) {
     options.timezone || config.timezone,
     Boolean(options.decimalNumbers),
     options.dateStrings,
+    Boolean(config.jsonStrings),
   ];
 
   for (let i = 0; i < fields.length; ++i) {
@@ -33,6 +34,8 @@ function keyFromFields(type, fields, options, config) {
       field.table,
       field.flags,
       field.characterSet,
+      field.extendedTypeName,
+      field.extendedFormat,
     ]);
   }
 

--- a/lib/parsers/static_binary_parser.js
+++ b/lib/parsers/static_binary_parser.js
@@ -22,6 +22,14 @@ function getBinaryParser(fields, _options, config) {
     const dateStrings = options.dateStrings || config.dateStrings;
     const unsigned = field.flags & FieldFlags.UNSIGNED;
 
+    // MariaDB sends JSON values as LONGTEXT; the JSON type is only visible in
+    // the extended metadata (MARIADB_CLIENT_EXTENDED_METADATA capability)
+    if (field.extendedFormat === 'json') {
+      return config.jsonStrings
+        ? packet.readLengthCodedString(field.encoding)
+        : JSON.parse(packet.readLengthCodedString(field.encoding));
+    }
+
     switch (field.columnType) {
       case Types.TINY:
         return unsigned ? packet.readInt8() : packet.readSInt8();
@@ -120,6 +128,8 @@ function getBinaryParser(fields, _options, config) {
               ? typeCast(
                   {
                     type: typeNames[field.columnType],
+                    extendedTypeName: field.extendedTypeName,
+                    extendedFormat: field.extendedFormat,
                     length: field.columnLength,
                     db: field.schema,
                     table: field.table,

--- a/lib/parsers/static_text_parser.js
+++ b/lib/parsers/static_text_parser.js
@@ -9,7 +9,15 @@ for (const t in Types) {
   typeNames[Types[t]] = t;
 }
 
-function readField({ packet, type, charset, encoding, config, options }) {
+function readField({
+  packet,
+  field,
+  type,
+  charset,
+  encoding,
+  config,
+  options,
+}) {
   const supportBigNumbers = Boolean(
     options.supportBigNumbers || config.supportBigNumbers
   );
@@ -18,6 +26,14 @@ function readField({ packet, type, charset, encoding, config, options }) {
   );
   const timezone = options.timezone || config.timezone;
   const dateStrings = options.dateStrings || config.dateStrings;
+
+  // MariaDB sends JSON values as LONGTEXT; the JSON type is only visible in
+  // the extended metadata (MARIADB_CLIENT_EXTENDED_METADATA capability)
+  if (field.extendedFormat === 'json') {
+    return config.jsonStrings
+      ? packet.readLengthCodedString(encoding)
+      : JSON.parse(packet.readLengthCodedString(encoding));
+  }
 
   switch (type) {
     case Types.TINY:
@@ -76,6 +92,8 @@ function readField({ packet, type, charset, encoding, config, options }) {
 function createTypecastField(field, packet) {
   return {
     type: typeNames[field.columnType],
+    extendedTypeName: field.extendedTypeName,
+    extendedFormat: field.extendedFormat,
     length: field.columnLength,
     db: field.schema,
     table: field.table,
@@ -110,6 +128,7 @@ function getTextParser(_fields, _options, config) {
         const next = () =>
           readField({
             packet,
+            field,
             type: field.columnType,
             encoding: field.encoding,
             charset: field.characterSet,

--- a/lib/parsers/text_parser.js
+++ b/lib/parsers/text_parser.js
@@ -11,7 +11,9 @@ for (const t in Types) {
   typeNames[Types[t]] = t;
 }
 
-function readCodeFor(type, charset, encodingExpr, config, options) {
+function readCodeFor(field, encodingExpr, config, options) {
+  const type = field.columnType;
+  const charset = field.characterSet;
   const supportBigNumbers = Boolean(
     options.supportBigNumbers || config.supportBigNumbers
   );
@@ -20,6 +22,14 @@ function readCodeFor(type, charset, encodingExpr, config, options) {
   );
   const timezone = options.timezone || config.timezone;
   const dateStrings = options.dateStrings || config.dateStrings;
+
+  // MariaDB sends JSON values as LONGTEXT; the JSON type is only visible in
+  // the extended metadata (MARIADB_CLIENT_EXTENDED_METADATA capability)
+  if (field.extendedFormat === 'json') {
+    return config.jsonStrings
+      ? `packet.readLengthCodedString(${encodingExpr})`
+      : `JSON.parse(packet.readLengthCodedString(${encodingExpr}))`;
+  }
 
   switch (type) {
     case Types.TINY:
@@ -88,6 +98,8 @@ function compile(fields, options, config) {
   function wrap(field, _this) {
     return {
       type: typeNames[field.columnType],
+      extendedTypeName: field.extendedTypeName,
+      extendedFormat: field.extendedFormat,
       length: field.columnLength,
       db: field.schema,
       table: field.table,
@@ -174,13 +186,7 @@ function compile(fields, options, config) {
       parserFn(`${lvalue} = packet.readLengthCodedBuffer();`);
     } else {
       const encodingExpr = `fields[${i}].encoding`;
-      const readCode = readCodeFor(
-        fields[i].columnType,
-        fields[i].characterSet,
-        encodingExpr,
-        config,
-        options
-      );
+      const readCode = readCodeFor(fields[i], encodingExpr, config, options);
       if (typeof options.typeCast === 'function') {
         parserFn(
           `${lvalue} = options.typeCast(this.wrap${i}, function() { return ${readCode} });`

--- a/test/common.test.mts
+++ b/test/common.test.mts
@@ -298,6 +298,8 @@ export const getMysqlVersion = async function (
     major,
     minor,
     patch,
+    version: serverVersion,
+    isMariaDB: /mariadb/i.test(serverVersion),
   };
 };
 

--- a/test/integration/connection/test-backpressure-result-streaming.test.mts
+++ b/test/integration/connection/test-backpressure-result-streaming.test.mts
@@ -12,9 +12,14 @@ await test('result event backpressure with pause/resume', async () => {
     skip('MySQL >= 8.0 required to use CTE');
   }
 
+  // MariaDB names the CTE depth limit max_recursive_iterations
+  const recursionVariable = mySqlVersion.isMariaDB
+    ? 'max_recursive_iterations'
+    : 'cte_max_recursion_depth';
+
   // the full result set will be over 6 MB uncompressed; about 490 KB with compression
   const largeQuery = `
-    SET SESSION cte_max_recursion_depth = 100000;
+    SET SESSION ${recursionVariable} = 100000;
     WITH RECURSIVE cte (n, s) AS (
       SELECT 1, 'this is just to cause more bytes transferred for each row'
       UNION ALL

--- a/test/integration/connection/test-binary-multiple-results.test.mts
+++ b/test/integration/connection/test-binary-multiple-results.test.mts
@@ -7,7 +7,7 @@ import process from 'node:process';
 // @ts-expect-error: no typings available
 import strict from 'assert-diff';
 import { describe, it, skip } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   skip('Skipping test for PlanetScale');
@@ -18,6 +18,7 @@ await describe('Binary Multiple Results', async () => {
   const mysql = createConnection({
     multipleStatements: true,
   });
+  const { isMariaDB } = await getMysqlVersion(mysql);
 
   mysql.query('CREATE TEMPORARY TABLE no_rows (test int)');
   mysql.query('CREATE TEMPORARY TABLE some_rows (test int)');
@@ -50,7 +51,8 @@ await describe('Binary Multiple Results', async () => {
       catalog: 'def',
       characterSet: 63,
       encoding: 'binary',
-      type: 8,
+      // MariaDB reports integer literals as LONG, MySQL as LONGLONG
+      type: isMariaDB ? 3 : 8,
       decimals: 0,
       flags: 129,
       name: '1',

--- a/test/integration/connection/test-custom-date-parameter.test.mts
+++ b/test/integration/connection/test-custom-date-parameter.test.mts
@@ -4,7 +4,7 @@ import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 await describe('Custom Date Parameter', async () => {
   const connection = createConnection({ timezone: 'Z' });
-  const { major } = await getMysqlVersion(connection);
+  const { major, isMariaDB } = await getMysqlVersion(connection);
 
   // @ts-expect-error: intentionally replacing global Date for testing
   // eslint-disable-next-line no-global-assign
@@ -34,7 +34,9 @@ await describe('Custom Date Parameter', async () => {
       );
     });
 
-    const expected = major < 8 ? 650073600 : '650073600.000000';
+    // MariaDB returns an integer for UNIX_TIMESTAMP(<datetime param>);
+    // MySQL 8+ returns a DECIMAL with microseconds
+    const expected = major < 8 || isMariaDB ? 650073600 : '650073600.000000';
     strict.equal(rows?.[0].t, expected);
   });
 

--- a/test/integration/connection/test-date-parameter.test.mts
+++ b/test/integration/connection/test-date-parameter.test.mts
@@ -4,7 +4,7 @@ import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 await describe('Date Parameter', async () => {
   const connection = createConnection({ timezone: 'Z' });
-  const { major } = await getMysqlVersion(connection);
+  const { major, isMariaDB } = await getMysqlVersion(connection);
 
   await it('should handle date parameter in execute', async () => {
     let rows: RowDataPacket[] | undefined;
@@ -23,7 +23,9 @@ await describe('Date Parameter', async () => {
       );
     });
 
-    const expected = major < 8 ? 631152000 : '631152000.000000';
+    // MariaDB returns an integer for UNIX_TIMESTAMP(<datetime param>);
+    // MySQL 8+ returns a DECIMAL with microseconds
+    const expected = major < 8 || isMariaDB ? 631152000 : '631152000.000000';
     strict.deepEqual(rows, [{ t: expected }]);
   });
 

--- a/test/integration/connection/test-datetime.test.mts
+++ b/test/integration/connection/test-datetime.test.mts
@@ -26,6 +26,16 @@ await describe('Datetime', async () => {
   const date = new Date('1990-01-01 08:15:11 UTC');
   const datetime = new Date('2010-12-10 14:12:09.019473');
 
+  // The "local TZ" assertions below compare FROM_UNIXTIME() results (built
+  // with the server's session time zone) against local Date getters, so the
+  // session time zone must match the client's local offset. CI containers run
+  // in UTC, but on developer machines the server and client zones can differ.
+  const offsetMinutes = -date.getTimezoneOffset();
+  const offsetAbs = Math.abs(offsetMinutes);
+  const localOffset = `${offsetMinutes < 0 ? '-' : '+'}${String(
+    Math.floor(offsetAbs / 60)
+  ).padStart(2, '0')}:${String(offsetAbs % 60).padStart(2, '0')}`;
+
   const date1 = new Date('2000-03-03 08:15:11 UTC');
   const date2 = '2010-12-10 14:12:09.019473';
   const date3 = null;
@@ -65,6 +75,7 @@ await describe('Datetime', async () => {
   connection.query(
     'CREATE TEMPORARY TABLE t (d1 DATE, d2 DATETIME(3), d3 DATETIME(6))'
   );
+  connection.query(`set time_zone = '${localOffset}'`);
   connection.query('INSERT INTO t set d1=?, d2=?, d3=?', [
     date,
     datetime,

--- a/test/integration/connection/test-execute-nocolumndef.test.mts
+++ b/test/integration/connection/test-execute-nocolumndef.test.mts
@@ -8,7 +8,7 @@ import process from 'node:process';
 // @ts-expect-error: no typings available
 import strict from 'assert-diff';
 import { describe, it, skip } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   skip('Skipping test for PlanetScale: different error codes');
@@ -194,8 +194,67 @@ const expectedFields = [
   },
 ];
 
+// MariaDB's EXPLAIN has no partitions/filtered columns and reports most
+// columns as VAR_STRING
+const mariadbTextField = (name: string, flags: number) => ({
+  catalog: 'def',
+  schema: '',
+  name,
+  orgName: '',
+  table: '',
+  orgTable: '',
+  characterSet: 224,
+  encoding: 'utf8',
+  type: 253,
+  flags,
+  decimals: 39,
+});
+
+const expectedRowsMariaDB = [
+  {
+    id: 1,
+    select_type: 'SIMPLE',
+    table: null,
+    type: null,
+    possible_keys: null,
+    key: null,
+    key_len: null,
+    ref: null,
+    rows: null,
+    Extra: 'No tables used',
+  },
+];
+
+const expectedFieldsMariaDB = [
+  {
+    catalog: 'def',
+    schema: '',
+    name: 'id',
+    orgName: '',
+    table: '',
+    orgTable: '',
+    characterSet: 63,
+    encoding: 'binary',
+    type: 8,
+    flags: 160,
+    decimals: 0,
+  },
+  mariadbTextField('select_type', 1),
+  mariadbTextField('table', 0),
+  mariadbTextField('type', 0),
+  mariadbTextField('possible_keys', 0),
+  mariadbTextField('key', 0),
+  mariadbTextField('key_len', 0),
+  mariadbTextField('ref', 0),
+  mariadbTextField('rows', 0),
+  mariadbTextField('Extra', 1),
+];
+
 await describe('Execute No Column Definition', async () => {
   const connection = createConnection();
+  const { isMariaDB } = await getMysqlVersion(connection);
+  const rowsExpectation = isMariaDB ? expectedRowsMariaDB : expectedRows;
+  const fieldsExpectation = isMariaDB ? expectedFieldsMariaDB : expectedFields;
 
   await it('should handle explain with no column definitions', async () => {
     const [rows, fields] = await new Promise<[RowDataPacket[], FieldPacket[]]>(
@@ -208,7 +267,7 @@ await describe('Execute No Column Definition', async () => {
       }
     );
 
-    strict.deepEqual(rows, expectedRows);
+    strict.deepEqual(rows, rowsExpectation);
     fields.forEach((f: FieldPacket, index: number) => {
       // @ts-expect-error: TODO: implement typings
       const fi = f.inspect();
@@ -217,9 +276,9 @@ await describe('Execute No Column Definition', async () => {
 
       strict.deepEqual(
         Object.keys(fi).sort(),
-        Object.keys(expectedFields[index]).sort()
+        Object.keys(fieldsExpectation[index]).sort()
       );
-      strict.deepEqual(expectedFields[index], fi);
+      strict.deepEqual(fieldsExpectation[index], fi);
     });
   });
 

--- a/test/integration/connection/test-insert-json.test.mts
+++ b/test/integration/connection/test-insert-json.test.mts
@@ -5,12 +5,13 @@
 
 import type { RowDataPacket } from '../../../index.js';
 import { describe, it, strict } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 type JsonRow = RowDataPacket & { data: { k: string } };
 
 await describe('Insert JSON', async () => {
   const connection = createConnection();
+  const { isMariaDB } = await getMysqlVersion(connection);
 
   connection.query('CREATE TEMPORARY TABLE json_test (data JSON)');
 
@@ -50,8 +51,16 @@ await describe('Insert JSON', async () => {
       );
     });
 
-    strict.equal(result.errorCode, 'ER_INVALID_JSON_TEXT');
-    strict.equal(result.errorNum, 3140);
+    if (isMariaDB) {
+      // MariaDB enforces JSON validity via a CHECK constraint and reports
+      // errno 4025 (its ER_CONSTRAINT_FAILED); mysql2's error-name table
+      // follows MySQL, where 4025 has a different meaning, so only the
+      // number is asserted here
+      strict.equal(result.errorNum, 4025);
+    } else {
+      strict.equal(result.errorCode, 'ER_INVALID_JSON_TEXT');
+      strict.equal(result.errorNum, 3140);
+    }
     strict.equal(result.res?.[0].data.k, 'v');
   });
 

--- a/test/integration/connection/test-invalid-date-result.test.mts
+++ b/test/integration/connection/test-invalid-date-result.test.mts
@@ -24,8 +24,7 @@ await describe('Invalid Date Result', async () => {
   await it('should handle invalid date values', async () => {
     const modeRows = await new Promise<SqlModeRow[]>((resolve, reject) => {
       connection.query<SqlModeRow[]>(
-        'SELECT variable_value as value FROM performance_schema.session_variables where variable_name = ?',
-        ['sql_mode'],
+        'SELECT @@sql_mode as value',
         (err, _rows) => (err ? reject(err) : resolve(_rows))
       );
     });

--- a/test/integration/connection/test-mariadb-extended-metadata.test.mts
+++ b/test/integration/connection/test-mariadb-extended-metadata.test.mts
@@ -1,7 +1,7 @@
 import type { FieldPacket, RowDataPacket } from '../../../index.js';
 import { Buffer } from 'node:buffer';
 import { describe, it, skip, strict } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 type TypesRow = RowDataPacket & {
   u: string;
@@ -24,17 +24,11 @@ const table = 'mariadb_extended_metadata_test';
 
 const connection = createConnection().promise();
 
-const [versionRows] = await connection.query<
-  (RowDataPacket & { version: string })[]
->('SELECT VERSION() AS `version`');
-const version = versionRows[0].version;
-const match = version.match(/^(\d+)\.(\d+)/);
-const major = Number(match?.[1]);
-const minor = Number(match?.[2]);
+const { major, minor, version, isMariaDB } = await getMysqlVersion(connection);
 
 // VECTOR requires MariaDB 11.7+; UUID, INET4, INET6 and the extended
 // metadata capability are older (MariaDB 10.5–10.10)
-if (!/mariadb/i.test(version) || major < 11 || (major === 11 && minor < 7)) {
+if (!isMariaDB || major < 11 || (major === 11 && minor < 7)) {
   await connection.end();
   skip(
     `Skipping the test, required server is MariaDB 11.7 and above, actual server is ${version}`

--- a/test/integration/connection/test-mariadb-extended-metadata.test.mts
+++ b/test/integration/connection/test-mariadb-extended-metadata.test.mts
@@ -1,0 +1,140 @@
+import type { FieldPacket, RowDataPacket } from '../../../index.js';
+import { Buffer } from 'node:buffer';
+import { describe, it, skip, strict } from 'poku';
+import { createConnection } from '../../common.test.mjs';
+
+type TypesRow = RowDataPacket & {
+  u: string;
+  i4: string;
+  i6: string;
+  v: Buffer;
+  j: { tag: string; nums: number[] };
+};
+
+const uuid = '123e4567-e89b-12d3-a456-426614174000';
+const inet4 = '203.0.113.7';
+const inet6 = '2001:db8::1';
+const vectorFloats = [1.5, -2.25, 3.75];
+const json = { tag: 'x', nums: [1, 2, 3] };
+
+const vector = Buffer.alloc(vectorFloats.length * 4);
+vectorFloats.forEach((value, i) => vector.writeFloatLE(value, i * 4));
+
+const table = 'mariadb_extended_metadata_test';
+
+const connection = createConnection().promise();
+
+const [versionRows] = await connection.query<
+  (RowDataPacket & { version: string })[]
+>('SELECT VERSION() AS `version`');
+const version = versionRows[0].version;
+const match = version.match(/^(\d+)\.(\d+)/);
+const major = Number(match?.[1]);
+const minor = Number(match?.[2]);
+
+// VECTOR requires MariaDB 11.7+; UUID, INET4, INET6 and the extended
+// metadata capability are older (MariaDB 10.5–10.10)
+if (!/mariadb/i.test(version) || major < 11 || (major === 11 && minor < 7)) {
+  await connection.end();
+  skip(
+    `Skipping the test, required server is MariaDB 11.7 and above, actual server is ${version}`
+  );
+}
+
+await describe('MariaDB extended type metadata', async () => {
+  await connection.query(`DROP TABLE IF EXISTS \`${table}\``);
+  await connection.query(
+    `CREATE TABLE \`${table}\` (u UUID, i4 INET4, i6 INET6, v VECTOR(3) NOT NULL, j JSON)`
+  );
+  await connection.execute(
+    `INSERT INTO \`${table}\` (u, i4, i6, v, j) VALUES (?, ?, ?, ?, ?)`,
+    [uuid, inet4, inet6, vector, JSON.stringify(json)]
+  );
+
+  const checkFields = (fields: FieldPacket[]) => {
+    const byName = new Map(fields.map((f) => [f.name, f]));
+    strict.equal(byName.get('u')?.extendedTypeName, 'uuid');
+    strict.equal(byName.get('i4')?.extendedTypeName, 'inet4');
+    strict.equal(byName.get('i6')?.extendedTypeName, 'inet6');
+    strict.equal(byName.get('j')?.extendedFormat, 'json');
+    strict.equal(byName.get('v')?.extendedTypeName, undefined);
+  };
+
+  const checkRow = (row: TypesRow) => {
+    strict.equal(row.u, uuid);
+    strict.equal(row.i4, inet4);
+    strict.equal(row.i6, inet6);
+    strict.ok(Buffer.isBuffer(row.v));
+    strict.deepEqual(
+      vectorFloats.map((_, i) => row.v.readFloatLE(i * 4)),
+      vectorFloats
+    );
+    strict.deepEqual(row.j, json);
+  };
+
+  await it('query: should expose extended metadata and parse values', async () => {
+    const [rows, fields] = await connection.query<TypesRow[]>(
+      `SELECT * FROM \`${table}\``
+    );
+    checkFields(fields);
+    checkRow(rows[0]);
+  });
+
+  await it('execute: should expose extended metadata and parse values', async () => {
+    const [rows, fields] = await connection.execute<TypesRow[]>(
+      `SELECT * FROM \`${table}\``
+    );
+    checkFields(fields);
+    checkRow(rows[0]);
+  });
+
+  await it('execute: should accept a JS object for a JSON column', async () => {
+    await connection.execute(`DELETE FROM \`${table}\` WHERE i4 IS NULL`);
+    await connection.execute(`INSERT INTO \`${table}\` (v, j) VALUES (?, ?)`, [
+      vector,
+      json,
+    ]);
+    const [rows] = await connection.execute<TypesRow[]>(
+      `SELECT j FROM \`${table}\` WHERE i4 IS NULL`
+    );
+    strict.deepEqual(rows[0].j, json);
+    await connection.execute(`DELETE FROM \`${table}\` WHERE i4 IS NULL`);
+  });
+
+  await it('typeCast: should receive extended metadata', async () => {
+    const seen = new Map<string, [string | undefined, string | undefined]>();
+    await connection.query({
+      sql: `SELECT * FROM \`${table}\``,
+      typeCast: (field, next) => {
+        seen.set(field.name, [field.extendedTypeName, field.extendedFormat]);
+        return next();
+      },
+    });
+    strict.deepEqual(seen.get('u'), ['uuid', undefined]);
+    strict.deepEqual(seen.get('i4'), ['inet4', undefined]);
+    strict.deepEqual(seen.get('i6'), ['inet6', undefined]);
+    strict.deepEqual(seen.get('j'), [undefined, 'json']);
+  });
+});
+
+await describe('MariaDB extended type metadata: jsonStrings', async () => {
+  const jsonStringsConnection = createConnection({
+    jsonStrings: true,
+  }).promise();
+
+  await it('should return JSON columns as strings', async () => {
+    const [rows] = await jsonStringsConnection.query<TypesRow[]>(
+      `SELECT j FROM \`${table}\``
+    );
+    strict.equal(typeof rows[0].j, 'string');
+    const [executeRows] = await jsonStringsConnection.execute<TypesRow[]>(
+      `SELECT j FROM \`${table}\``
+    );
+    strict.equal(typeof executeRows[0].j, 'string');
+  });
+
+  await jsonStringsConnection.end();
+});
+
+await connection.query(`DROP TABLE IF EXISTS \`${table}\``);
+await connection.end();

--- a/test/integration/connection/test-multiple-results.test.mts
+++ b/test/integration/connection/test-multiple-results.test.mts
@@ -7,7 +7,7 @@ import process from 'node:process';
 // @ts-expect-error: no typings available
 import strict from 'assert-diff';
 import { describe, it, skip } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
   skip('Skipping test for PlanetScale');
@@ -18,6 +18,7 @@ await describe('Multiple Results', async () => {
   const mysql = createConnection({
     multipleStatements: true,
   });
+  const { isMariaDB } = await getMysqlVersion(mysql);
   mysql.query('CREATE TEMPORARY TABLE no_rows (test int)');
   mysql.query('CREATE TEMPORARY TABLE some_rows (test int)');
   mysql.query('INSERT INTO some_rows values(0)');
@@ -48,7 +49,8 @@ await describe('Multiple Results', async () => {
       catalog: 'def',
       characterSet: 63,
       encoding: 'binary',
-      type: 8,
+      // MariaDB reports integer literals as LONG, MySQL as LONGLONG
+      type: isMariaDB ? 3 : 8,
       decimals: 0,
       flags: 129,
       name: '1',

--- a/test/integration/connection/test-reset-connection.test.mts
+++ b/test/integration/connection/test-reset-connection.test.mts
@@ -175,6 +175,7 @@ await describe('Reset Connection', async () => {
     const mysql = await import('../../../promise.js');
     const connection = await mysql.createConnection({
       host: process.env.MYSQL_HOST || 'localhost',
+      port: Number(process.env.MYSQL_PORT) || 3306,
       user: process.env.MYSQL_USER || 'root',
       password: process.env.MYSQL_PASSWORD || '',
       database: process.env.MYSQL_DATABASE || 'test',

--- a/test/integration/connection/test-vector.test.mts
+++ b/test/integration/connection/test-vector.test.mts
@@ -17,16 +17,12 @@ await describe(async () => {
   const connection = createConnection().promise();
   const mySqlVersion = await getMysqlVersion(connection);
 
-  const [versionRows] = await connection.query<
-    (RowDataPacket & { version: string })[]
-  >('SELECT VERSION() AS `version`');
-
   // MariaDB vectors use a different wire representation and functions
   // (VEC_FromText instead of TO_VECTOR); they are covered by
   // test-mariadb-extended-metadata.test.mts
-  if (mySqlVersion.major < 9 || /mariadb/i.test(versionRows[0].version)) {
+  if (mySqlVersion.major < 9 || mySqlVersion.isMariaDB) {
     console.log(
-      `Skipping the test, required mysql version is 9 and above, actual version is ${versionRows[0].version}`
+      `Skipping the test, required mysql version is 9 and above, actual version is ${mySqlVersion.version}`
     );
     await connection.end();
     return;

--- a/test/integration/connection/test-vector.test.mts
+++ b/test/integration/connection/test-vector.test.mts
@@ -17,9 +17,16 @@ await describe(async () => {
   const connection = createConnection().promise();
   const mySqlVersion = await getMysqlVersion(connection);
 
-  if (mySqlVersion.major < 9) {
+  const [versionRows] = await connection.query<
+    (RowDataPacket & { version: string })[]
+  >('SELECT VERSION() AS `version`');
+
+  // MariaDB vectors use a different wire representation and functions
+  // (VEC_FromText instead of TO_VECTOR); they are covered by
+  // test-mariadb-extended-metadata.test.mts
+  if (mySqlVersion.major < 9 || /mariadb/i.test(versionRows[0].version)) {
     console.log(
-      `Skipping the test, required mysql version is 9 and above, actual version is ${mySqlVersion.major}`
+      `Skipping the test, required mysql version is 9 and above, actual version is ${versionRows[0].version}`
     );
     await connection.end();
     return;

--- a/test/integration/parsers/json-parse.test.mts
+++ b/test/integration/parsers/json-parse.test.mts
@@ -1,15 +1,22 @@
 import type { RowDataPacket } from '../../../index.js';
 import { describe, it, strict } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 type JsonRow = RowDataPacket & { json_result: { test: boolean } };
 
 await describe('JSON Parser', async () => {
   const connection = createConnection().promise();
+  const { isMariaDB } = await getMysqlVersion(connection);
+
+  // MariaDB has no CAST(... AS JSON); JSON_EXTRACT also produces a
+  // JSON-typed result there
+  const jsonExpression = isMariaDB
+    ? `JSON_EXTRACT('{"test": true}', '$')`
+    : `CAST('{"test": true}' AS JSON)`;
 
   await it(async () => {
     const [result] = await connection.query<JsonRow[]>(
-      `SELECT CAST('{"test": true}' AS JSON) AS json_result`
+      `SELECT ${jsonExpression} AS json_result`
     );
 
     strict.deepStrictEqual(
@@ -21,7 +28,7 @@ await describe('JSON Parser', async () => {
 
   await it(async () => {
     const [result] = await connection.execute<JsonRow[]>(
-      `SELECT CAST('{"test": true}' AS JSON) AS json_result`
+      `SELECT ${jsonExpression} AS json_result`
     );
 
     strict.deepStrictEqual(

--- a/test/integration/parsers/json-string.test.mts
+++ b/test/integration/parsers/json-string.test.mts
@@ -1,6 +1,6 @@
 import type { RowDataPacket } from '../../../index.js';
 import { describe, it, strict } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 type JsonRow = RowDataPacket & { json_result: string };
 
@@ -8,10 +8,17 @@ await describe('JSON String', async () => {
   const connection = createConnection({
     jsonStrings: true,
   }).promise();
+  const { isMariaDB } = await getMysqlVersion(connection);
+
+  // MariaDB has no CAST(... AS JSON); JSON_EXTRACT also produces a
+  // JSON-typed result there
+  const jsonExpression = isMariaDB
+    ? `JSON_EXTRACT('{"test": true}', '$')`
+    : `CAST('{"test": true}' AS JSON)`;
 
   await it(async () => {
     const [result] = await connection.query<JsonRow[]>(
-      `SELECT CAST('{"test": true}' AS JSON) AS json_result`
+      `SELECT ${jsonExpression} AS json_result`
     );
 
     strict.deepStrictEqual(
@@ -23,7 +30,7 @@ await describe('JSON String', async () => {
 
   await it(async () => {
     const [result] = await connection.execute<JsonRow[]>(
-      `SELECT CAST('{"test": true}' AS JSON) AS json_result`
+      `SELECT ${jsonExpression} AS json_result`
     );
 
     strict.deepStrictEqual(

--- a/test/integration/pool/test-pool-reset-on-release.test.mts
+++ b/test/integration/pool/test-pool-reset-on-release.test.mts
@@ -178,6 +178,7 @@ await describe('Pool Reset On Release', async () => {
     const mysql = await import('../../../promise.js');
     const pool = mysql.createPool({
       host: process.env.MYSQL_HOST || 'localhost',
+      port: Number(process.env.MYSQL_PORT) || 3306,
       user: process.env.MYSQL_USER || 'root',
       password: process.env.MYSQL_PASSWORD || '',
       database: process.env.MYSQL_DATABASE || 'test',

--- a/test/integration/regressions/test-#1019.test.mts
+++ b/test/integration/regressions/test-#1019.test.mts
@@ -13,8 +13,7 @@ await describe('Regression #1019 — readDateTime zero date with numeric timezon
 
     const modeRows = await new Promise<SqlModeRow[]>((resolve, reject) => {
       connection.query<SqlModeRow[]>(
-        'SELECT variable_value as value FROM performance_schema.session_variables where variable_name = ?',
-        ['sql_mode'],
+        'SELECT @@sql_mode as value',
         (err, rows) => (err ? reject(err) : resolve(rows))
       );
     });
@@ -69,8 +68,7 @@ await describe('Regression #1019 — readDateTime zero date with numeric timezon
 
     const modeRows = await new Promise<SqlModeRow[]>((resolve, reject) => {
       connection.query<SqlModeRow[]>(
-        'SELECT variable_value as value FROM performance_schema.session_variables where variable_name = ?',
-        ['sql_mode'],
+        'SELECT @@sql_mode as value',
         (err, rows) => (err ? reject(err) : resolve(rows))
       );
     });

--- a/test/unit/constants/test-mariadb-collation-encodings.test.mts
+++ b/test/unit/constants/test-mariadb-collation-encodings.test.mts
@@ -1,0 +1,29 @@
+import { describe, it, strict } from 'poku';
+import CharsetToEncoding from '../../../lib/constants/charset_encodings.js';
+
+describe('MariaDB collation id encodings', () => {
+  it('should map NO PAD collations like their PAD SPACE counterparts', () => {
+    // utf8mb4_nopad_bin = utf8mb4_bin (46) + 1024
+    strict.equal(CharsetToEncoding[1070], CharsetToEncoding[46]);
+    // latin1_swedish_nopad_ci = latin1_swedish_ci (8) + 1024
+    strict.equal(CharsetToEncoding[1032], CharsetToEncoding[8]);
+    // big5_chinese_nopad_ci = big5_chinese_ci (1) + 1024
+    strict.equal(CharsetToEncoding[1025], CharsetToEncoding[1]);
+  });
+
+  it('should map UCA-14.0.0 collation blocks to their character sets', () => {
+    strict.equal(CharsetToEncoding[2048], 'cesu8'); // utf8mb3_uca1400_ai_ci
+    strict.equal(CharsetToEncoding[2304], 'utf8'); // utf8mb4_uca1400_ai_ci
+    strict.equal(CharsetToEncoding[2559], 'utf8'); // utf8mb4 block end
+    strict.equal(CharsetToEncoding[2560], 'ucs2'); // ucs2_uca1400_ai_ci
+    strict.equal(CharsetToEncoding[2816], 'utf16'); // utf16_uca1400_ai_ci
+    strict.equal(CharsetToEncoding[3072], 'utf32'); // utf32_uca1400_ai_ci
+  });
+
+  it('should keep MySQL collation ids unchanged', () => {
+    strict.equal(CharsetToEncoding[33], 'cesu8'); // utf8_general_ci
+    strict.equal(CharsetToEncoding[45], 'utf8'); // utf8mb4_general_ci
+    strict.equal(CharsetToEncoding[63], 'binary');
+    strict.equal(CharsetToEncoding[224], 'utf8'); // utf8mb4_unicode_ci
+  });
+});

--- a/test/unit/packets/test-execute-blob-params.test.mts
+++ b/test/unit/packets/test-execute-blob-params.test.mts
@@ -1,0 +1,37 @@
+import { Buffer } from 'node:buffer';
+import { describe, it, strict } from 'poku';
+import Execute from '../../../lib/packets/execute.js';
+import Packet from '../../../lib/packets/packet.js';
+
+const reparse = (execute: InstanceType<typeof Execute>) => {
+  const buf = execute.toPacket().buffer;
+  const packet = new Packet(0, buf, 0, buf.length);
+  packet.readInt8(); // the COM_STMT_EXECUTE byte, consumed by the dispatcher
+  return Execute.fromPacket(packet, 'utf8');
+};
+
+describe('Execute packet: parameter encoding round-trip', () => {
+  it('should send and decode Buffer parameters as BLOB', () => {
+    const blob = Buffer.from([0x80, 0x00, 0xff, 0x42]);
+    const execute = new Execute(1, ['text', blob, null], 224, 'local');
+    const parsed = reparse(execute);
+    strict.equal(parsed.stmtId, 1);
+    strict.equal(parsed.values[0], 'text');
+    strict.ok(Buffer.isBuffer(parsed.values[1]));
+    strict.deepEqual(parsed.values[1], blob);
+    strict.equal(parsed.values[2], null);
+  });
+
+  it('should send JSON objects as strings when jsonAsString is set', () => {
+    const value = { a: [1, 'x'] };
+    // MariaDB rejects the JSON parameter type; jsonAsString keeps the
+    // parameter a VAR_STRING
+    const asString = new Execute(2, [value], 224, 'local', undefined, 0, true);
+    const parsed = reparse(asString);
+    strict.equal(parsed.values[0], JSON.stringify(value));
+
+    // without jsonAsString the parameter keeps the JSON type
+    const asJson = new Execute(2, [value], 224, 'local');
+    strict.deepEqual(reparse(asJson).values[0], value);
+  });
+});

--- a/test/unit/packets/test-mariadb-extended-metadata.test.mts
+++ b/test/unit/packets/test-mariadb-extended-metadata.test.mts
@@ -1,0 +1,237 @@
+import { Buffer } from 'node:buffer';
+import { describe, it, strict } from 'poku';
+import ClientConstants from '../../../lib/constants/client.js';
+import MariaDBClientConstants from '../../../lib/constants/mariadb_client.js';
+import ColumnDefinition from '../../../lib/packets/column_definition.js';
+import HandshakeResponse from '../../../lib/packets/handshake_response.js';
+import Handshake from '../../../lib/packets/handshake.js';
+import Packet from '../../../lib/packets/packet.js';
+import SSLRequest from '../../../lib/packets/ssl_request.js';
+
+const lenenc = (value: string | Buffer): Buffer => {
+  const buf = Buffer.isBuffer(value) ? value : Buffer.from(value, 'utf8');
+  strict.ok(buf.length < 251);
+  return Buffer.concat([Buffer.from([buf.length]), buf]);
+};
+
+const asPacket = (payload: Buffer): typeof Packet.prototype => {
+  const buf = Buffer.concat([Buffer.alloc(4), payload]);
+  return new Packet(0, buf, 0, buf.length);
+};
+
+const buildHandshakePayload = (
+  serverCapabilities: number,
+  mariadbExtendedCapabilities: number
+): Buffer => {
+  const capabilities = Buffer.alloc(4);
+  capabilities.writeUInt32LE(serverCapabilities >>> 0, 0);
+  const extendedCapabilities = Buffer.alloc(4);
+  extendedCapabilities.writeUInt32LE(mariadbExtendedCapabilities >>> 0, 0);
+  return Buffer.concat([
+    Buffer.from([10]), // protocol version
+    Buffer.from('11.8.2-MariaDB\0', 'latin1'), // server version
+    Buffer.from([1, 0, 0, 0]), // connection id
+    Buffer.alloc(8, 0x2a), // auth plugin data part 1
+    Buffer.from([0]), // filler
+    capabilities.subarray(0, 2), // capabilities (lower 2 bytes)
+    Buffer.from([45]), // server default collation
+    Buffer.from([2, 0]), // status flags
+    capabilities.subarray(2, 4), // capabilities (upper 2 bytes)
+    Buffer.from([21]), // length of auth plugin data
+    Buffer.alloc(6, 0), // filler
+    extendedCapabilities, // MariaDB extended capabilities (or filler)
+    Buffer.alloc(13, 0x2b), // auth plugin data part 2
+    Buffer.from('mysql_native_password\0', 'latin1'),
+  ]);
+};
+
+const mariadbServerCapabilities =
+  ClientConstants.PROTOCOL_41 |
+  ClientConstants.SECURE_CONNECTION |
+  ClientConstants.PLUGIN_AUTH;
+
+describe('Handshake packet: MariaDB extended capabilities', () => {
+  it('should parse extended capabilities when CLIENT_MYSQL is unset', () => {
+    const handshake = Handshake.fromPacket(
+      asPacket(
+        buildHandshakePayload(
+          mariadbServerCapabilities,
+          MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA |
+            MariaDBClientConstants.MARIADB_CLIENT_PROGRESS
+        )
+      )
+    );
+    strict.equal(
+      handshake.mariadbExtendedCapabilityFlags,
+      MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA |
+        MariaDBClientConstants.MARIADB_CLIENT_PROGRESS
+    );
+    strict.equal(handshake.authPluginName, 'mysql_native_password');
+  });
+
+  it('should treat the extended capability bytes as filler when CLIENT_MYSQL is set', () => {
+    const handshake = Handshake.fromPacket(
+      asPacket(
+        buildHandshakePayload(
+          mariadbServerCapabilities | ClientConstants.LONG_PASSWORD,
+          MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA
+        )
+      )
+    );
+    strict.equal(handshake.mariadbExtendedCapabilityFlags, 0);
+    strict.equal(handshake.authPluginName, 'mysql_native_password');
+  });
+});
+
+describe('HandshakeResponse / SSLRequest: MariaDB extended client capabilities', () => {
+  const baseConfig = {
+    user: 'testuser',
+    database: 'testdb',
+    password: 'testpass',
+    flags:
+      ClientConstants.PROTOCOL_41 |
+      ClientConstants.SECURE_CONNECTION |
+      ClientConstants.CONNECT_WITH_DB,
+    charsetNumber: 224,
+    authPluginData1: Buffer.alloc(8),
+    authPluginData2: Buffer.alloc(12),
+  };
+  // 4 header + 4 client flags + 4 max packet size + 1 charset + 19 filler
+  const extendedFlagsOffset = 4 + 4 + 4 + 1 + 19;
+
+  it('should write extended client capabilities into the reserved bytes', () => {
+    const response = new HandshakeResponse({
+      ...baseConfig,
+      mariadbExtendedClientFlags:
+        MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA,
+    });
+    const buffer = response.toPacket().buffer;
+    strict.equal(
+      buffer.readUInt32LE(extendedFlagsOffset),
+      MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA
+    );
+  });
+
+  it('should leave the reserved bytes zeroed by default', () => {
+    const response = new HandshakeResponse(baseConfig);
+    const buffer = response.toPacket().buffer;
+    strict.equal(buffer.readUInt32LE(extendedFlagsOffset), 0);
+  });
+
+  it('should write extended client capabilities into the SSL request', () => {
+    const sslRequest = new SSLRequest(
+      baseConfig.flags,
+      baseConfig.charsetNumber,
+      MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA
+    );
+    const buffer = sslRequest.toPacket().buffer;
+    strict.equal(
+      buffer.readUInt32LE(extendedFlagsOffset),
+      MariaDBClientConstants.MARIADB_CLIENT_EXTENDED_METADATA
+    );
+    strict.equal(buffer.length, 36);
+  });
+});
+
+describe('ColumnDefinition: MariaDB extended metadata', () => {
+  const buildColumnDefinitionPayload = (extendedMetadata?: Buffer): Buffer => {
+    const fixed = Buffer.alloc(13);
+    fixed[0] = 0x0c; // length of fixed fields
+    fixed.writeUInt16LE(224, 1); // character set (utf8mb4)
+    fixed.writeUInt32LE(144, 3); // column length
+    fixed[7] = 0xfe; // column type (STRING)
+    fixed.writeUInt16LE(128, 8); // flags (BINARY)
+    fixed[10] = 0; // decimals
+    return Buffer.concat([
+      lenenc('def'),
+      lenenc('test'),
+      lenenc('t'),
+      lenenc('t'),
+      lenenc('u'),
+      lenenc('u'),
+      ...(extendedMetadata ? [lenenc(extendedMetadata)] : []),
+      fixed,
+    ]);
+  };
+
+  it('should parse extended type and format', () => {
+    const extended = Buffer.concat([
+      Buffer.from([0]), // data type: type name
+      lenenc('uuid'),
+      Buffer.from([1]), // data type: format
+      lenenc('json'),
+    ]);
+    const column = new ColumnDefinition(
+      asPacket(buildColumnDefinitionPayload(extended)),
+      'utf8',
+      true
+    );
+    strict.equal(column.extendedTypeName, 'uuid');
+    strict.equal(column.extendedFormat, 'json');
+    strict.equal(column.name, 'u');
+    strict.equal(column.columnType, 0xfe);
+    strict.equal(column.characterSet, 224);
+    strict.equal(column.columnLength, 144);
+    strict.equal(column.flags, 128);
+  });
+
+  it('should skip unknown extended metadata entries', () => {
+    const extended = Buffer.concat([
+      Buffer.from([7]), // unknown data type
+      lenenc('future'),
+      Buffer.from([0]),
+      lenenc('inet6'),
+    ]);
+    const column = new ColumnDefinition(
+      asPacket(buildColumnDefinitionPayload(extended)),
+      'utf8',
+      true
+    );
+    strict.equal(column.extendedTypeName, 'inet6');
+    strict.equal(column.extendedFormat, undefined);
+    strict.equal(column.columnType, 0xfe);
+  });
+
+  it('should resynchronise after a malformed extended metadata block', () => {
+    // the value claims 200 bytes but the block only contains 2
+    const extended = Buffer.concat([
+      Buffer.from([0]),
+      Buffer.from([200]),
+      Buffer.from('ab'),
+    ]);
+    const column = new ColumnDefinition(
+      asPacket(buildColumnDefinitionPayload(extended)),
+      'utf8',
+      true
+    );
+    strict.equal(column.name, 'u');
+    strict.equal(column.columnType, 0xfe);
+    strict.equal(column.characterSet, 224);
+    strict.equal(column.columnLength, 144);
+    strict.equal(column.flags, 128);
+  });
+
+  it('should parse an empty extended metadata block', () => {
+    const column = new ColumnDefinition(
+      asPacket(buildColumnDefinitionPayload(Buffer.alloc(0))),
+      'utf8',
+      true
+    );
+    strict.equal(column.extendedTypeName, undefined);
+    strict.equal(column.extendedFormat, undefined);
+    strict.equal(column.name, 'u');
+    strict.equal(column.columnLength, 144);
+  });
+
+  it('should not consume extended metadata when not negotiated', () => {
+    const column = new ColumnDefinition(
+      asPacket(buildColumnDefinitionPayload()),
+      'utf8',
+      false
+    );
+    strict.equal(column.extendedTypeName, undefined);
+    strict.equal(column.extendedFormat, undefined);
+    strict.equal(column.name, 'u');
+    strict.equal(column.columnLength, 144);
+  });
+});

--- a/test/unit/parsers/cache-key-serialization.test.mts
+++ b/test/unit/parsers/cache-key-serialization.test.mts
@@ -410,7 +410,7 @@ describe('Cache Key Serialization', () => {
     const result1 = keyFrom(test1);
     strict.deepStrictEqual(
       result1,
-      '[null,"undefined",null,false,false,false,"undefined",null,false,null,[null,null,null,null,null,null,null]]'
+      '[null,"undefined",null,false,false,false,"undefined",null,false,null,false,[null,null,null,null,null,null,null,null,null]]'
     );
     strict(JSON.parse(result1));
   });
@@ -419,7 +419,7 @@ describe('Cache Key Serialization', () => {
     const result2 = keyFrom(test2);
     strict.deepStrictEqual(
       result2,
-      '[null,"undefined",null,false,false,false,"undefined","local",false,null,[null,null,null,null,null,null,null]]'
+      '[null,"undefined",null,false,false,false,"undefined","local",false,null,false,[null,null,null,null,null,null,null,null,null]]'
     );
     strict(JSON.parse(result2));
   });
@@ -428,7 +428,7 @@ describe('Cache Key Serialization', () => {
     const result3 = keyFrom(test3);
     strict.deepStrictEqual(
       result3,
-      '[null,"string","",false,false,false,true,"local",false,false,[null,null,null,null,null,null,null]]'
+      '[null,"string","",false,false,false,true,"local",false,false,false,[null,null,null,null,null,null,null,null,null]]'
     );
     strict(JSON.parse(result3));
   });
@@ -437,7 +437,7 @@ describe('Cache Key Serialization', () => {
     const result4 = keyFrom(test4);
     strict.deepStrictEqual(
       result4,
-      '["binary","boolean",false,false,false,false,true,"local",false,"DATETIME",["id","3",null,"test","test","16899","63"],["value","246",null,"test","test","0","63"]]'
+      '["binary","boolean",false,false,false,false,true,"local",false,"DATETIME",false,["id","3",null,"test","test","16899","63",null,null],["value","246",null,"test","test","0","63",null,null]]'
     );
     strict(JSON.parse(result4));
   });
@@ -453,7 +453,7 @@ describe('Cache Key Serialization', () => {
     const result6 = keyFrom(test6);
     strict.deepStrictEqual(
       result6,
-      '["binary","boolean",false,true,true,true,true,"\\"\\"`\'",true,"#",[":","©",null,"/",",","_","❌"]]'
+      '["binary","boolean",false,true,true,true,true,"\\"\\"`\'",true,"#",false,[":","©",null,"/",",","_","❌",null,null]]'
     );
     // Ensuring that JSON is valid with invalid delimiters
     strict(JSON.parse(result6));
@@ -463,7 +463,7 @@ describe('Cache Key Serialization', () => {
     const result7 = keyFrom(test7);
     strict.deepStrictEqual(
       result7,
-      '["binary","boolean",true,true,true,true,true,"local",true,"DATETIME",["id","3",null,"test","test","16899","63"],["value","246",null,"test","test","0","63"]]'
+      '["binary","boolean",true,true,true,true,true,"local",true,"DATETIME",false,["id","3",null,"test","test","16899","63",null,null],["value","246",null,"test","test","0","63",null,null]]'
     );
     strict(JSON.parse(result7));
   });
@@ -479,7 +479,7 @@ describe('Cache Key Serialization', () => {
     const result9 = keyFrom(test9);
     strict.deepStrictEqual(
       result9,
-      '["binary","boolean",false,false,false,true,"function","local",false,null,["id","3",null,"test","test","16899","63"]]'
+      '["binary","boolean",false,false,false,true,"function","local",false,null,false,["id","3",null,"test","test","16899","63",null,null]]'
     );
     strict(JSON.parse(result9));
     strict(JSON.parse(result9)[5] === true);
@@ -491,7 +491,7 @@ describe('Cache Key Serialization', () => {
     const result10 = keyFrom(test10);
     strict.deepStrictEqual(
       result10,
-      '["binary","boolean",false,false,false,false,false,"local",false,"DATETIME",["id","3",null,"test","test","16899","63"],["value","246",null,"test","test","0","63"]]'
+      '["binary","boolean",false,false,false,false,false,"local",false,"DATETIME",false,["id","3",null,"test","test","16899","63",null,null],["value","246",null,"test","test","0","63",null,null]]'
     );
     strict(JSON.parse(result10));
   });

--- a/test/unit/parsers/test-mariadb-json-format.test.mts
+++ b/test/unit/parsers/test-mariadb-json-format.test.mts
@@ -1,0 +1,105 @@
+import { Buffer } from 'node:buffer';
+import { describe, it, strict } from 'poku';
+import Packet from '../../../lib/packets/packet.js';
+import getBinaryParser from '../../../lib/parsers/binary_parser.js';
+import getStaticBinaryParser from '../../../lib/parsers/static_binary_parser.js';
+import getStaticTextParser from '../../../lib/parsers/static_text_parser.js';
+import getTextParser from '../../../lib/parsers/text_parser.js';
+
+// MariaDB sends JSON columns as LONG_BLOB with utf8mb4 charset; only the
+// extended metadata (extendedFormat) identifies them as JSON
+const jsonField = {
+  name: 'j',
+  columnType: 0xfb, // LONG_BLOB
+  characterSet: 224,
+  encoding: 'utf8',
+  flags: 144,
+  decimals: 39,
+  columnLength: 4294967295,
+  schema: 'test',
+  table: 't',
+  orgName: 'j',
+  orgTable: 't',
+  extendedTypeName: undefined,
+  extendedFormat: 'json',
+};
+
+const value = { tag: 'x', nums: [1, 2, 3] };
+const raw = Buffer.from(JSON.stringify(value), 'utf8');
+strict.ok(raw.length < 251);
+
+const textRowPacket = () => {
+  const buf = Buffer.concat([Buffer.alloc(4), Buffer.from([raw.length]), raw]);
+  return new Packet(0, buf, 0, buf.length);
+};
+
+const binaryRowPacket = () => {
+  const buf = Buffer.concat([
+    Buffer.alloc(4),
+    Buffer.from([0]), // status byte
+    Buffer.from([0]), // null bitmap
+    Buffer.from([raw.length]),
+    raw,
+  ]);
+  return new Packet(0, buf, 0, buf.length);
+};
+
+const fields = [jsonField];
+const options = {};
+
+// the compiled row classes are untyped internals
+const jsonOf = (row: object): unknown => (row as { j: unknown }).j;
+
+describe('MariaDB extended JSON format parsing', () => {
+  it('text parser should parse JSON-formatted columns', () => {
+    const Parser = getTextParser(fields, options, {});
+    const row = new Parser(fields).next(textRowPacket(), fields, options);
+    strict.deepEqual(jsonOf(row), value);
+  });
+
+  it('text parser should respect jsonStrings', () => {
+    const Parser = getTextParser(fields, options, { jsonStrings: true });
+    const row = new Parser(fields).next(textRowPacket(), fields, options);
+    strict.equal(jsonOf(row), JSON.stringify(value));
+  });
+
+  it('binary parser should parse JSON-formatted columns', () => {
+    const Parser = getBinaryParser(fields, options, {});
+    const row = new Parser().next(binaryRowPacket(), fields, options);
+    strict.deepEqual(jsonOf(row), value);
+  });
+
+  it('binary parser should respect jsonStrings', () => {
+    const Parser = getBinaryParser(fields, options, { jsonStrings: true });
+    const row = new Parser().next(binaryRowPacket(), fields, options);
+    strict.equal(jsonOf(row), JSON.stringify(value));
+  });
+
+  it('static text parser should parse JSON-formatted columns', () => {
+    const parser = getStaticTextParser(fields, options, {});
+    const row = parser.next(textRowPacket(), fields, options);
+    strict.deepEqual(jsonOf(row), value);
+  });
+
+  it('static text parser should respect jsonStrings', () => {
+    const parser = getStaticTextParser(fields, options, {
+      jsonStrings: true,
+    });
+    const row = parser.next(textRowPacket(), fields, options);
+    strict.equal(jsonOf(row), JSON.stringify(value));
+  });
+
+  it('static binary parser should parse JSON-formatted columns', () => {
+    const Parser = getStaticBinaryParser(fields, options, {});
+    const row = new Parser().next(binaryRowPacket(), fields, options);
+    strict.deepEqual(jsonOf(row), value);
+  });
+
+  it('static binary parser should respect jsonStrings', () => {
+    const Parser = getStaticBinaryParser(fields, options, {
+      jsonStrings: true,
+    });
+    const row = new Parser().next(binaryRowPacket(), fields, options);
+    strict.equal(jsonOf(row), JSON.stringify(value));
+  });
+});

--- a/test/unit/parsers/test-text-parser.test.mts
+++ b/test/unit/parsers/test-text-parser.test.mts
@@ -3,8 +3,8 @@ import type {
   TypeCastField,
   TypeCastNext,
 } from '../../../index.js';
-import { describe, it, strict } from 'poku';
-import { createConnection } from '../../common.test.mjs';
+import { describe, it, skip, strict } from 'poku';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
 
 const typeCastWrapper = function (
   ...args: [encoding?: BufferEncoding | string | undefined]
@@ -20,6 +20,15 @@ const typeCastWrapper = function (
 
 await describe('Text Parser: typeCast with JSON fields', async () => {
   const connection = createConnection();
+  const { isMariaDB } = await getMysqlVersion(connection);
+
+  if (isMariaDB) {
+    await connection.promise().end();
+    // MariaDB JSON columns are utf8mb4 LONGTEXT, so the MySQL-specific
+    // binary-charset footgun tested here does not exist there
+    skip('MariaDB does not report JSON columns with the BINARY charset');
+  }
+
   connection.query('CREATE TEMPORARY TABLE t (i JSON)');
   connection.query('INSERT INTO t values(\'{ "test": "😀" }\')');
 

--- a/typings/mysql/lib/parsers/typeCast.d.ts
+++ b/typings/mysql/lib/parsers/typeCast.d.ts
@@ -40,6 +40,17 @@ export type Type = {
 };
 
 export type Field = Type & {
+  /**
+   * MariaDB extended data type name (e.g. `uuid`, `inet4`, `inet6`, `point`),
+   * available when the server supports the MARIADB_CLIENT_EXTENDED_METADATA
+   * capability (MariaDB 10.5+)
+   */
+  extendedTypeName?: string;
+  /**
+   * MariaDB extended format name (e.g. `json`), available when the server
+   * supports the MARIADB_CLIENT_EXTENDED_METADATA capability (MariaDB 10.5+)
+   */
+  extendedFormat?: string;
   length: number;
   db: string;
   table: string;

--- a/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
+++ b/typings/mysql/lib/protocol/packets/FieldPacket.d.ts
@@ -22,6 +22,17 @@ declare interface FieldPacket {
   typeName?: string;
   encoding?: string;
   columnLength?: number;
+  /**
+   * MariaDB extended data type name (e.g. `uuid`, `inet4`, `inet6`, `point`),
+   * available when the server supports the MARIADB_CLIENT_EXTENDED_METADATA
+   * capability (MariaDB 10.5+)
+   */
+  extendedTypeName?: string;
+  /**
+   * MariaDB extended format name (e.g. `json`), available when the server
+   * supports the MARIADB_CLIENT_EXTENDED_METADATA capability (MariaDB 10.5+)
+   */
+  extendedFormat?: string;
 }
 
 export { FieldPacket };

--- a/website/docs/documentation/00-index.mdx
+++ b/website/docs/documentation/00-index.mdx
@@ -21,6 +21,7 @@ Not only **MySQL2** offers better performance over [Node MySQL][node-mysql], we 
 
 - [Prepared Statements](/docs/documentation/prepared-statements)
 - [Query Attributes](/docs/documentation/query-attributes)
+- [MariaDB Data Types](/docs/documentation/mariadb-data-types)
 - [Reset Connection](/docs/documentation/reset-connection)
 - [Promise Wrapper](/docs/documentation/promise-wrapper)
 - [Authentication Switch](/docs/documentation/authentication-switch)

--- a/website/docs/documentation/mariadb-data-types.mdx
+++ b/website/docs/documentation/mariadb-data-types.mdx
@@ -1,0 +1,152 @@
+---
+tags: [MariaDB, UUID, INET4, INET6, VECTOR, JSON, extended metadata]
+---
+
+# MariaDB Data Types
+
+MariaDB has data types that do not exist in MySQL: `UUID`, `INET4`, `INET6` and
+`VECTOR`, plus a `JSON` type that is an alias for `LONGTEXT` rather than a
+native binary type. On the wire these columns are sent as standard string and
+blob types, so a client cannot distinguish, for example, a `UUID` column from a
+`CHAR` column, unless the server also sends its extended type metadata.
+
+When MySQL2 connects to a MariaDB server that supports it (MariaDB 10.5 and
+above), it automatically negotiates the `MARIADB_CLIENT_EXTENDED_METADATA`
+capability, and each column definition then carries the MariaDB type
+information. No configuration is needed.
+
+## Extended column metadata
+
+Every field object exposes two additional properties when the server provides
+them:
+
+- `extendedTypeName`: the MariaDB data type name, e.g. `uuid`, `inet4`,
+  `inet6`, or a geometry subtype such as `point`.
+- `extendedFormat`: the value format, e.g. `json` for JSON columns.
+
+```js
+const [rows, fields] = await connection.query(
+  'SELECT id, addr FROM hosts LIMIT 1'
+);
+
+console.log(fields[1].extendedTypeName);
+// 'inet6'
+```
+
+Both properties are also available on the field object passed to a custom
+[`typeCast`](/docs/api-and-configurations) function, which makes it possible to
+apply custom conversions to MariaDB-specific types:
+
+```js
+const [rows] = await connection.query({
+  sql: 'SELECT * FROM sessions',
+  typeCast: (field, next) => {
+    if (field.extendedTypeName === 'uuid') {
+      return field.string()?.toUpperCase();
+    }
+    return next();
+  },
+});
+```
+
+On MySQL servers (and MariaDB older than 10.5) both properties are
+`undefined`.
+
+## UUID, INET4 and INET6
+
+Values are returned as strings, exactly as MariaDB formats them:
+
+```js
+const [rows] = await connection.query('SELECT u, i4, i6 FROM t');
+// rows[0].u  === '123e4567-e89b-12d3-a456-426614174000'
+// rows[0].i4 === '203.0.113.7'
+// rows[0].i6 === '2001:db8::1'
+```
+
+To insert values, bind them as strings: MariaDB converts them to the compact
+internal representation on the server:
+
+```js
+await connection.execute('INSERT INTO t (u, i4, i6) VALUES (?, ?, ?)', [
+  '123e4567-e89b-12d3-a456-426614174000',
+  '203.0.113.7',
+  '2001:db8::1',
+]);
+```
+
+## JSON
+
+MariaDB `JSON` columns (and JSON function results such as `JSON_OBJECT()`) are
+identified through the extended metadata and parsed into objects by default,
+matching the behavior of MySQL's native `JSON` type:
+
+```js
+const [rows] = await connection.query('SELECT j FROM t');
+// rows[0].j is an object, e.g. { tag: 'x', nums: [1, 2, 3] }
+```
+
+To receive JSON values as raw strings instead, use the `jsonStrings`
+connection option:
+
+```js
+const connection = mysql.createConnection({
+  // ...
+  jsonStrings: true,
+});
+```
+
+Objects bound as parameters are automatically serialized with
+`JSON.stringify()`:
+
+```js
+await connection.execute('INSERT INTO t (j) VALUES (?)', [
+  { tag: 'x', nums: [1, 2, 3] },
+]);
+```
+
+:::note
+Before this feature, MariaDB JSON columns were returned as plain strings. If
+your application depends on the previous behavior, set `jsonStrings: true`.
+:::
+
+## VECTOR
+
+The MariaDB protocol does not tag `VECTOR` columns with extended metadata (as
+of MariaDB 11.8), so MySQL2 returns them as a `Buffer` containing the raw
+little-endian IEEE 754 float32 values, the same bytes MariaDB stores. This
+differs from MySQL 9 `VECTOR` columns, which have their own wire type and are
+returned as an array of numbers.
+
+Converting the returned `Buffer` to numbers:
+
+```js
+const [rows] = await connection.query('SELECT v FROM embeddings LIMIT 1');
+const buffer = rows[0].v;
+
+const floats = Array.from(
+  new Float32Array(
+    buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.length)
+  )
+);
+// [1.5, -2.25, 3.75]
+```
+
+Alternatively, select the text representation directly:
+
+```js
+const [rows] = await connection.query(
+  'SELECT VEC_ToText(v) AS v FROM embeddings LIMIT 1'
+);
+// rows[0].v === '[1.5,-2.25,3.75]'
+```
+
+To insert a vector, bind a `Buffer` with the packed float32 values (or use
+`VEC_FromText()` with a JSON-style string):
+
+```js
+const vector = [1.5, -2.25, 3.75];
+const buffer = Buffer.alloc(vector.length * 4);
+vector.forEach((value, i) => buffer.writeFloatLE(value, i * 4));
+
+await connection.execute('INSERT INTO embeddings (v) VALUES (?)', [buffer]);
+```


### PR DESCRIPTION
# Support MariaDB data types: UUID, INET4, INET6, VECTOR, and the JSON alias

MariaDB sends its own data types (`UUID`, `INET4`, `INET6`, `VECTOR`, and `JSON`, which is an alias for `LONGTEXT`) as standard string/blob types on the wire, so MySQL2 could not distinguish them from `CHAR`/`VARBINARY`/`LONGTEXT` columns. This PR negotiates MariaDB's `MARIADB_CLIENT_EXTENDED_METADATA` capability (MariaDB 10.5+) so the real type is visible, and fixes the issues that surfaced along the way.

The wire format was verified against the MariaDB protocol documentation, the MariaDB server source (through 11.8 and `main`), and a live MariaDB 11.8 server.

Fixes #1287 (with the extended metadata negotiated, MariaDB JSON columns and JSON expressions such as `JSON_EXTRACT(...)` parse to objects by default; `jsonStrings: true` keeps strings).

This PR also makes the existing test suite pass against MariaDB and adds `mariadb:11.8` to the Linux CI matrix, resolving the `TODO - add mariadb to the matrix` in `ci-linux.yml` (originally split out as #4374, consolidated here per review feedback).

## What this does

### Extended type metadata (`MARIADB_CLIENT_EXTENDED_METADATA`)

- The MariaDB extended server capabilities are parsed from the 4 reserved bytes of the initial handshake packet (present when the server leaves `CLIENT_MYSQL`/`LONG_PASSWORD` unset, i.e. genuine MariaDB 10.2+ servers only; MySQL and MySQL-compatible proxies are untouched).
- When the server offers `MARIADB_CLIENT_EXTENDED_METADATA`, the client requests it in the last 4 reserved bytes of the handshake response and SSL request, and clears `CLIENT_MYSQL` (the server only reads the extended bytes when that bit is unset, mirroring its own side of the negotiation).
- Column definition packets then carry a length-encoded metadata block, exposed on every field object (including the `typeCast` field wrapper) as:
  - `extendedTypeName`: e.g. `'uuid'`, `'inet4'`, `'inet6'`, `'point'`
  - `extendedFormat`: e.g. `'json'`

Both properties are `undefined` on MySQL and on MariaDB < 10.5. Parsing is bounds-checked, so a malformed block from a buggy server/proxy cannot desynchronise the packet.

### Per type

| Type | Behavior |
| --- | --- |
| `UUID`, `INET4`, `INET6` | Returned as strings (unchanged); now identifiable via `extendedTypeName`. |
| `JSON` | Identified via `extendedFormat: 'json'` and parsed into objects by default, matching MySQL's native JSON type. `jsonStrings: true` keeps strings. |
| `VECTOR` | Returned as a `Buffer` of little-endian float32 values. MariaDB attaches no extended metadata to VECTOR columns (verified in the server source through 11.8 and `main`), so they are genuinely indistinguishable from `VARBINARY` on the wire; the docs show how to convert and insert. |
| `GEOMETRY` subtypes | Parsed as before; the subtype (`point`, …) is now visible via `extendedTypeName`. |

### Bugs fixed along the way

- **JSON object parameters failed on MariaDB**: `connection.execute(sql, [{...}])` always failed with `Incorrect arguments to mysqld_stmt_execute` because MariaDB rejects the `MYSQL_TYPE_JSON` parameter type. Objects are now sent as strings to MariaDB (MySQL keeps `MYSQL_TYPE_JSON`).
- **Buffer parameters corrupted MariaDB VECTOR inserts**: Buffers were sent as `MYSQL_TYPE_VAR_STRING`, letting the server treat the bytes as text in the connection charset: inserting a vector via `execute()` silently stored `[0,0,...]` (or errors under strict `sql_mode`). Buffers are now sent as `MYSQL_TYPE_BLOB`, the conventional type for binary parameters. `Execute.fromPacket` (server side, `stmt_execute` event) decodes them as Buffers.
- **`jsonStrings` was missing from the row parser cache key**: two connections differing only in `jsonStrings` could reuse each other's compiled row parsers. This also affected MySQL.
- **MariaDB NO PAD / UCA-14.0.0 collation ids crashed connections**: e.g. after `SET NAMES utf8mb4 COLLATE utf8mb4_nopad_bin`, reading any string column failed with `Encoding not recognized: 'undefined'` and killed the connection. The charset→encoding table now covers the NO PAD range (PAD SPACE id + 1024) and the uca1400 blocks (256-id blocks from 2048).
- **Timezone-dependent test**: the datetime test's "local TZ" assertions assumed the server session time zone matches the client's local zone (true on CI, false on non-UTC dev machines); the session time zone is now pinned, as the `Z`/`+09:30` cases in the same test already do.
- **`test-vector.test.mts` ran MySQL's `TO_VECTOR()` on MariaDB** (it only checked `major >= 9`); it now skips MariaDB, whose vectors are covered by the new integration test.

## ⚠️ Behavior changes to review

1. **MariaDB JSON columns now return parsed objects instead of strings** (consistent with MySQL; `jsonStrings: true` restores the previous behavior). This is the headline semver consideration.
2. **Buffer parameters are typed as `BLOB` instead of `VAR_STRING`** in `COM_STMT_EXECUTE`. No behavioral difference was observed on MySQL 8.4 across the full test suite, but it is technically observable server-side.

## Tests & docs

- New unit tests (run in CI without a MariaDB server): handshake extended-capability parsing, handshake response/SSL request byte layout, extended-metadata column definition parsing (including malformed/truncated blocks), and the collation-id encoding ranges.
- New integration test (`test-mariadb-extended-metadata.test.mts`) covering both protocols, metadata exposure, JSON object round-trips, vector Buffer round-trips, `typeCast`, and `jsonStrings`; skips (via poku `skip`) on non-MariaDB servers, so the current CI matrix is unaffected.
- New documentation page: **MariaDB Data Types** (`website/docs/documentation/mariadb-data-types.mdx`), linked from the docs index.
- Typings: `extendedTypeName`/`extendedFormat` added to `FieldPacket` and the `typeCast` field type.

## Test suite fixes (running the existing suite against MariaDB)

`getMysqlVersion()` in `test/common.test.mts` now also returns `version` (the raw server string) and `isMariaDB`, and the affected tests branch on it:

**MySQL-only SQL, replaced with portable or per-server equivalents:**

- `json-parse` / `json-string`: `CAST(... AS JSON)` is not valid MariaDB syntax; MariaDB uses `JSON_EXTRACT(..., '$')`, which also produces a JSON-typed result there.
- `test-invalid-date-result` / `test-#1019`: `performance_schema.session_variables` does not exist on MariaDB; both only fetched `sql_mode`, so they now use `SELECT @@sql_mode`.
- `test-backpressure-result-streaming`: MariaDB names the CTE depth limit `max_recursive_iterations` instead of `cte_max_recursion_depth`.

**Server behavior differences, expectations branched:**

- `test-date-parameter` / `test-custom-date-parameter`: MariaDB returns an integer for `UNIX_TIMESTAMP(<datetime param>)`; MySQL 8+ returns a DECIMAL string with microseconds.
- `test-multiple-results` / `test-binary-multiple-results`: MariaDB reports integer literals (`SELECT 1`) as `LONG`, MySQL as `LONGLONG`.
- `test-execute-nocolumndef`: MariaDB's `EXPLAIN` has no `partitions`/`filtered` columns and different field metadata; an explicit MariaDB expectation table is used (the regression itself, execute after a no-column-definition prepare, is exercised on both servers).
- `test-insert-json`: MariaDB enforces JSON validity via a CHECK constraint and reports errno 4025 (its `ER_CONSTRAINT_FAILED`) instead of MySQL's `ER_INVALID_JSON_TEXT` (3140). Only the errno is asserted on MariaDB because mysql2's error-name table follows MySQL, where 4025 has a different meaning. That name collision deserves its own discussion: mapping MariaDB error numbers (4000+) through the MySQL table produces misleading `code` values.
- `test-text-parser` (unit): skipped on MariaDB via poku `skip`; the MySQL-specific footgun it tests (JSON columns reported with the BINARY charset, issue #1661) does not exist on MariaDB, where JSON columns are utf8mb4 `LONGTEXT`.

## CI

`mariadb:11.8` (current LTS) is added to the `tests-linux` matrix alongside `mysql:8.3`. The existing docker-run step works unchanged: the mariadb image accepts `MYSQL_ALLOW_EMPTY_PASSWORD`/`MYSQL_DATABASE`, uses the same datadir, and the custom conf only sets `ssl-ca`/`ssl-cert`/`ssl-key`, which are the same variable names on MariaDB. Bun/Deno jobs stay MySQL-only for now to limit matrix growth; more MariaDB versions (e.g. `mariadb:10.11`) can be added later if wanted.

Two additional pre-existing test issues found along the way: the reset-connection tests built raw connections from environment variables but omitted `MYSQL_PORT`, silently connecting to the wrong server on non-default-port setups.

## Verification

Full local suite runs (for reference, current master fails 19 test files against MariaDB 11.8; this PR brings it to 0):

| Server | Options | Result |
| --- | --- | --- |
| MariaDB 11.8 | plain | 212 pass / 0 fail / 1 skip |
| MariaDB 11.8 | `MYSQL_USE_COMPRESSION=1` | pass |
| MariaDB 11.8 | `MYSQL_USE_TLS=1` | pass |
| MySQL 8.3 / 8.4 | plain | pass (no regressions) |

The 16 new `mariadb:11.8` CI jobs (Node 18/20/22/24 x SSL x compression) all passed on GitHub runners in the earlier #4374 run. Also exercised by hand against both servers: TLS connections (SSL request path), `disableEval` static parsers, prepared-statement parameter definitions, and `typeCast`.

One item left for a separate discussion: the MariaDB error-code namespace (MariaDB errno 4025, its `ER_CONSTRAINT_FAILED`, currently maps to `ER_INNODB_AUTOEXTEND_SIZE_OUT_OF_RANGE` via the MySQL error table).
