### PR TITLE
fix: zero dates come back as "undefined 00:00:00" with dateStrings

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -11,6 +11,7 @@ const Long = require('long');
 const StringParser = require('../parsers/string.js');
 const Types = require('../constants/types.js');
 const INVALID_DATE = new Date(NaN);
+const ZERO_DATE = '0000-00-00';
 
 // this is nearly duplicate of previous function so generated code is not slower
 // due to "if (dateStrings)" branching
@@ -317,7 +318,7 @@ class Packet {
       return new Date(y, m - 1, d, H, M, S, ms);
     }
     let str = this.readDateTimeString(6, 'T', null);
-    if (!str) {
+    if (str.startsWith(ZERO_DATE)) {
       return INVALID_DATE;
     }
     if (str.length === 10) {
@@ -335,7 +336,7 @@ class Packet {
     let M = 0;
     let S = 0;
     let ms = 0;
-    let str;
+    let str = ZERO_DATE;
     if (length > 3) {
       y = this.readInt16();
       m = this.readInt8();

--- a/test/integration/connection/test-datestrings-binary-zero-date.test.mts
+++ b/test/integration/connection/test-datestrings-binary-zero-date.test.mts
@@ -1,0 +1,38 @@
+import type { RowDataPacket } from '../../../index.js';
+import { describe, it, strict } from 'poku';
+import { createConnection } from '../../common.test.mjs';
+
+await describe('dateStrings: binary protocol keeps the zero date of DATE/DATETIME/TIMESTAMP', async () => {
+  const connection = createConnection({ dateStrings: true }).promise();
+
+  const [modes] = await connection.query<RowDataPacket[]>(
+    'SELECT @@sql_mode AS value'
+  );
+  const relaxedMode = String(modes[0].value)
+    .split(',')
+    .filter((mode) => mode !== 'NO_ZERO_DATE' && mode !== 'NO_ZERO_IN_DATE')
+    .join(',');
+
+  await connection.query('SET sql_mode=?', [relaxedMode]);
+  await connection.query(
+    'CREATE TEMPORARY TABLE zero_dates (d DATE, dt DATETIME, ts TIMESTAMP NULL)'
+  );
+  await connection.query(
+    "INSERT INTO zero_dates VALUES ('0000-00-00', '0000-00-00 00:00:00', '0000-00-00 00:00:00')"
+  );
+
+  const [rows] = await connection.execute<RowDataPacket[]>(
+    'SELECT * FROM zero_dates'
+  );
+
+  await it('returns the zero DATETIME and TIMESTAMP as strings', () => {
+    strict.equal(rows[0].dt, '0000-00-00 00:00:00');
+    strict.equal(rows[0].ts, '0000-00-00 00:00:00');
+  });
+
+  await it('returns the zero DATE as a string', () => {
+    strict.equal(rows[0].d, '0000-00-00');
+  });
+
+  await connection.end();
+});


### PR DESCRIPTION
With `dateStrings` on, a zero `DATETIME` or `TIMESTAMP` read through `execute()` comes back as the string `undefined 00:00:00`, and a zero `DATE` as plain `undefined`. `query()` gives `0000-00-00 00:00:00` and `0000-00-00` for the same rows. Thats MySQL 9.7.2 here, I've not tried MariaDB. A `typeCast` function calling `field.string()` lands on it too, without `dateStrings` involved at all.

When every part of the value is zero the server sends a zero-length payload, so `str` never gets assigned and the midnight branch appends to `undefined`. `test-datestrings-binary-zero-time.test.mts` covers the neighbouring case but uses a real date at midnight, so it never reaches that path.

The `!str` check in `readDateTime` was only there to swalow the undefined (#4258), so it's looking for the zero date itself now. Read as `Date`s they're still `Invalid Date` and `test-#1019.test.mts` passes either way.
