### PR TITLE
ci: pin EXPLAIN to FORMAT=TRADITIONAL for MySQL 9.5+

### DIFF
--- a/test/integration/connection/test-execute-nocolumndef.test.mts
+++ b/test/integration/connection/test-execute-nocolumndef.test.mts
@@ -255,12 +255,18 @@ await describe('Execute No Column Definition', async () => {
   const { isMariaDB } = await getMysqlVersion(connection);
   const rowsExpectation = isMariaDB ? expectedRowsMariaDB : expectedRows;
   const fieldsExpectation = isMariaDB ? expectedFieldsMariaDB : expectedFields;
+  // MySQL 9.5 changed the default explain_format from TRADITIONAL to TREE,
+  // whose output is not deterministic; pin the tabular format the assertions
+  // expect. MariaDB has no explain_format and stays tabular by default.
+  const explainQuery = isMariaDB
+    ? 'explain SELECT 1'
+    : 'explain format=traditional SELECT 1';
 
   await it('should handle explain with no column definitions', async () => {
     const [rows, fields] = await new Promise<[RowDataPacket[], FieldPacket[]]>(
       (resolve, reject) => {
         connection.execute<RowDataPacket[]>(
-          'explain SELECT 1',
+          explainQuery,
           (err, _rows, _fields) =>
             err ? reject(err) : resolve([_rows, _fields])
         );


### PR DESCRIPTION
## Problem

`test/integration/connection/test-execute-nocolumndef.test.mts` fails against MySQL ≥ 9.5 (current `mysql:9` / `mysql:lts` images), while passing on 5.7–9.0 and MariaDB.

## Root cause

MySQL 9.5.0 changed the default of the `explain_format` system variable from `TRADITIONAL` to `TREE` (same change that hit rails/rails#55958). A bare `EXPLAIN SELECT 1` now returns a single `EXPLAIN` column whose text embeds optimizer cost numbers:

```
-> Rows fetched before execution  (cost=0..0 rows=1)
```

The driver parses this resultset fine — only the test's hard-coded rows/fields expectations assume the traditional 12-column table. CI's `mysql:9.0` job predates the default flip, which is why CI stayed green.

## Fix

Pin the statement to `explain format=traditional SELECT 1` on MySQL so the assertions stay deterministic. `FORMAT=TRADITIONAL` is accepted since MySQL 5.6 and emits no deprecation warning on 9.7.

MariaDB keeps the bare `explain`: it has no `explain_format` variable, its tabular default is unchanged, and its expectations were already branched via `isMariaDB` (I only verified `FORMAT=TRADITIONAL` support on MariaDB 12.3, not CI's 11.8, so the MariaDB path is deliberately untouched).

The test's actual purpose — the binary-protocol path from #130 / #37 where `COM_STMT_PREPARE` returns **zero column definitions** and fields only arrive at execute — is preserved: verified that prepare still returns 0 columns for the pinned statement on 8.3 and 9.7.

## Verification

Test passes against all four local servers, `npm run typecheck` and `npm run lint` clean:

| Server | Result |
| --- | --- |
| MySQL 5.7.44 | ✅ |
| MySQL 8.3.0 | ✅ |
| MySQL 9.7.2 (`explain_format=TREE` default) | ✅ |
| MariaDB 12.3.2 | ✅ |