### PR TITLE
fix(pool): propagate query dispatch errors instead of throwing

### DIFF
--- a/lib/base/pool.js
+++ b/lib/base/pool.js
@@ -254,7 +254,11 @@ class BasePool extends EventEmitter {
         });
       } catch (e) {
         conn.release();
-        throw e;
+        if (typeof cmdQuery.onResult === 'function') {
+          cmdQuery.onResult(e);
+        } else {
+          cmdQuery.emit('error', e);
+        }
       }
     });
     return cmdQuery;

--- a/test/unit/pool/test-query-error-propagation.test.mts
+++ b/test/unit/pool/test-query-error-propagation.test.mts
@@ -1,0 +1,46 @@
+import { describe, it, strict } from 'poku';
+import BasePool from '../../../lib/base/pool.js';
+
+const createPool = () => {
+  const released: string[] = [];
+  const connection = {
+    query() {
+      throw new Error('Simulated error.');
+    },
+    release() {
+      released.push('released');
+    },
+  };
+  const pool = Object.create(BasePool.prototype);
+
+  pool.config = { connectionConfig: {} };
+  pool.getConnection = (cb: (err: Error | null, conn: unknown) => void) => {
+    setImmediate(() => cb(null, connection));
+  };
+
+  return { pool, released };
+};
+
+await describe('pool.query() error propagation', async () => {
+  await it('forwards dispatch errors to the callback', async () => {
+    const { pool, released } = createPool();
+
+    const error = await new Promise<Error>((resolve) => {
+      pool.query('SELECT 1', [], resolve);
+    });
+
+    strict.strictEqual(error.message, 'Simulated error.');
+    strict.deepStrictEqual(released, ['released']);
+  });
+
+  await it('emits an error event without a callback', async () => {
+    const { pool, released } = createPool();
+
+    const error = await new Promise<Error>((resolve) => {
+      pool.query('SELECT 1').once('error', resolve);
+    });
+
+    strict.strictEqual(error.message, 'Simulated error.');
+    strict.deepStrictEqual(released, ['released']);
+  });
+});


### PR DESCRIPTION
## What

`pool.query()` re-threw any error raised while dispatching a query to a pooled connection, so the error escaped as an `uncaughtException` instead of reaching the caller. This routes it through the query's normal error channel.

Closes #2317

## Why

In `lib/base/pool.js`, `query()` wrapped the dispatch in a `try`/`catch` whose only action was `conn.release()` followed by `throw e`. Because that `throw` happens inside the `getConnection()` callback — on a later tick, no longer on the caller's stack — there is nothing the caller can wrap to catch it, so it becomes an `uncaughtException` and kills the process.

The reporter hit this in production on AWS RDS as `Cannot read properties of undefined (reading 'once')`: when the pooled connection has already switched to the closed state, `conn.query(cmdQuery)` returns `undefined`, so `.once('end', ...)` throws. Attaching an `error` handler to the returned query object did not help, because the error was never routed to that object.

It was also inconsistent with the two adjacent code paths in the same file. The `getConnection()` failure path a few lines above already reports through `cmdQuery.onResult(err)` or an `error` event, and `execute()` just below already does `conn.release(); return cb(e);`.

## How

`throw e` is replaced with exactly the propagation pattern that the `getConnection()` failure path in the same function already uses:

```js
} catch (e) {
  conn.release();
  if (typeof cmdQuery.onResult === 'function') {
    cmdQuery.onResult(e);
  } else {
    cmdQuery.emit('error', e);
  }
}
```

Callback users now receive the failure as `cb(err)`, and streaming users receive it as an `error` event on the object returned by `pool.query()`. `conn.release()` still runs first, so pool accounting is unchanged, and the success path is untouched. The promise wrapper benefits automatically, since it rejects from the same callback.

## Tests

Added `test/unit/pool/test-query-error-propagation.test.mts`. It drives `BasePool.prototype.query` with a stubbed connection whose `query()` throws, and asserts for both call styles that the error reaches the caller and that the connection was released: once via the query callback, and once via the `error` event when no callback is given. Both assertions would have failed before this change, because the throw would have escaped as an uncaught exception instead. The test needs no database.

## Notes

No public API change — this only turns a fatal crash into a normal, catchable error. I could not run the full suite locally, so I am relying on CI for the integration tests.