### PR TITLE
fix: correct connectAttributes typo in ChangeUser packet

### DIFF
--- a/lib/packets/change_user.js
+++ b/lib/packets/change_user.js
@@ -16,7 +16,7 @@ class ChangeUser {
     this.passwordSha1 = opts.passwordSha1;
     this.authPluginData1 = opts.authPluginData1;
     this.authPluginData2 = opts.authPluginData2;
-    this.connectAttributes = opts.connectAttrinutes || {};
+    this.connectAttributes = opts.connectAttributes || {};
     let authToken;
     if (this.passwordSha1) {
       authToken = auth41.calculateTokenFromPasswordSha(


### PR DESCRIPTION
## Summary
- Fixes a typo in the ChangeUser packet where `opts.connectAttrinutes` was used instead of `opts.connectAttributes`, so connect attributes were never read.
- References #2140

## Test plan
- [x] Confirmed the misspelled property is corrected in `lib/packets/change_user.js`
- [ ] CI / existing ChangeUser tests

---

Edit: Closes #2140