### PR TITLE
fix: clear connectTimeout when the handshake completes instead of on first byte

### DIFF
--- a/lib/base/connection.js
+++ b/lib/base/connection.js
@@ -104,7 +104,10 @@ class BaseConnection extends EventEmitter {
       this.handlePacket(p);
     });
     this.stream.on('data', (data) => {
-      if (this.connectTimeout) {
+      // server-side connections have no ClientHandshake command to clear the
+      // timer on, so first activity keeps doing it; for client connections it
+      // is cleared once the handshake completes (see the 'end' listener below)
+      if (this.connectTimeout && this.config.isServer) {
         Timers.clearTimeout(this.connectTimeout);
         this.connectTimeout = null;
       }
@@ -133,6 +136,12 @@ class BaseConnection extends EventEmitter {
     if (!this.config.isServer) {
       handshakeCommand = new Commands.ClientHandshake(this.config.clientFlags);
       handshakeCommand.on('end', () => {
+        // the initial connection is only established once the handshake has
+        // completed; error paths clear the timer in _notifyError
+        if (this.connectTimeout) {
+          Timers.clearTimeout(this.connectTimeout);
+          this.connectTimeout = null;
+        }
         // this happens when handshake finishes early either because there was
         // some fatal error or the server sent an error packet instead of
         // an hello packet (for example, 'Too many connections' error)

--- a/test/unit/connection/test-connect-timeout-covers-handshake.test.mts
+++ b/test/unit/connection/test-connect-timeout-covers-handshake.test.mts
@@ -1,0 +1,161 @@
+import type { Socket } from 'node:net';
+import { createServer as createTcpServer } from 'node:net';
+import { describe, it, strict } from 'poku';
+import mysql from '../../../index.js';
+import ClientFlags from '../../../lib/constants/client.js';
+import Handshake from '../../../lib/packets/handshake.js';
+
+function buildGreeting(): Buffer {
+  let capabilityFlags = 0xffffff;
+  capabilityFlags = capabilityFlags ^ (ClientFlags.COMPRESS | ClientFlags.SSL);
+
+  const handshake = new Handshake({
+    protocolVersion: 10,
+    serverVersion: '8.0.0-stalled-test',
+    connectionId: 1,
+    statusFlags: 2,
+    characterSet: 8,
+    capabilityFlags,
+    authPluginData1: Buffer.from('12345678'),
+    authPluginData2: Buffer.from('901234567890'),
+  });
+
+  const packet = handshake.toPacket(0);
+  packet.writeHeader(0);
+
+  return packet.buffer;
+}
+
+await describe('connectTimeout covers the full handshake', async () => {
+  const sockets = new Set<Socket>();
+  let onClientData: () => void;
+  const clientSentHandshakeResponse = new Promise<void>((resolve) => {
+    onClientData = resolve;
+  });
+
+  // sends a valid greeting, then never answers the client HandshakeResponse
+  const server = createTcpServer((socket) => {
+    sockets.add(socket);
+    socket.on('error', () => {});
+    socket.on('data', () => onClientData());
+    socket.write(buildGreeting());
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        return reject(new Error('unexpected server address'));
+      }
+      resolve(address.port);
+    });
+  });
+
+  await it('keeps the timer armed mid-handshake and fails with ETIMEDOUT', async () => {
+    const connection = mysql.createConnection({
+      host: '127.0.0.1',
+      port,
+      user: 'test_user',
+      // generous value: the timer is fired manually below, this only needs to
+      // outlive the test so it cannot race the assertions under load
+      connectTimeout: 60000,
+    });
+
+    let watchdog: NodeJS.Timeout | undefined;
+
+    try {
+      const settled = new Promise<NodeJS.ErrnoException>((resolve, reject) => {
+        watchdog = setTimeout(() => {
+          reject(new Error('connect() never settled'));
+        }, 10000);
+
+        connection.connect((connectError) => {
+          if (!connectError) {
+            return reject(
+              new Error(
+                'connection unexpectedly succeeded against a stalled server'
+              )
+            );
+          }
+
+          resolve(connectError);
+        });
+      });
+      settled.catch(() => {
+        // inspected below; prevents an unhandled rejection when an assertion
+        // fails before `settled` is awaited
+      });
+
+      await clientSentHandshakeResponse;
+
+      // the handshake is in progress and the server went silent: the timer
+      // must still be armed (it used to be cleared by the greeting bytes,
+      // leaving the connection hanging forever)
+      // @ts-expect-error: internal access
+      strict.notEqual(connection.connectTimeout, null);
+
+      // fire the timeout path without waiting out the timer
+      // @ts-expect-error: internal access
+      connection._handleTimeoutError();
+
+      const err = await settled;
+      strict.equal(err.code, 'ETIMEDOUT');
+      strict.equal((err as Error & { fatal?: boolean }).fatal, true);
+    } finally {
+      clearTimeout(watchdog);
+      connection.destroy();
+    }
+  });
+
+  server.close();
+  for (const socket of sockets) {
+    socket.destroy();
+  }
+});
+
+await describe('connectTimeout is cleared once the handshake completes', async () => {
+  // @ts-expect-error: TODO: implement typings
+  const server = mysql.createServer();
+
+  server.on('connection', (conn) => {
+    conn.on('error', () => {
+      // server side of the connection
+      // ignore disconnects
+    });
+    conn.serverHandshake({
+      serverVersion: 'node.js rocks',
+    });
+  });
+
+  const port = await new Promise<number>((resolve, reject) => {
+    // @ts-expect-error: TODO: implement typings
+    server.listen(0, (err?: Error) => {
+      if (err) return reject(err);
+      // @ts-expect-error: internal access
+      resolve(server._server.address().port as number);
+    });
+  });
+
+  await it('clears the timer when the handshake completes', async () => {
+    const connection = mysql.createConnection({
+      host: '127.0.0.1',
+      port,
+      user: 'test_user',
+      connectTimeout: 60000,
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        connection.connect((err) => (err ? reject(err) : resolve()));
+      });
+
+      // @ts-expect-error: internal access
+      strict.equal(connection.connectTimeout, null);
+    } finally {
+      connection.destroy();
+    }
+  });
+
+  // @ts-expect-error: TODO: implement typings
+  server.close();
+});


### PR DESCRIPTION

`connectTimeout` is documented as "the milliseconds before a timeout occurs
during the initial connection to the MySQL server", but the timer is cleared
as soon as the first byte arrives from the server. If the server sends its
greeting and then stops responding mid-handshake (crashed backend, misbehaving
proxy, socket dropped without FIN), the client hangs forever: the connect
timer is already gone, and the query-level `timeout` never arms because it is
set in `Query.start()`, which only runs once the handshake has finished.
`pool.getConnection()` never calls back either. We hit this in production
against RDS — the connection sat there for days until the process was
restarted.

Run this from a repo checkout (a server that sends a valid greeting and never
answers the client's `HandshakeResponse`):

```js
const net = require('net');
const mysql = require('./index.js');
const Handshake = require('./lib/packets/handshake.js');
const ClientFlags = require('./lib/constants/client.js');

const server = net.createServer((socket) => {
  const greeting = new Handshake({
    protocolVersion: 10,
    serverVersion: '8.0.0-stalled',
    connectionId: 1,
    statusFlags: 2,
    characterSet: 8,
    capabilityFlags: 0xffffff ^ (ClientFlags.COMPRESS | ClientFlags.SSL),
    authPluginData1: Buffer.from('12345678'),
    authPluginData2: Buffer.from('901234567890'),
  });
  const packet = greeting.toPacket(0);
  packet.writeHeader(0);
  socket.write(packet.buffer); // greeting, then silence
});

server.listen(3307, () => {
  const conn = mysql.createConnection({
    port: 3307,
    user: 'root',
    connectTimeout: 500,
  });
  conn.connect((err) => console.log('settled:', err && err.code));
});
```

On master this never settles. With this change it prints `settled: ETIMEDOUT`
after 500 ms. The new unit test covers both this case and the healthy path
(timer cleared once the handshake completes, connection unaffected).

The fix moves the clearing from the first `data` event to the `end` listener
of `ClientHandshake`, so the timer covers the whole connection establishment.
Error paths already clear it in `_notifyError()`. Server-side connections
(`isServer`) don't run `ClientHandshake`, so for those the first-byte clearing
is kept as is. The first-byte behavior was introduced in #396, when
`connectTimeout` was originally implemented.

One behavioral note: a handshake that legitimately takes longer than
`connectTimeout` (default 10s) now fails with `ETIMEDOUT` instead of
eventually connecting. That matches what the option documents; raising
`connectTimeout` covers that case.
