### PR TITLE
feat(sql-escaper): add Temporal support when escaping values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "long": "^5.3.2",
         "lru.min": "^1.1.4",
         "named-placeholders": "^1.1.6",
-        "sql-escaper": "^1.4.0"
+        "sql-escaper": "^1.5.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.3",
@@ -4678,9 +4678,9 @@
       }
     },
     "node_modules/sql-escaper": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.4.0.tgz",
-      "integrity": "sha512-Ti/Zx9J3aITMYUMFhCKbkplQjyi7Kk2SyYXp+rzrkyKZetIy19XbQtVZ+0ZR5aVm/178tIJ6+aVvBqXkH+Xs7w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+      "integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "long": "^5.3.2",
     "lru.min": "^1.1.4",
     "named-placeholders": "^1.1.6",
-    "sql-escaper": "^1.4.0"
+    "sql-escaper": "^1.5.1"
   },
   "peerDependencies": {
     "@types/node": ">= 8"


### PR DESCRIPTION
## Summary

Bumps the direct `sql-escaper` dependency from `^1.4.0` to `^1.5.1`.

sql-escaper 1.5.x adds Temporal API support when escaping values (`Temporal.Instant`, `PlainDate`, `PlainTime`, `PlainDateTime`, `ZonedDateTime`), detected via `Object.prototype.toString` so no newer runtime is required.

As discussed in #4216, the range `^1.4.0` already permits these on fresh installs, but existing installations won't pick them up without this bump. Releasing as a `feat:` forces the update to reach all users on `npm update`.

`^1.5.1` (not `1.5.0`): 1.5.0's emitted types referenced the global `Temporal` namespace, which broke `tsc` for any consumer without the `ESNext.Temporal` lib (TypeScript < 7) — including this repo's own typecheck. Fixed in mysqljs/sql-escaper#49, released as 1.5.1.

Refs #4216