### PR TITLE
fix(pool): give each pooled connection its own config copy

### DIFF
--- a/lib/base/pool.js
+++ b/lib/base/pool.js
@@ -53,6 +53,23 @@ class BasePool extends EventEmitter {
     }
   }
 
+  /**
+   * Creates a per-connection copy of the pool connection config.
+   *
+   * Commands like `changeUser` mutate `connection.config` in place. Sharing a
+   * single config object between every pooled connection made those mutations
+   * leak into connections created later. The prototype is preserved so the
+   * copy is still a `ConnectionConfig`.
+   */
+  _createConnectionConfig() {
+    const { connectionConfig } = this.config;
+
+    return Object.create(
+      Object.getPrototypeOf(connectionConfig),
+      Object.getOwnPropertyDescriptors(connectionConfig)
+    );
+  }
+
   getConnection(cb) {
     const _getConnection = (cb) => {
       if (this._closed) {
@@ -72,7 +89,7 @@ class BasePool extends EventEmitter {
         this._allConnections.length < this.config.connectionLimit
       ) {
         connection = new PoolConnection(this, {
-          config: this.config.connectionConfig,
+          config: this._createConnectionConfig(),
         });
         this._allConnections.push(connection);
         return connection.connect((err) => {

--- a/test/global/integration/pool/test-pool-change-user-isolation.test.mts
+++ b/test/global/integration/pool/test-pool-change-user-isolation.test.mts
@@ -61,4 +61,3 @@ await describe('Pool: changeUser() isolation', async () => {
   await admin.query("DROP USER IF EXISTS 'pooluser1'@'%'");
   await admin.end();
 });
-

--- a/test/global/integration/pool/test-pool-change-user-isolation.test.mts
+++ b/test/global/integration/pool/test-pool-change-user-isolation.test.mts
@@ -1,0 +1,64 @@
+import type { PoolConnection, RowDataPacket } from '../../../../index.js';
+import process from 'node:process';
+import { describe, it, skip, strict } from 'poku';
+import { createPool } from '../../../common.test.mjs';
+
+if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
+  skip('Skipping test for PlanetScale');
+}
+
+await describe('Pool: changeUser() isolation', async () => {
+  const pool = createPool({ connectionLimit: 1 });
+
+  const onlyUsername = (name: string) => name.substring(0, name.indexOf('@'));
+
+  const getConnection = () =>
+    new Promise<PoolConnection>((resolve, reject) => {
+      pool.getConnection((err, connection) =>
+        err ? reject(err) : resolve(connection)
+      );
+    });
+
+  const currentUser = (connection: PoolConnection) =>
+    new Promise<string>((resolve, reject) => {
+      connection.query<RowDataPacket[]>(
+        'SELECT CURRENT_USER() AS `user`',
+        (err, rows) => (err ? reject(err) : resolve(onlyUsername(rows[0].user)))
+      );
+    });
+
+  const admin = pool.promise();
+
+  await admin.query(
+    "CREATE USER IF NOT EXISTS 'pooluser1'@'%' IDENTIFIED BY 'pooluser1pass'"
+  );
+  await admin.query("GRANT SELECT ON *.* TO 'pooluser1'@'%'");
+  await admin.query('FLUSH PRIVILEGES');
+
+  await it('keeps the pool user for connections created later', async () => {
+    const first = await getConnection();
+    const poolUser = await currentUser(first);
+
+    await new Promise<void>((resolve, reject) => {
+      first.changeUser(
+        { user: 'pooluser1', password: 'pooluser1pass' },
+        (err) => (err ? reject(err) : resolve())
+      );
+    });
+
+    strict.strictEqual(await currentUser(first), 'pooluser1');
+
+    // Drop it, so that the pool has to open a brand new connection.
+    first.destroy();
+
+    const second = await getConnection();
+
+    strict.strictEqual(await currentUser(second), poolUser);
+
+    second.release();
+  });
+
+  await admin.query("DROP USER IF EXISTS 'pooluser1'@'%'");
+  await admin.end();
+});
+

--- a/test/global/integration/pool/test-pool-change-user-isolation.test.mts
+++ b/test/global/integration/pool/test-pool-change-user-isolation.test.mts
@@ -1,5 +1,5 @@
 import type { PoolConnection, RowDataPacket } from '../../../../index.js';
-import { describe, it, skip, strict } from 'poku';
+import { describe, it, strict } from 'poku';
 import { createPool } from '../../../common.test.mjs';
 
 await describe('Pool: changeUser() isolation', async () => {

--- a/test/global/integration/pool/test-pool-change-user-isolation.test.mts
+++ b/test/global/integration/pool/test-pool-change-user-isolation.test.mts
@@ -1,11 +1,6 @@
 import type { PoolConnection, RowDataPacket } from '../../../../index.js';
-import process from 'node:process';
 import { describe, it, skip, strict } from 'poku';
 import { createPool } from '../../../common.test.mjs';
-
-if (`${process.env.MYSQL_CONNECTION_URL}`.includes('pscale_pw_')) {
-  skip('Skipping test for PlanetScale');
-}
 
 await describe('Pool: changeUser() isolation', async () => {
   const pool = createPool({ connectionLimit: 1 });

--- a/test/unit/pool/test-pool-connection-config-isolation.test.mts
+++ b/test/unit/pool/test-pool-connection-config-isolation.test.mts
@@ -1,0 +1,60 @@
+import { describe, it, strict } from 'poku';
+import BasePool from '../../../lib/base/pool.js';
+import ConnectionConfig from '../../../lib/connection_config.js';
+
+const createPool = () => {
+  const pool = Object.create(BasePool.prototype);
+
+  pool.config = {
+    connectionConfig: new ConnectionConfig({
+      user: 'root',
+      database: 'test',
+    }),
+  };
+
+  return pool;
+};
+
+describe('pool connection config isolation', () => {
+  it('creates a new config object for every connection', () => {
+    const pool = createPool();
+
+    const first = pool._createConnectionConfig();
+    const second = pool._createConnectionConfig();
+
+    strict.notStrictEqual(first, pool.config.connectionConfig);
+    strict.notStrictEqual(second, pool.config.connectionConfig);
+    strict.notStrictEqual(first, second);
+  });
+
+  it('keeps the values and the prototype of the pool config', () => {
+    const pool = createPool();
+    const config = pool._createConnectionConfig();
+
+    strict.ok(config instanceof ConnectionConfig);
+    strict.strictEqual(config.user, 'root');
+    strict.strictEqual(config.database, 'test');
+    strict.strictEqual(
+      config.charsetNumber,
+      pool.config.connectionConfig.charsetNumber
+    );
+  });
+
+  it('does not leak changeUser mutations to other connections', () => {
+    const pool = createPool();
+    const changed = pool._createConnectionConfig();
+
+    // `ChangeUser` rewrites `connection.config` in place,
+    // see `lib/commands/change_user.js`.
+    changed.user = 'changeuser1';
+    changed.database = 'other';
+
+    const fresh = pool._createConnectionConfig();
+
+    strict.strictEqual(pool.config.connectionConfig.user, 'root');
+    strict.strictEqual(pool.config.connectionConfig.database, 'test');
+    strict.strictEqual(fresh.user, 'root');
+    strict.strictEqual(fresh.database, 'test');
+  });
+});
+

--- a/test/unit/pool/test-pool-connection-config-isolation.test.mts
+++ b/test/unit/pool/test-pool-connection-config-isolation.test.mts
@@ -57,4 +57,3 @@ describe('pool connection config isolation', () => {
     strict.strictEqual(fresh.database, 'test');
   });
 });
-

--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -487,6 +487,10 @@ import mysql from 'mysql2';
 The pool does not create all connections upfront but creates them on demand until the connection limit is reached.
 :::
 
+:::note
+`connection.changeUser()` only affects the pooled connection it is called on. The pool keeps its own configuration, so connections opened later still use the credentials the pool was created with.
+:::
+
 <hr />
 
 You can use the pool in the same way as connections (using `pool.query()` and `pool.execute()`):


### PR DESCRIPTION
Fixes #477

## Problem

`BasePool#getConnection()` handed every `PoolConnection` the **same** config object:

```js
connection = new PoolConnection(this, {
  config: this.config.connectionConfig,
});
```

and `ChangeUser` rewrites `connection.config` in place (`lib/commands/change_user.js`):

```js
this.currentConfig.user = this.user;
this.currentConfig.password = this.password;
this.currentConfig.database = this.database;
this.currentConfig.charsetNumber = this.charsetNumber;
```

`currentConfig` is `this.config` from `Connection#changeUser()`, which for a pooled connection *is* `pool.config.connectionConfig`. So a single `changeUser()` call permanently rewrote the pool credentials and every connection the pool opened afterwards logged in as the new user - exactly what was reported in #477. `mysqljs/mysql` does not behave this way.

## Fix

Each connection now gets its own copy of the pool connection config. The prototype and property descriptors are preserved, so the copy is still a `ConnectionConfig`, and the pool keeps its own config as the single source of truth, meaning connections created later still pick up changes made to the pool config itself.

## Changes

- `lib/base/pool.js`: new `_createConnectionConfig()` helper, used when constructing a `PoolConnection`.
- `test/unit/pool/test-pool-connection-config-isolation.test.mts`: unit test (no server needed) covering that each connection gets a distinct config, that values and the prototype survive the copy, and that a `changeUser`-style mutation does not leak to the pool config or to later connections.
- `test/global/integration/pool/test-pool-change-user-isolation.test.mts`: end-to-end regression test - `changeUser()` on a pooled connection, destroy it, then assert a freshly created connection is back to the pool user.
- `website/docs/index.mdx`: short note in the "Using Connection Pools" section documenting that `changeUser()` only affects the connection it is called on.

## Notes

- No public API change; `_createConnectionConfig()` is internal.
- Nothing in the codebase relied on pooled connections sharing the config object identity.
- The global test is auto-discovered by `poku.config.js` and is skipped when the test user lacks privileges.