### PR TITLE
fix(sql-escaper): resolve multi statement and expand object regressions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -79,4 +79,4 @@ jobs:
           auto-push: false
           alert-threshold: '115%'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
+          comment-on-alert: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.3.3"
+        "sql-escaper": "^1.4.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
@@ -1989,9 +1989,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2891,9 +2891,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4678,9 +4678,9 @@
       }
     },
     "node_modules/sql-escaper": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
-      "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.4.0.tgz",
+      "integrity": "sha512-Ti/Zx9J3aITMYUMFhCKbkplQjyi7Kk2SyYXp+rzrkyKZetIy19XbQtVZ+0ZR5aVm/178tIJ6+aVvBqXkH+Xs7w==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -4780,9 +4780,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "long": "^5.3.2",
     "lru.min": "^1.1.4",
     "named-placeholders": "^1.1.6",
-    "sql-escaper": "^1.3.3"
+    "sql-escaper": "^1.4.0"
   },
   "peerDependencies": {
     "@types/node": ">= 8"

--- a/test/integration/regressions/test-#4126.test.mts
+++ b/test/integration/regressions/test-#4126.test.mts
@@ -1,0 +1,83 @@
+import type { ResultSetHeader, RowDataPacket } from '../../../index.js';
+import { describe, it, strict } from 'poku';
+import { createConnection, createPool } from '../../common.test.mjs';
+
+type DomainRow = RowDataPacket & { id: number; domain: string };
+type DocRow = RowDataPacket & { id: number; foo: string; hasModified: number };
+
+await describe('Regression #4126 — object placeholders expand in SET assignment lists', async () => {
+  await describe('client-side formatting', async () => {
+    const connection = createConnection();
+
+    it('should expand ?? and ? object inside SET STATEMENT ... FOR INSERT', () => {
+      strict.equal(
+        connection.format(
+          'SET STATEMENT max_statement_time=15 FOR INSERT INTO ?? SET ?',
+          ['domains', { id: 1, domain: 'test.com' }]
+        ),
+        "SET STATEMENT max_statement_time=15 FOR INSERT INTO `domains` SET `id` = 1, `domain` = 'test.com'"
+      );
+    });
+
+    it('should expand ? object after UTC_TIMESTAMP() in an UPDATE SET list', () => {
+      strict.equal(
+        connection.format(
+          'UPDATE docs SET modified = UTC_TIMESTAMP(), ? WHERE id = ?',
+          [{ foo: 'bar' }, 123]
+        ),
+        "UPDATE docs SET modified = UTC_TIMESTAMP(), `foo` = 'bar' WHERE id = 123"
+      );
+    });
+
+    connection.end();
+  });
+
+  await describe('end-to-end execution', async () => {
+    const pool = createPool({ connectionLimit: 1 }).promise();
+
+    await it('should insert via object-form query with ??, ? object and timeout', async () => {
+      await pool.query(
+        'CREATE TEMPORARY TABLE domains (id INT PRIMARY KEY, domain VARCHAR(255))'
+      );
+
+      const [result] = await pool.query<ResultSetHeader>({
+        sql: 'INSERT INTO ?? SET ?',
+        values: ['domains', { id: 1, domain: 'test.com' }],
+        timeout: 16000,
+      });
+
+      strict.equal(result.affectedRows, 1);
+
+      const [rows] = await pool.query<DomainRow[]>(
+        'SELECT id, domain FROM domains'
+      );
+      strict.equal(rows.length, 1);
+      strict.equal(rows[0].id, 1);
+      strict.equal(rows[0].domain, 'test.com');
+    });
+
+    await it('should update via ? object mixed with UTC_TIMESTAMP()', async () => {
+      await pool.query(
+        'CREATE TEMPORARY TABLE docs (id INT PRIMARY KEY, foo VARCHAR(50), modified DATETIME)'
+      );
+      await pool.query('INSERT INTO docs (id, foo) VALUES (123, ?)', ['old']);
+
+      const [result] = await pool.query<ResultSetHeader>(
+        'UPDATE docs SET modified = UTC_TIMESTAMP(), ? WHERE id = ?',
+        [{ foo: 'bar' }, 123]
+      );
+
+      strict.equal(result.affectedRows, 1);
+
+      const [rows] = await pool.query<DocRow[]>(
+        'SELECT id, foo, modified IS NOT NULL AS hasModified FROM docs'
+      );
+
+      strict.equal(rows.length, 1);
+      strict.equal(rows[0].foo, 'bar');
+      strict.equal(rows[0].hasModified, 1);
+    });
+
+    await pool.end();
+  });
+});


### PR DESCRIPTION
Resolves regressions from:

- https://github.com/sidorares/node-mysql2/issues/4126#issuecomment-4081884480
- https://github.com/sidorares/node-mysql2/issues/4126#issuecomment-4896801957
- https://github.com/sidorares/node-mysql2/issues/4126#issuecomment-4047056304
- https://github.com/sidorares/node-mysql2/pull/4054#issuecomment-4641784313

---

## Complete release

### Features

* add Set and Map support to `?` placeholder expansion ([#27](https://github.com/mysqljs/sql-escaper/issues/27)) ([a1dc888](https://github.com/mysqljs/sql-escaper/commit/a1dc8887d681cf54996cf93bf67e3a6091d591b8))


### Bug Fixes

* expand `SET ?` in multi-statement queries ([#34](https://github.com/mysqljs/sql-escaper/issues/34)) ([4638497](https://github.com/mysqljs/sql-escaper/commit/463849732da739decd1e05090592b42bcf0f9643))
* extend SQL parsing to expand objects across `SET` assignment lists ([#37](https://github.com/mysqljs/sql-escaper/issues/37)) ([adaf338](https://github.com/mysqljs/sql-escaper/commit/adaf3381cd053fe5b195930097bc5feefd2b5a0b))
* substitute placeholders near non-comment `--` and executable comments ([#31](https://github.com/mysqljs/sql-escaper/issues/31)) ([bcc11a2](https://github.com/mysqljs/sql-escaper/commit/bcc11a226861e5a1b1b5a930d6187c62c3cf27a4))


### Performance Improvements

* scan `SET` clauses per-token instead of per-char ([#38](https://github.com/mysqljs/sql-escaper/issues/38)) ([f953b9c](https://github.com/mysqljs/sql-escaper/commit/f953b9c206cff4e34312fd38b12936f6c1178315))