### PR TITLE
perf: serialize COM_STMT_EXECUTE in a single exact-size pass

### DIFF
--- a/benchmarks/perf/ANALYSIS.md
+++ b/benchmarks/perf/ANALYSIS.md
@@ -108,7 +108,45 @@ Cheap, user-visible wins worth surfacing in the docs:
 - `trace: false` in production hot paths: ~10% less client CPU per promise-API query (now honored by the promise wrapper).
 - `.stream()` for 100k+-row results: bounds memory and avoids major-GC stalls from megabyte row arrays.
 
-## 7. Repro
+## 7. Follow-up: outgoing packet serialization (branch `packet-buffer-allocation`, Aug 2026)
+
+Write-path counterpart to the receive-path work above. Benchmarked with `serialize.js`, a synchronous `toPacket()` loop with no socket; run it interleaved against a baseline checkout and compare best-of-N, since run-to-run variance on a shared machine exceeds small deltas.
+
+**Baseline.** `Execute.toPacket()` serialized every `COM_STMT_EXECUTE` twice: a dry run against `Packet.MockBuffer()` to learn the length, then the real pass. Both passes called `toParameter` per parameter, and both `lengthCodedStringLength` and `writeLengthCodedString` encode the string, so one string parameter was UTF-8-encoded **four times** per execute. `Query.toPacket()` had the same shape on its attribute path (the no-attribute fast path was already single-pass, see §3.1).
+
+**Change.** Every parameter encoder already returns the exact wire length of its value, so the dry run is redundant: `toPacket` now encodes each parameter once, sums the exact packet length arithmetically, allocates once, and writes once. String-shaped values are encoded to bytes inside `toParameter`/`lengthCodedEncoder` and written with `writeLengthCodedBuffer`, so each string is encoded exactly once. `timeEncoder` previously declared `length: 13` while `writeTime` emits 1, 9, or 13 bytes; it now computes the exact length (`Packet.timeLength`, kept next to `writeTime`). Because a length/writer drift would otherwise send uninitialized `allocUnsafe` bytes to the server, both serializers end with an `offset === length` guard that throws instead of returning a short-filled packet, and a unit test pins `parameter.length` to the bytes each writer actually emits across the full type matrix. Byte-for-byte equivalence with the old serializer was verified over randomized packets (legacy, typed and hinted parameters, three charsets including an iconv one, both flag modes, attributes with multibyte names).
+
+Two pre-existing `COM_QUERY` attribute-path bugs fell out of the rewrite: a typed NULL attribute (e.g. `TypedParameter.INT(null)`) kept its declared type so the null bitmap was never set and the packet was malformed, and the unsigned flag of typed attributes was hardcoded to 0. Both now match the `COM_STMT_EXECUTE` path, with regression tests.
+
+### Measured results (`serialize.js`, interleaved best-of-3, M1 Pro)
+
+| Scenario                        | Baseline ops/s | Single-pass | Δ         |
+| ------------------------------- | -------------- | ----------- | --------- |
+| execute, 3 params (num/str/dbl) | 222k           | 1 454k      | **6.6×**  |
+| execute, same, no attr flag     | 328k           | 1 399k      | **4.3×**  |
+| execute, 10 short strings       | 46k            | 245k        | **5.3×**  |
+| execute, 3 dates                | 191k           | 750k        | **3.9×**  |
+| execute, typed mixed            | 174k           | 559k        | **3.2×**  |
+| execute, 3 params + attribute   | 163k           | 727k        | **4.5×**  |
+| execute, no params              | 1 950k         | 5 329k      | **2.7×**  |
+| execute, 16KB blob              | 166k           | 226k        | 1.4×      |
+| query, 2 attributes             | 211k           | 629k        | **3.0×**  |
+| query, no attributes (§3.1)     | 3 393k         | 3 687k      | unchanged |
+
+E2E deltas are not reportable: on this shared Docker setup the execute scenarios sit at 2–14% client CPU and swing ±50% between runs; the full test suite passes against MySQL 5.7/8.3/9 and MariaDB LTS.
+
+### Buffer pooling and size heuristics: measured, not adopted
+
+The classic alternatives — a pool of pre-allocated send buffers, or serializing into a growable scratch buffer sized by heuristic — were measured (`serialize.js --alloc`) and rejected for this path:
+
+- `Buffer.allocUnsafe` costs 76ns at 32B, 129ns at 256B, 286ns at 1KB (Node's internal 8KB slab already pools small allocations); a pooled-slab view (`subarray`) costs ~70ns flat. For the typical sub-1KB command packet a pool's _best case_ saves a few percent of the packet's build cost — before paying its real costs.
+- The real costs are structural: `stream.write()` retains the buffer until flushed, so pooled buffers could only be recycled from the write callback, and TLS, the compressed protocol (async zlib holds the input), and >16MB packet slicing all alias the buffer with their own lifetimes. A bug in that tracking sends another packet's bytes — a cross-connection data leak, not just corruption.
+- Real `malloc` only starts at ≥4KB (1.4µs at 4KB, 3µs at 16KB), but such packets are dominated by their payload memcpy and the server round trip; the 16KB-blob row above moved only 1.4× for this reason.
+- A size _heuristic_ is unnecessary: every parameter encoder knows its exact wire length, so exact computation replaces guessing, growth, and copy-out (a 64KB copy-out costs 12µs — worse than the allocation it would avoid).
+
+The receive path already avoids per-packet allocation (§3.8): complete packets are views over the socket chunk delivered through one reused `Packet`; only a packet spanning chunk boundaries allocates (~one per 64KB chunk), and pooling those buffers is off the table because BLOB values and column definitions alias them for arbitrarily long (§5.2c).
+
+## 8. Repro
 
 ```sh
 docker run -d --name mysql83-bench -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_DATABASE=test -p 3308:3306 mysql:8.3
@@ -117,4 +155,6 @@ MYSQL_PORT=3308 node benchmarks/perf/capture.js     # record wire fixtures
 ./benchmarks/perf/run-all.sh all 3308               # full matrix
 node --cpu-prof --cpu-prof-dir=profiles benchmarks/perf/replay.js select-1m-3cols captured
 node benchmarks/perf/profile-summary.js profiles/<file>.cpuprofile
+node benchmarks/perf/serialize.js                   # outgoing toPacket() scenarios
+node benchmarks/perf/serialize.js --alloc           # allocation-strategy micro
 ```

--- a/benchmarks/perf/serialize.js
+++ b/benchmarks/perf/serialize.js
@@ -1,0 +1,180 @@
+'use strict';
+
+// Isolated benchmark for outgoing packet serialization (toPacket): the
+// client->server write path. No server, no socket, sync tight loop.
+//
+// Usage: node benchmarks/perf/serialize.js [filter]
+//        node benchmarks/perf/serialize.js --alloc   (allocation-strategy micro)
+
+const Query = require('../../lib/packets/query.js');
+const Execute = require('../../lib/packets/execute.js');
+const ClientConstants = require('../../lib/constants/client.js');
+const { types } = require('../../lib/packets/typed_parameter.js');
+
+const QA = ClientConstants.CLIENT_QUERY_ATTRIBUTES;
+const CHARSET = 224; // utf8mb4_unicode_ci
+
+const now = () => process.hrtime.bigint();
+const ms = (delta) => Number(delta) / 1e6;
+
+function bench(name, fn, opts = {}) {
+  const batch = opts.batch || 1000;
+  const minMs = opts.minMs || Number(process.env.BENCH_MS || 1500);
+  const warmupMs = opts.warmupMs || 400;
+  let sink = 0;
+  let t0 = now();
+  while (ms(now() - t0) < warmupMs) {
+    for (let i = 0; i < batch; i++) {
+      sink += fn();
+    }
+  }
+  let iters = 0;
+  t0 = now();
+  let elapsed = 0;
+  do {
+    for (let i = 0; i < batch; i++) {
+      sink += fn();
+    }
+    iters += batch;
+    elapsed = ms(now() - t0);
+  } while (elapsed < minMs);
+  const opsPerSec = iters / (elapsed / 1000);
+  const nsPerOp = (elapsed * 1e6) / iters;
+  console.log(
+    `${name.padEnd(34)} ${Math.round(opsPerSec).toString().padStart(12)} ops/s | ${nsPerOp.toFixed(0).padStart(8)} ns/op`
+  );
+  if (process.env.BENCH_JSON) {
+    console.log(`@@RESULT@@${JSON.stringify({ name, opsPerSec, nsPerOp })}`);
+  }
+  return sink;
+}
+
+const shortStrings = Array.from(
+  { length: 10 },
+  (_, i) => `value-${i}-abcdefghijklmnopqrstuvw`
+);
+const dates = [
+  new Date(2026, 0, 15, 10, 30, 0),
+  new Date(2026, 5, 1, 0, 0, 1, 500),
+  new Date(2026, 11, 31, 23, 59, 59),
+];
+const blob16k = Buffer.alloc(16384, 0xab);
+
+const scenarios = {
+  'query-select-1': () =>
+    new Query('SELECT 1', CHARSET, undefined, QA).toPacket().buffer.length,
+  'query-insert-120b': () =>
+    new Query(
+      `INSERT INTO t_insert (a, b) VALUES (42, '${'x'.repeat(80)}')`,
+      CHARSET,
+      undefined,
+      QA
+    ).toPacket().buffer.length,
+  'query-2-attrs': () =>
+    new Query(
+      'SELECT 1',
+      CHARSET,
+      { trace_id: 'abc123ef', span_id: '0011223344' },
+      QA
+    ).toPacket().buffer.length,
+  'execute-0-params': () =>
+    new Execute(5, [], CHARSET, 'local', undefined, QA).toPacket().buffer
+      .length,
+  'execute-3-params': () =>
+    new Execute(
+      5,
+      [42, 'hello world payload', 3.1415],
+      CHARSET,
+      'local',
+      undefined,
+      QA
+    ).toPacket().buffer.length,
+  'execute-3-params-noattrs': () =>
+    new Execute(
+      5,
+      [42, 'hello world payload', 3.1415],
+      CHARSET,
+      'local',
+      undefined,
+      0
+    ).toPacket().buffer.length,
+  'execute-10-strings': () =>
+    new Execute(5, shortStrings, CHARSET, 'local', undefined, QA).toPacket()
+      .buffer.length,
+  'execute-3-dates': () =>
+    new Execute(5, dates, CHARSET, 'local', undefined, QA).toPacket().buffer
+      .length,
+  'execute-typed-mixed': () =>
+    new Execute(
+      5,
+      [
+        types.BIGINT(1234567890123n),
+        types.VARCHAR('abcdefgh'),
+        types.DATETIME(dates[0]),
+      ],
+      CHARSET,
+      'local',
+      undefined,
+      QA
+    ).toPacket().buffer.length,
+  'execute-attrs-3-params': () =>
+    new Execute(
+      5,
+      [42, 'hello world payload', 3.1415],
+      CHARSET,
+      'local',
+      {
+        traceparent: '00-0123456789abcdef0123456789abcdef-0123456789abcdef-01',
+      },
+      QA
+    ).toPacket().buffer.length,
+  'execute-blob-16k': () =>
+    new Execute(5, [blob16k], CHARSET, 'local', undefined, QA).toPacket().buffer
+      .length,
+};
+
+const allocScenarios = () => {
+  // What a buffer pool could save at best: allocation cost alone, by size.
+  for (const size of [32, 256, 1024, 4096, 16384, 65536, 1048576]) {
+    const batch = size >= 65536 ? 200 : 2000;
+    bench(`allocUnsafe-${size}`, () => Buffer.allocUnsafe(size).length, {
+      batch,
+    });
+  }
+  const slab = Buffer.allocUnsafe(1 << 20);
+  for (const size of [32, 256, 1024, 4096, 16384, 65536]) {
+    // pool best case: no allocation, only an exact-size view of a pooled slab
+    bench(`slab-subarray-${size}`, () => slab.subarray(0, size).length, {
+      batch: 2000,
+    });
+    // scratch strategy: serialize into slab, copy out an exact-size buffer
+    bench(
+      `slab-copy-out-${size}`,
+      () => {
+        const out = Buffer.allocUnsafe(size);
+        slab.copy(out, 0, 0, size);
+        return out.length;
+      },
+      { batch: 2000 }
+    );
+  }
+};
+
+function main() {
+  const arg = process.argv[2];
+  if (arg === '--alloc') {
+    allocScenarios();
+    return;
+  }
+  let total = 0;
+  for (const [name, fn] of Object.entries(scenarios)) {
+    if (arg && !name.includes(arg)) {
+      continue;
+    }
+    const batch = name.includes('blob-16k') ? 200 : 1000;
+    total += bench(name, fn, { batch });
+  }
+  console.log(`(sink ${total & 0xffff})`);
+}
+
+main();

--- a/lib/packets/encode_parameter.js
+++ b/lib/packets/encode_parameter.js
@@ -2,6 +2,7 @@
 
 const Types = require('../constants/types');
 const Packet = require('../packets/packet');
+const StringParser = require('../parsers/string.js');
 const {
   TypedParameter,
   encodeTypedParameter,
@@ -33,9 +34,7 @@ function toParameter(value, encoding, timezone, jsonAsString, hint) {
   }
   let type = Types.VAR_STRING;
   let length;
-  let writer = function (value) {
-    return Packet.prototype.writeLengthCodedString.call(this, value, encoding);
-  };
+  let writer = Packet.prototype.writeLengthCodedBuffer;
   if (value !== null) {
     switch (typeof value) {
       case 'undefined':
@@ -86,9 +85,12 @@ function toParameter(value, encoding, timezone, jsonAsString, hint) {
   } else {
     value = '';
     type = Types.NULL;
+    length = 0;
+    writer = writeNothing;
   }
-  if (!length) {
-    length = Packet.lengthCodedStringLength(value, encoding);
+  if (length === undefined) {
+    value = StringParser.encode(value, encoding);
+    length = Packet.lengthCodedNumberLength(value.length) + value.length;
   }
   return {
     value,
@@ -99,5 +101,7 @@ function toParameter(value, encoding, timezone, jsonAsString, hint) {
     isNull: type === Types.NULL,
   };
 }
+
+function writeNothing() {}
 
 module.exports = { toParameter, isJSON };

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -5,6 +5,7 @@ const CommandCodes = require('../constants/commands');
 const ClientConstants = require('../constants/client');
 const Types = require('../constants/types');
 const Packet = require('../packets/packet');
+const StringParser = require('../parsers/string.js');
 const CharsetToEncoding = require('../constants/charset_encodings.js');
 const { toParameter } = require('./encode_parameter.js');
 
@@ -97,7 +98,7 @@ class Execute {
     return { stmtId, flags, iterationCount, values };
   }
 
-  _serializeToBuffer(buffer) {
+  toPacket() {
     const useQueryAttributes =
       this.clientFlags & ClientConstants.CLIENT_QUERY_ATTRIBUTES;
 
@@ -107,7 +108,53 @@ class Execute {
     const numAttrs = attrNames.length;
     const totalParams = numParams + numAttrs;
 
-    const packet = new Packet(0, buffer, 0, buffer.length);
+    // packet header, command, statement id, cursor flags, iteration count
+    let length = 14;
+    if (useQueryAttributes) {
+      length += Packet.lengthCodedNumberLength(totalParams);
+    }
+
+    let allParams = null;
+    let attrNameBuffers = null;
+    if (totalParams > 0) {
+      allParams = new Array(totalParams);
+      for (let i = 0; i < numParams; i++) {
+        allParams[i] = toParameter(
+          this.parameters[i],
+          this.encoding,
+          this.timezone,
+          this.jsonAsString,
+          this.parameterDefinitions[i]
+        );
+      }
+      for (let i = 0; i < numAttrs; i++) {
+        allParams[numParams + i] = toParameter(
+          this.attributes[attrNames[i]],
+          this.encoding,
+          this.timezone
+        );
+      }
+
+      // null bitmap, new-params-bound flag, type and unsigned byte per parameter
+      length += ((totalParams + 7) >> 3) + 1 + totalParams * 2;
+      if (useQueryAttributes) {
+        // one empty length-coded name per bind parameter
+        length += numParams;
+        attrNameBuffers = new Array(numAttrs);
+        for (let i = 0; i < numAttrs; i++) {
+          const name = StringParser.encode(attrNames[i], this.encoding);
+          attrNameBuffers[i] = name;
+          length += Packet.lengthCodedNumberLength(name.length) + name.length;
+        }
+      }
+      for (let i = 0; i < totalParams; i++) {
+        if (!allParams[i].isNull) {
+          length += allParams[i].length;
+        }
+      }
+    }
+
+    const packet = new Packet(0, Buffer.allocUnsafe(length), 0, length);
     packet.offset = 4;
     packet.writeInt8(CommandCodes.STMT_EXECUTE);
     packet.writeInt32(this.id);
@@ -124,29 +171,11 @@ class Execute {
     }
 
     if (totalParams > 0) {
-      const bindParams =
-        numParams > 0
-          ? this.parameters.map((v, i) =>
-              toParameter(
-                v,
-                this.encoding,
-                this.timezone,
-                this.jsonAsString,
-                this.parameterDefinitions[i]
-              )
-            )
-          : [];
-      const attrParams = attrNames.map((name) =>
-        toParameter(this.attributes[name], this.encoding, this.timezone)
-      );
-      const allParams = bindParams.concat(attrParams);
-
-      // null bitmap
       let bitmap = 0;
       let bitValue = 1;
-      allParams.forEach((parameter) => {
-        if (parameter.isNull) {
-          bitmap += bitValue;
+      for (let i = 0; i < totalParams; i++) {
+        if (allParams[i].isNull) {
+          bitmap |= bitValue;
         }
         bitValue *= 2;
         if (bitValue === 256) {
@@ -154,37 +183,40 @@ class Execute {
           bitmap = 0;
           bitValue = 1;
         }
-      });
+      }
       if (bitValue !== 1) {
         packet.writeInt8(bitmap);
       }
 
       packet.writeInt8(1); // new-params-bound-flag
 
-      // types (and names for attributes)
-      for (let i = 0; i < allParams.length; i++) {
-        packet.writeInt8(allParams[i].type);
-        packet.writeInt8(allParams[i].unsigned ? 0x80 : 0);
+      for (let i = 0; i < totalParams; i++) {
+        const parameter = allParams[i];
+        packet.writeInt8(parameter.type);
+        packet.writeInt8(parameter.unsigned ? 0x80 : 0);
         if (useQueryAttributes) {
-          const name = i < numParams ? '' : attrNames[i - numParams];
-          packet.writeLengthCodedString(name, this.encoding);
+          if (i < numParams) {
+            packet.writeInt8(0); // bind parameters have an empty name
+          } else {
+            packet.writeLengthCodedBuffer(attrNameBuffers[i - numParams]);
+          }
         }
       }
 
-      // values
-      allParams.forEach((parameter) => {
+      for (let i = 0; i < totalParams; i++) {
+        const parameter = allParams[i];
         if (!parameter.isNull) {
           parameter.writer.call(packet, parameter.value);
         }
-      });
+      }
     }
 
+    if (packet.offset !== length) {
+      throw new Error(
+        `Internal error: COM_STMT_EXECUTE serialized ${packet.offset - 4} bytes, expected ${length - 4}`
+      );
+    }
     return packet;
-  }
-
-  toPacket() {
-    const p = this._serializeToBuffer(Packet.MockBuffer());
-    return this._serializeToBuffer(Buffer.allocUnsafe(p.offset));
   }
 }
 

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -965,6 +965,14 @@ class Packet {
     this.offset += bytes;
   }
 
+  // must match writeTime's choice of encoding byte for byte
+  static timeLength({ days, hours, minutes, seconds, microseconds }) {
+    if (!days && !hours && !minutes && !seconds && !microseconds) {
+      return 1;
+    }
+    return microseconds ? 13 : 9;
+  }
+
   writeTime({ negative, days, hours, minutes, seconds, microseconds }) {
     if (!days && !hours && !minutes && !seconds && !microseconds) {
       this.writeInt8(0);

--- a/lib/packets/query.js
+++ b/lib/packets/query.js
@@ -5,7 +5,6 @@ const CommandCode = require('../constants/commands.js');
 const StringParser = require('../parsers/string.js');
 const CharsetToEncoding = require('../constants/charset_encodings.js');
 const ClientConstants = require('../constants/client.js');
-const Types = require('../constants/types.js');
 const { toParameter } = require('./encode_parameter.js');
 
 class Query {
@@ -15,67 +14,6 @@ class Query {
     this.encoding = CharsetToEncoding[charsetNumber];
     this.attributes = attributes;
     this.clientFlags = clientFlags || 0;
-  }
-
-  serializeToBuffer(buffer) {
-    const useQueryAttributes =
-      this.clientFlags & ClientConstants.CLIENT_QUERY_ATTRIBUTES;
-    const sqlBuf = StringParser.encode(this.query, this.encoding);
-    const packet = new Packet(0, buffer, 0, buffer.length);
-    packet.offset = 4;
-    packet.writeInt8(CommandCode.QUERY);
-
-    if (useQueryAttributes) {
-      const attrs = this.attributes;
-      const names = attrs ? Object.keys(attrs) : [];
-      const paramCount = names.length;
-
-      packet.writeLengthCodedNumber(paramCount);
-      packet.writeLengthCodedNumber(1); // parameter_set_count, always 1
-
-      if (paramCount > 0) {
-        const parameters = names.map((name) =>
-          toParameter(attrs[name], this.encoding, 'local')
-        );
-
-        // null bitmap
-        let bitmap = 0;
-        let bitValue = 1;
-        parameters.forEach((parameter) => {
-          if (parameter.type === Types.NULL) {
-            bitmap += bitValue;
-          }
-          bitValue *= 2;
-          if (bitValue === 256) {
-            packet.writeInt8(bitmap);
-            bitmap = 0;
-            bitValue = 1;
-          }
-        });
-        if (bitValue !== 1) {
-          packet.writeInt8(bitmap);
-        }
-
-        packet.writeInt8(1); // new_params_bind_flag
-
-        // types and names
-        for (let i = 0; i < paramCount; i++) {
-          packet.writeInt8(parameters[i].type);
-          packet.writeInt8(0); // unsigned flag
-          packet.writeLengthCodedString(names[i], this.encoding);
-        }
-
-        // values
-        parameters.forEach((parameter) => {
-          if (parameter.type !== Types.NULL) {
-            parameter.writer.call(packet, parameter.value);
-          }
-        });
-      }
-    }
-
-    packet.writeBuffer(sqlBuf);
-    return packet;
   }
 
   toPacket() {
@@ -119,9 +57,81 @@ class Query {
       return packet;
     }
 
-    // dry run to calculate required buffer length
-    const p = this.serializeToBuffer(Packet.MockBuffer());
-    return this.serializeToBuffer(Buffer.allocUnsafe(p.offset));
+    const names = Object.keys(this.attributes);
+    const parameters = new Array(attributeCount);
+    const nameBuffers = new Array(attributeCount);
+
+    // packet header, command, parameter count, parameter_set_count (always
+    // the single-byte form), null bitmap, new_params_bind_flag, type and
+    // unsigned byte per parameter
+    let length =
+      5 +
+      Packet.lengthCodedNumberLength(attributeCount) +
+      1 +
+      ((attributeCount + 7) >> 3) +
+      1 +
+      attributeCount * 2;
+    for (let i = 0; i < attributeCount; i++) {
+      parameters[i] = toParameter(
+        this.attributes[names[i]],
+        this.encoding,
+        'local'
+      );
+      const name = StringParser.encode(names[i], this.encoding);
+      nameBuffers[i] = name;
+      length += Packet.lengthCodedNumberLength(name.length) + name.length;
+      if (!parameters[i].isNull) {
+        length += parameters[i].length;
+      }
+    }
+    const sqlBuffer = StringParser.encode(this.query, this.encoding);
+    length += sqlBuffer.length;
+
+    const packet = new Packet(0, Buffer.allocUnsafe(length), 0, length);
+    packet.offset = 4;
+    packet.writeInt8(CommandCode.QUERY);
+    packet.writeLengthCodedNumber(attributeCount);
+    packet.writeLengthCodedNumber(1); // parameter_set_count, always 1
+
+    let bitmap = 0;
+    let bitValue = 1;
+    for (let i = 0; i < attributeCount; i++) {
+      if (parameters[i].isNull) {
+        bitmap |= bitValue;
+      }
+      bitValue *= 2;
+      if (bitValue === 256) {
+        packet.writeInt8(bitmap);
+        bitmap = 0;
+        bitValue = 1;
+      }
+    }
+    if (bitValue !== 1) {
+      packet.writeInt8(bitmap);
+    }
+
+    packet.writeInt8(1); // new_params_bind_flag
+
+    for (let i = 0; i < attributeCount; i++) {
+      packet.writeInt8(parameters[i].type);
+      packet.writeInt8(parameters[i].unsigned ? 0x80 : 0);
+      packet.writeLengthCodedBuffer(nameBuffers[i]);
+    }
+
+    for (let i = 0; i < attributeCount; i++) {
+      if (!parameters[i].isNull) {
+        parameters[i].writer.call(packet, parameters[i].value);
+      }
+    }
+
+    packet.writeBuffer(sqlBuffer);
+
+    if (packet.offset !== length) {
+      throw new Error(
+        `Internal error: COM_QUERY serialized ${packet.offset - 4} bytes, expected ${length - 4}`
+      );
+    }
+    return packet;
   }
 }
 

--- a/lib/packets/typed_parameter.js
+++ b/lib/packets/typed_parameter.js
@@ -2,6 +2,7 @@
 
 const Types = require('../constants/types.js');
 const Packet = require('./packet.js');
+const StringParser = require('../parsers/string.js');
 
 const INTEGER_BYTES = {
   [Types.TINY]: 1,
@@ -223,31 +224,30 @@ function toTimeParts(value) {
 }
 
 function timeEncoder() {
-  return (value) => ({
-    value: toTimeParts(value),
-    length: 13,
-    writer(v) {
-      this.writeTime(v);
-    },
-  });
+  return (value) => {
+    const parts = toTimeParts(value);
+    return {
+      value: parts,
+      length: Packet.timeLength(parts),
+      writer(v) {
+        this.writeTime(v);
+      },
+    };
+  };
 }
 
 function lengthCodedEncoder(encoding) {
   return (value) => {
-    if (Buffer.isBuffer(value)) {
-      return {
-        value,
-        length: Packet.lengthCodedNumberLength(value.length) + value.length,
-        writer: Packet.prototype.writeLengthCodedBuffer,
-      };
-    }
-    const str = typeof value === 'string' ? value : String(value);
+    const buffer = Buffer.isBuffer(value)
+      ? value
+      : StringParser.encode(
+          typeof value === 'string' ? value : String(value),
+          encoding
+        );
     return {
-      value: str,
-      length: Packet.lengthCodedStringLength(str, encoding),
-      writer(v) {
-        Packet.prototype.writeLengthCodedString.call(this, v, encoding);
-      },
+      value: buffer,
+      length: Packet.lengthCodedNumberLength(buffer.length) + buffer.length,
+      writer: Packet.prototype.writeLengthCodedBuffer,
     };
   };
 }

--- a/test/unit/packets/test-query-attributes.test.mts
+++ b/test/unit/packets/test-query-attributes.test.mts
@@ -5,7 +5,7 @@ import CursorType from '../../../lib/constants/cursor.js';
 import Execute from '../../../lib/packets/execute.js';
 import Query from '../../../lib/packets/query.js';
 
-const { Types } = mysql;
+const { Types, TypedParameter } = mysql;
 const CLIENT_QUERY_ATTRIBUTES = ClientConstants.CLIENT_QUERY_ATTRIBUTES;
 const UTF8_CHARSET = 33; // utf8_general_ci
 
@@ -120,6 +120,58 @@ describe('COM_QUERY with query attributes', () => {
     // no value bytes for NULL, remainder is SQL
     const sql = packet.readString(undefined, 'utf8');
     strict.strictEqual(sql, 'SELECT 1');
+  });
+
+  it('should set the null bitmap for a typed NULL attribute', () => {
+    const attrs = { gone: TypedParameter.INT(null) };
+    const q = new Query(
+      'SELECT 1',
+      UTF8_CHARSET,
+      attrs,
+      CLIENT_QUERY_ATTRIBUTES
+    );
+    const packet = q.toPacket();
+    packet.offset = 4;
+
+    strict.strictEqual(packet.readInt8(), 0x03);
+    strict.strictEqual(packet.readLengthCodedNumber(), 1);
+    strict.strictEqual(packet.readLengthCodedNumber(), 1);
+
+    // a typed NULL keeps its declared type, so only the bitmap marks it
+    strict.strictEqual(packet.readInt8(), 1);
+    strict.strictEqual(packet.readInt8(), 1); // new_params_bind_flag
+    strict.strictEqual(packet.readInt8(), Types.LONG);
+    packet.readInt8(); // unsigned flag
+    strict.strictEqual(packet.readLengthCodedString('utf8'), 'gone');
+
+    // no value bytes, remainder is SQL
+    strict.strictEqual(packet.readString(undefined, 'utf8'), 'SELECT 1');
+  });
+
+  it('should carry the unsigned flag of a typed attribute', () => {
+    const attrs = {
+      big: TypedParameter.BIGINT.unsigned(18446744073709551615n),
+    };
+    const q = new Query(
+      'SELECT 1',
+      UTF8_CHARSET,
+      attrs,
+      CLIENT_QUERY_ATTRIBUTES
+    );
+    const packet = q.toPacket();
+    packet.offset = 4;
+
+    strict.strictEqual(packet.readInt8(), 0x03);
+    strict.strictEqual(packet.readLengthCodedNumber(), 1);
+    strict.strictEqual(packet.readLengthCodedNumber(), 1);
+    strict.strictEqual(packet.readInt8(), 0); // null bitmap
+    strict.strictEqual(packet.readInt8(), 1); // new_params_bind_flag
+    strict.strictEqual(packet.readInt8(), Types.LONGLONG);
+    strict.strictEqual(packet.readInt8(), 0x80); // unsigned flag
+    strict.strictEqual(packet.readLengthCodedString('utf8'), 'big');
+
+    packet.skip(8); // the LONGLONG value
+    strict.strictEqual(packet.readString(undefined, 'utf8'), 'SELECT 1');
   });
 });
 

--- a/test/unit/packets/test-serialize-exact-length.test.mts
+++ b/test/unit/packets/test-serialize-exact-length.test.mts
@@ -1,0 +1,171 @@
+import { describe, it, strict } from 'poku';
+import mysql from '../../../index.js';
+import ClientConstants from '../../../lib/constants/client.js';
+import Execute from '../../../lib/packets/execute.js';
+import Query from '../../../lib/packets/query.js';
+
+const { TypedParameter } = mysql;
+
+const { toParameter } =
+  await import('../../../lib/packets/encode_parameter.js');
+const { default: Packet } = await import('../../../lib/packets/packet.js');
+
+const CLIENT_QUERY_ATTRIBUTES = ClientConstants.CLIENT_QUERY_ATTRIBUTES;
+const UTF8MB4_CHARSET = 224;
+
+const parameterMatrix: [string, unknown[]][] = [
+  ['no parameters', []],
+  ['null', [null]],
+  ['booleans', [true, false]],
+  ['numbers', [0, 42, -1.5, Number.NaN, Number.POSITIVE_INFINITY]],
+  ['strings', ['', 'ascii', 'ünïcødé 汉字 🙂', 'x'.repeat(300)]],
+  ['buffers', [Buffer.alloc(0), Buffer.from('abc'), Buffer.alloc(300, 1)]],
+  ['dates', [new Date(2026, 0, 2, 3, 4, 5, 678)]],
+  ['json objects', [{ a: [1, 'two', null] }, [1, 2, 3]]],
+  ['bigint', [123456789n]],
+  [
+    'nine nulls spilling the bitmap',
+    [null, null, null, null, null, null, null, null, null],
+  ],
+  [
+    'typed integers',
+    [
+      TypedParameter.TINY(1),
+      TypedParameter.SHORT.unsigned(65535),
+      TypedParameter.INT(-5),
+      TypedParameter.BIGINT.unsigned(18446744073709551615n),
+    ],
+  ],
+  [
+    'typed temporal',
+    [
+      TypedParameter.DATETIME(new Date(2026, 3, 4, 5, 6, 7, 890)),
+      TypedParameter.DATE(new Date(2026, 3, 4)),
+      TypedParameter.TIME('00:00:00'),
+      TypedParameter.TIME('01:02:03'),
+      TypedParameter.TIME('123:04:05.5'),
+    ],
+  ],
+  [
+    'typed text and nulls',
+    [
+      TypedParameter.VARCHAR('ab'),
+      TypedParameter.JSON({ a: 1 }),
+      TypedParameter.BLOB(Buffer.from('xy')),
+      TypedParameter.NULL(),
+      TypedParameter.INT(null),
+    ],
+  ],
+];
+
+describe('toParameter length matches the bytes its writer emits', () => {
+  for (const [name, values] of parameterMatrix) {
+    it(name, () => {
+      for (const value of values) {
+        const parameter = toParameter(value, 'utf8', 'local', false);
+        const buffer = Buffer.alloc(1024);
+        const packet = new Packet(0, buffer, 0, buffer.length);
+        packet.offset = 0;
+        if (!parameter.isNull) {
+          parameter.writer.call(packet, parameter.value);
+        }
+        strict.equal(
+          packet.offset,
+          parameter.isNull ? 0 : parameter.length,
+          `written bytes != declared length for ${String(value)}`
+        );
+      }
+    });
+  }
+});
+
+describe('COM_STMT_EXECUTE single-pass serialization fills the buffer exactly', () => {
+  for (const [name, values] of parameterMatrix) {
+    for (const flags of [0, CLIENT_QUERY_ATTRIBUTES]) {
+      it(`${name} (${flags ? 'attribute' : 'legacy'} format)`, () => {
+        const packet = new Execute(
+          3,
+          values,
+          UTF8MB4_CHARSET,
+          'local',
+          undefined,
+          flags
+        ).toPacket();
+        strict.equal(packet.offset, packet.buffer.length);
+        strict.equal(packet.length(), packet.buffer.length);
+      });
+    }
+  }
+
+  it('with attributes, including multibyte names', () => {
+    const attributes = {
+      tag: 'test',
+      nâmé汉: 42,
+      gone: null,
+      typed: TypedParameter.BIGINT.unsigned(1n),
+    };
+    const packet = new Execute(
+      3,
+      ['value'],
+      UTF8MB4_CHARSET,
+      'local',
+      attributes,
+      CLIENT_QUERY_ATTRIBUTES
+    ).toPacket();
+    strict.equal(packet.offset, packet.buffer.length);
+  });
+});
+
+describe('COM_STMT_EXECUTE hand-computed packet sizes', () => {
+  // 4 header + 1 command + 4 statement id + 1 flags + 4 iteration count = 14
+  it('one TINY parameter, legacy format', () => {
+    const packet = new Execute(
+      1,
+      [true],
+      UTF8MB4_CHARSET,
+      'local',
+      undefined,
+      0
+    ).toPacket();
+    // 14 + 1 null bitmap + 1 bind flag + 2 type/unsigned + 1 value
+    strict.equal(packet.buffer.length, 19);
+  });
+
+  it('one TINY parameter, attribute format', () => {
+    const packet = new Execute(
+      1,
+      [true],
+      UTF8MB4_CHARSET,
+      'local',
+      undefined,
+      CLIENT_QUERY_ATTRIBUTES
+    ).toPacket();
+    // 19 + 1 parameter count + 1 empty parameter name
+    strict.equal(packet.buffer.length, 21);
+  });
+});
+
+describe('COM_QUERY with attributes fills the buffer exactly', () => {
+  it('hand-computed size for one string attribute', () => {
+    const packet = new Query(
+      'SELECT 1',
+      UTF8MB4_CHARSET,
+      { a: 'bc' },
+      CLIENT_QUERY_ATTRIBUTES
+    ).toPacket();
+    // 4 header + 1 command + 1 count + 1 set count + 1 bitmap + 1 bind flag
+    // + 2 type/unsigned + 2 name + 3 value + 8 sql
+    strict.equal(packet.buffer.length, 24);
+    strict.equal(packet.offset, packet.buffer.length);
+  });
+
+  it('multibyte attribute names and values', () => {
+    const packet = new Query(
+      'SELECT 1',
+      UTF8MB4_CHARSET,
+      { nâmé汉: 'ünïcødé 🙂', n: null, typed: TypedParameter.TIME('01:02:03') },
+      CLIENT_QUERY_ATTRIBUTES
+    ).toPacket();
+    strict.equal(packet.offset, packet.buffer.length);
+  });
+});

--- a/test/unit/packets/test-serialize-exact-length.test.mts
+++ b/test/unit/packets/test-serialize-exact-length.test.mts
@@ -66,9 +66,7 @@ describe('toParameter length matches the bytes its writer emits', () => {
         const buffer = Buffer.alloc(1024);
         const packet = new Packet(0, buffer, 0, buffer.length);
         packet.offset = 0;
-        if (!parameter.isNull) {
-          parameter.writer.call(packet, parameter.value);
-        }
+        parameter.writer.call(packet, parameter.value);
         strict.equal(
           packet.offset,
           parameter.isNull ? 0 : parameter.length,
@@ -167,5 +165,72 @@ describe('COM_QUERY with attributes fills the buffer exactly', () => {
       CLIENT_QUERY_ATTRIBUTES
     ).toPacket();
     strict.equal(packet.offset, packet.buffer.length);
+  });
+
+  it('nine attributes spill into a second null-bitmap byte', () => {
+    const attributes: Record<string, unknown> = {};
+    for (let i = 0; i < 9; i++) {
+      attributes[`a${i}`] = i === 0 || i === 8 ? null : i;
+    }
+    const packet = new Query(
+      'SELECT 1',
+      UTF8MB4_CHARSET,
+      attributes,
+      CLIENT_QUERY_ATTRIBUTES
+    ).toPacket();
+    strict.equal(packet.offset, packet.buffer.length);
+
+    packet.offset = 5;
+    strict.equal(packet.readLengthCodedNumber(), 9);
+    strict.equal(packet.readLengthCodedNumber(), 1);
+    strict.equal(packet.readInt8(), 1); // attributes 0-7: only a0 is null
+    strict.equal(packet.readInt8(), 1); // attribute 8 is null
+    strict.equal(packet.readInt8(), 1); // new_params_bind_flag
+  });
+});
+
+describe('a writer that drifts from its declared length throws', () => {
+  const originalWriteDouble = Packet.prototype.writeDouble;
+  const drift = function (this: typeof Packet.prototype, n: number) {
+    originalWriteDouble.call(this, n);
+    this.offset -= 1;
+  };
+
+  it('COM_STMT_EXECUTE', () => {
+    Packet.prototype.writeDouble = drift;
+    try {
+      strict.throws(
+        () =>
+          new Execute(
+            1,
+            [1.5],
+            UTF8MB4_CHARSET,
+            'local',
+            undefined,
+            0
+          ).toPacket(),
+        /Internal error: COM_STMT_EXECUTE serialized/
+      );
+    } finally {
+      Packet.prototype.writeDouble = originalWriteDouble;
+    }
+  });
+
+  it('COM_QUERY', () => {
+    Packet.prototype.writeDouble = drift;
+    try {
+      strict.throws(
+        () =>
+          new Query(
+            'SELECT 1',
+            UTF8MB4_CHARSET,
+            { a: 1.5 },
+            CLIENT_QUERY_ATTRIBUTES
+          ).toPacket(),
+        /Internal error: COM_QUERY serialized/
+      );
+    } finally {
+      Packet.prototype.writeDouble = originalWriteDouble;
+    }
   });
 });

--- a/test/unit/packets/test-typed-parameter.test.mts
+++ b/test/unit/packets/test-typed-parameter.test.mts
@@ -189,7 +189,10 @@ describe('TypedParameter: non-integer encoders', () => {
   });
 
   it('stringifies a value the caller did not stringify', () => {
-    strict.equal(encode(TypedParameter.VARCHAR(42)).value, '42');
+    strict.deepEqual(
+      wire(TypedParameter.VARCHAR(42)),
+      Buffer.from([2, 0x34, 0x32])
+    );
   });
 
   it('has no encoder for a type outside the supported set', () => {


### PR DESCRIPTION
## What

`Execute.toPacket()` serialized every `COM_STMT_EXECUTE` twice: a dry run against `Packet.MockBuffer()` to learn the packet length, then the real pass. Both passes re-encoded every parameter, and since `lengthCodedStringLength` and `writeLengthCodedString` each encode internally, a string parameter was UTF-8-encoded **four times** per `execute()`. `Query.toPacket()` had the same shape on its attributes path (the no-attributes fast path from #4486 is untouched).

Every parameter encoder already reports the exact wire length of its value, so the dry run is redundant. `toPacket` now encodes each parameter once, sums the exact packet length arithmetically, allocates once, and writes once. String-shaped values leave `toParameter`/`lengthCodedEncoder` as encoded bytes and are written with `writeLengthCodedBuffer`, so each string is encoded exactly once. `timeEncoder` declared `length: 13` while `writeTime` emits 1, 9 or 13 bytes; it now computes the exact length (`Packet.timeLength`, kept next to `writeTime`).

Because a length/writer drift would otherwise send uninitialized `allocUnsafe` bytes to the server, both serializers throw on `offset !== length` instead of returning a short-filled packet, and a new unit test pins `parameter.length` to the bytes each writer actually emits across the parameter type matrix.

## Bug fixes that fell out of the rewrite

Two pre-existing `COM_QUERY` attribute-path bugs, now aligned with the `COM_STMT_EXECUTE` path and covered by regression tests that fail against the previous serializer:

- a typed NULL attribute (e.g. `TypedParameter.INT(null)`) kept its declared type, so the null bitmap was never set and the packet was malformed;
- the unsigned flag of typed attributes was hardcoded to 0.

## Measurements

New isolated benchmark `benchmarks/perf/serialize.js` (sync `toPacket()` loop, no socket), interleaved best-of-3 vs baseline:

| Scenario | Baseline | This PR | Δ |
| --- | --- | --- | --- |
| execute, 3 params (num/str/dbl) | 222k ops/s | 1454k | **6.6×** |
| execute, 10 short strings | 46k | 245k | **5.3×** |
| execute, 3 params + attribute | 163k | 727k | **4.5×** |
| execute, same, no attr flag (5.7/MariaDB) | 328k | 1399k | **4.3×** |
| execute, 3 dates | 191k | 750k | **3.9×** |
| execute, typed mixed | 174k | 559k | **3.2×** |
| execute, no params | 1950k | 5329k | **2.7×** |
| execute, 16KB blob | 166k | 226k | 1.4× |
| query, 2 attributes | 211k | 629k | **3.0×** |
| query, no attributes | 3393k | 3687k | unchanged |

Buffer pooling and heuristic sizing for send buffers were also evaluated (`serialize.js --alloc`) and rejected: `allocUnsafe` costs 76–286ns under 1KB against ~70ns for a pooled-slab view, while `stream.write()` retention (plus TLS, async zlib and >16MB slicing aliasing the buffer) makes recycling unsafe to track for a few percent of best-case gain. Data and reasoning are recorded in `benchmarks/perf/ANALYSIS.md` §7.

## Verification

- 1100 randomized packets byte-identical to the previous serializer (legacy, typed and hinted parameters, utf8/big5/binary charsets, both flag modes, attributes with multibyte names).
- Full suite: 238 files pass against MySQL 8.3 and MariaDB LTS; execute/typed/prepare suites pass against MySQL 5.7; MySQL 9 shows only the pre-existing `test-execute-nocolumndef` failure, which also fails on master.
- Lint and typecheck clean.