### PR TITLE
fix: don't leave a failed `execute` as the active command

### DIFF
--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -63,10 +63,6 @@ class Execute extends Command {
     try {
       connection.writePacket(executePacket.toPacket(1));
     } catch (error) {
-      // Nothing reached the wire, so no resultset will ever arrive. End the
-      // command here instead of advancing to resultsetHeader, otherwise it stays
-      // the active command forever and blocks the queue (e.g. a following
-      // rollback never runs). See #3293.
       this.onResult(error);
       return null;
     }

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -63,7 +63,12 @@ class Execute extends Command {
     try {
       connection.writePacket(executePacket.toPacket(1));
     } catch (error) {
+      // Nothing reached the wire, so no resultset will ever arrive. End the
+      // command here instead of advancing to resultsetHeader, otherwise it stays
+      // the active command forever and blocks the queue (e.g. a following
+      // rollback never runs). See #3293.
       this.onResult(error);
+      return null;
     }
     return Execute.prototype.resultsetHeader;
   }

--- a/lib/commands/execute.js
+++ b/lib/commands/execute.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Timers = require('timers');
+
 const Command = require('./command.js');
 const Query = require('./query.js');
 const Packets = require('../packets/index.js');
@@ -63,7 +65,15 @@ class Execute extends Command {
     try {
       connection.writePacket(executePacket.toPacket(1));
     } catch (error) {
-      this.onResult(error);
+      if (this.queryTimeout) {
+        Timers.clearTimeout(this.queryTimeout);
+        this.queryTimeout = null;
+      }
+      if (this.onResult) {
+        this.onResult(error);
+      } else {
+        this.emit('error', error);
+      }
       return null;
     }
     return Execute.prototype.resultsetHeader;

--- a/test/integration/connection/test-bind-undefined.test.mts
+++ b/test/integration/connection/test-bind-undefined.test.mts
@@ -36,14 +36,10 @@ await describe('Bind Undefined', async () => {
       'INSERT INTO test_bind_undefined (name) VALUES (?)'
     );
 
-    await strict.rejects(
-      // @ts-expect-error: testing that undefined bind parameter throws TypeError
-      statement.execute([undefined]),
-      {
-        name: 'TypeError',
-        message: 'Bind parameters must not contain undefined',
-      }
-    );
+    await strict.rejects(statement.execute([undefined]), {
+      name: 'TypeError',
+      message: 'Bind parameters must not contain undefined',
+    });
 
     // Regression #3293: the failed execute used to stay the active command and
     // block the queue, so this rollback — and every command after it — hung forever.

--- a/test/integration/connection/test-bind-undefined.test.mts
+++ b/test/integration/connection/test-bind-undefined.test.mts
@@ -41,8 +41,7 @@ await describe('Bind Undefined', async () => {
       message: 'Bind parameters must not contain undefined',
     });
 
-    // Regression #3293: the failed execute used to stay the active command and
-    // block the queue, so this rollback — and every command after it — hung forever.
+    // Regression #3293: the failed `execute` used to stay the active command blocks the queue indefinitely.
     await connection.rollback();
 
     const [results] =

--- a/test/integration/connection/test-bind-undefined.test.mts
+++ b/test/integration/connection/test-bind-undefined.test.mts
@@ -26,6 +26,34 @@ await describe('Bind Undefined', async () => {
     strict.strictEqual(results[0].result, 1);
   });
 
+  await it('prepared statement: should reject undefined parameter without deadlocking the connection', async () => {
+    await connection.query(
+      'CREATE TEMPORARY TABLE test_bind_undefined (id INT PRIMARY KEY AUTO_INCREMENT, name VARCHAR(50) NOT NULL)'
+    );
+    await connection.beginTransaction();
+
+    const statement = await connection.prepare(
+      'INSERT INTO test_bind_undefined (name) VALUES (?)'
+    );
+
+    await strict.rejects(
+      // @ts-expect-error: testing that undefined bind parameter throws TypeError
+      statement.execute([undefined]),
+      {
+        name: 'TypeError',
+        message: 'Bind parameters must not contain undefined',
+      }
+    );
+
+    // Regression #3293: the failed execute used to stay the active command and
+    // block the queue, so this rollback — and every command after it — hung forever.
+    await connection.rollback();
+
+    const [results] =
+      await connection.query<RowDataPacket[]>('SELECT 1 AS result');
+    strict.strictEqual(results[0].result, 1);
+  });
+
   await it('query: should accept undefined bind parameter as NULL', async () => {
     const [results] = await connection.query<RowDataPacket[]>(
       'SELECT ? AS result',

--- a/test/integration/connection/test-bind-undefined.test.mts
+++ b/test/integration/connection/test-bind-undefined.test.mts
@@ -1,4 +1,4 @@
-import type { RowDataPacket } from '../../../index.js';
+import type { ResultSetHeader, RowDataPacket } from '../../../index.js';
 import { describe, it, strict } from 'poku';
 import { createConnection } from '../../common.test.mjs';
 
@@ -36,13 +36,21 @@ await describe('Bind Undefined', async () => {
       'INSERT INTO test_bind_undefined (name) VALUES (?)'
     );
 
-    await strict.rejects(statement.execute([undefined]), {
-      name: 'TypeError',
-      message: 'Bind parameters must not contain undefined',
-    });
+    try {
+      await strict.rejects(statement.execute([undefined]), {
+        name: 'TypeError',
+        message: 'Bind parameters must not contain undefined',
+      });
 
-    // Regression #3293: the failed `execute` used to stay the active command blocks the queue indefinitely.
-    await connection.rollback();
+      // Regression #3293: the failed `execute` used to stay the active command blocks the queue indefinitely.
+      await connection.rollback();
+
+      // The statement stays usable after the failed execute.
+      const [result] = await statement.execute(['ok']);
+      strict.strictEqual((result as ResultSetHeader).affectedRows, 1);
+    } finally {
+      await statement.close();
+    }
 
     const [results] =
       await connection.query<RowDataPacket[]>('SELECT 1 AS result');


### PR DESCRIPTION
Fixes #3293.

### The bug
Inside a transaction, calling `statement.execute([undefined])` on a prepared statement wedges the connection — the following `rollback()`, and every later command, hangs forever.

### Cause
`Execute.start()` wraps `writePacket()` in a try/catch (added in #689 so a bad bind parameter doesn't kill the connection). When parameter encoding throws, it rejects the query via `onResult(error)` but still returns `Execute.prototype.resultsetHeader`. Nothing reached the socket, so no resultset will ever arrive — yet the command stays active waiting for one. It never ends, so `handlePacket` never shifts the next command off the queue and whatever is queued behind it (the rollback) never runs.

`Connection#execute` isn't affected because it checks for `undefined` up front and throws before a command is created. The raw `PreparedStatementInfo.execute` path has no such guard, so it reaches this code.

### Fix
Return `null` from the catch path so the command ends (emits `end`, and `handlePacket` moves on to the queue). This matches how a server error packet is already handled in `Command#execute` — `onResult(err)` followed by ending the command.

### Verification
- Added a regression test in `test-bind-undefined` that reproduces the hang: it deadlocks on the current code and passes with the fix. Also checked the connection is fully usable afterwards — a later query and re-executing the same statement with a valid parameter both succeed.
- Green in both default and `STATIC_PARSER=1` modes; prepare / transaction / reset / promise-wrapper and the existing regression tests still pass.

AI-assisted, disclosed in the commit trailer; I've reviewed the change and can walk through it.