### PR TITLE
perf: single-pass utf8 string encoding for outgoing packets

### DIFF
--- a/lib/packets/encode_parameter.js
+++ b/lib/packets/encode_parameter.js
@@ -88,14 +88,28 @@ function toParameter(value, encoding, timezone, jsonAsString, hint) {
     length = 0;
     writer = writeNothing;
   }
+  let byteLength;
   if (length === undefined) {
-    value = StringParser.encode(value, encoding);
-    length = Packet.lengthCodedNumberLength(value.length) + value.length;
+    // a non-string here (e.g. a Uint8Array) keeps the Buffer.from coercion
+    // inside StringParser.encode
+    if (
+      typeof value === 'string' &&
+      StringParser.hasFastUtf8Write &&
+      (encoding === 'utf8' || encoding === 'utf-8')
+    ) {
+      byteLength = Buffer.byteLength(value, 'utf8');
+      length = Packet.lengthCodedNumberLength(byteLength) + byteLength;
+      writer = Packet.prototype.writeLengthCodedUtf8String;
+    } else {
+      value = StringParser.encode(value, encoding);
+      length = Packet.lengthCodedNumberLength(value.length) + value.length;
+    }
   }
   return {
     value,
     type,
     length,
+    byteLength,
     writer,
     unsigned: false,
     isNull: type === Types.NULL,

--- a/lib/packets/execute.js
+++ b/lib/packets/execute.js
@@ -206,7 +206,7 @@ class Execute {
       for (let i = 0; i < totalParams; i++) {
         const parameter = allParams[i];
         if (!parameter.isNull) {
-          parameter.writer.call(packet, parameter.value);
+          parameter.writer.call(packet, parameter.value, parameter.byteLength);
         }
       }
     }

--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -1030,6 +1030,18 @@ class Packet {
     this.offset += buf.length;
   }
 
+  // byteLength, when the caller sized the packet, must be
+  // Buffer.byteLength(string, 'utf8'); only used where
+  // Buffer.prototype.utf8Write exists
+  writeLengthCodedUtf8String(string, byteLength) {
+    if (byteLength === undefined) {
+      byteLength = Buffer.byteLength(string, 'utf8');
+    }
+    this.writeLengthCodedNumber(byteLength);
+    this.buffer.utf8Write(string, this.offset, byteLength);
+    this.offset += byteLength;
+  }
+
   writeLengthCodedBuffer(b) {
     this.writeLengthCodedNumber(b.length);
     b.copy(this.buffer, this.offset);

--- a/lib/packets/prepare_statement.js
+++ b/lib/packets/prepare_statement.js
@@ -13,6 +13,18 @@ class PrepareStatement {
   }
 
   toPacket() {
+    if (
+      StringParser.hasFastUtf8Write &&
+      (this.encoding === 'utf8' || this.encoding === 'utf-8')
+    ) {
+      const length = 5 + Buffer.byteLength(this.query, 'utf8');
+      const buffer = Buffer.allocUnsafe(length);
+      buffer[4] = CommandCodes.STMT_PREPARE;
+      buffer.utf8Write(this.query, 5, length - 5);
+      const packet = new Packet(0, buffer, 0, length);
+      packet.offset = length;
+      return packet;
+    }
     const buf = StringParser.encode(this.query, this.encoding);
     const length = 5 + buf.length;
     const buffer = Buffer.allocUnsafe(length);

--- a/lib/packets/query.js
+++ b/lib/packets/query.js
@@ -7,6 +7,27 @@ const CharsetToEncoding = require('../constants/charset_encodings.js');
 const ClientConstants = require('../constants/client.js');
 const { toParameter } = require('./encode_parameter.js');
 
+// utf8Write skips the per-call encoding normalization and dispatch inside
+// buffer.write(); it has been a stable Node internal for years but may be
+// missing on other runtimes
+const hasFastUtf8Write = typeof Buffer.prototype.utf8Write === 'function';
+
+// below this many characters, encoding in a single pass into a buffer sized
+// for the utf8 worst case (3 bytes per UTF-16 code unit) beats the exact-size
+// two-pass byteLength + write; above it, the over-allocation costs more
+const SINGLE_PASS_MAX_SQL_LENGTH = 128;
+
+function toQueryPacket(buffer, headerLength, length) {
+  buffer[4] = CommandCode.QUERY;
+  if (headerLength === 7) {
+    buffer[5] = 0; // parameter_count
+    buffer[6] = 1; // parameter_set_count, always 1
+  }
+  const packet = new Packet(0, buffer, 0, length);
+  packet.offset = length;
+  return packet;
+}
+
 class Query {
   constructor(sql, charsetNumber, attributes, clientFlags) {
     this.query = sql;
@@ -25,36 +46,47 @@ class Query {
         : 0;
 
     if (attributeCount === 0) {
-      // fast path: no attribute values to serialize, so the packet length is
-      // known upfront and the SQL can be encoded straight into the buffer
+      // fast path: no attribute values to serialize, so the packet is the
+      // header plus the encoded SQL
       const headerLength = useQueryAttributes ? 7 : 5;
-      if (Buffer.isEncoding(this.encoding)) {
-        const sqlLength = Buffer.byteLength(this.query, this.encoding);
-        const length = headerLength + sqlLength;
-        const buffer = Buffer.allocUnsafe(length);
-        const packet = new Packet(0, buffer, 0, length);
-        packet.offset = 4;
-        packet.writeInt8(CommandCode.QUERY);
-        if (useQueryAttributes) {
-          packet.writeInt8(0); // parameter_count
-          packet.writeInt8(1); // parameter_set_count, always 1
+      if (
+        hasFastUtf8Write &&
+        (this.encoding === 'utf8' || this.encoding === 'utf-8')
+      ) {
+        if (this.query.length <= SINGLE_PASS_MAX_SQL_LENGTH) {
+          const buffer = Buffer.allocUnsafe(
+            headerLength + this.query.length * 3
+          );
+          const length =
+            headerLength +
+            buffer.utf8Write(
+              this.query,
+              headerLength,
+              buffer.length - headerLength
+            );
+          return toQueryPacket(
+            buffer.length === length ? buffer : buffer.subarray(0, length),
+            headerLength,
+            length
+          );
         }
-        buffer.write(this.query, packet.offset, this.encoding);
-        packet.offset = length;
-        return packet;
+        const length = headerLength + Buffer.byteLength(this.query, 'utf8');
+        const buffer = Buffer.allocUnsafe(length);
+        buffer.utf8Write(this.query, headerLength, length - headerLength);
+        return toQueryPacket(buffer, headerLength, length);
       }
-      const buf = StringParser.encode(this.query, this.encoding);
-      const length = headerLength + buf.length;
+      if (Buffer.isEncoding(this.encoding)) {
+        const length =
+          headerLength + Buffer.byteLength(this.query, this.encoding);
+        const buffer = Buffer.allocUnsafe(length);
+        buffer.write(this.query, headerLength, this.encoding);
+        return toQueryPacket(buffer, headerLength, length);
+      }
+      const sqlBuffer = StringParser.encode(this.query, this.encoding);
+      const length = headerLength + sqlBuffer.length;
       const buffer = Buffer.allocUnsafe(length);
-      const packet = new Packet(0, buffer, 0, length);
-      packet.offset = 4;
-      packet.writeInt8(CommandCode.QUERY);
-      if (useQueryAttributes) {
-        packet.writeInt8(0); // parameter_count
-        packet.writeInt8(1); // parameter_set_count, always 1
-      }
-      packet.writeBuffer(buf);
-      return packet;
+      sqlBuffer.copy(buffer, headerLength);
+      return toQueryPacket(buffer, headerLength, length);
     }
 
     const names = Object.keys(this.attributes);

--- a/lib/packets/query.js
+++ b/lib/packets/query.js
@@ -7,15 +7,7 @@ const CharsetToEncoding = require('../constants/charset_encodings.js');
 const ClientConstants = require('../constants/client.js');
 const { toParameter } = require('./encode_parameter.js');
 
-// utf8Write skips the per-call encoding normalization and dispatch inside
-// buffer.write(); it has been a stable Node internal for years but may be
-// missing on other runtimes
-const hasFastUtf8Write = typeof Buffer.prototype.utf8Write === 'function';
-
-// below this many characters, encoding in a single pass into a buffer sized
-// for the utf8 worst case (3 bytes per UTF-16 code unit) beats the exact-size
-// two-pass byteLength + write; above it, the over-allocation costs more
-const SINGLE_PASS_MAX_SQL_LENGTH = 128;
+const { hasFastUtf8Write } = StringParser;
 
 function toQueryPacket(buffer, headerLength, length) {
   buffer[4] = CommandCode.QUERY;
@@ -53,23 +45,6 @@ class Query {
         hasFastUtf8Write &&
         (this.encoding === 'utf8' || this.encoding === 'utf-8')
       ) {
-        if (this.query.length <= SINGLE_PASS_MAX_SQL_LENGTH) {
-          const buffer = Buffer.allocUnsafe(
-            headerLength + this.query.length * 3
-          );
-          const length =
-            headerLength +
-            buffer.utf8Write(
-              this.query,
-              headerLength,
-              buffer.length - headerLength
-            );
-          return toQueryPacket(
-            buffer.length === length ? buffer : buffer.subarray(0, length),
-            headerLength,
-            length
-          );
-        }
         const length = headerLength + Buffer.byteLength(this.query, 'utf8');
         const buffer = Buffer.allocUnsafe(length);
         buffer.utf8Write(this.query, headerLength, length - headerLength);
@@ -152,7 +127,11 @@ class Query {
 
     for (let i = 0; i < attributeCount; i++) {
       if (!parameters[i].isNull) {
-        parameters[i].writer.call(packet, parameters[i].value);
+        parameters[i].writer.call(
+          packet,
+          parameters[i].value,
+          parameters[i].byteLength
+        );
       }
     }
 

--- a/lib/packets/typed_parameter.js
+++ b/lib/packets/typed_parameter.js
@@ -238,15 +238,25 @@ function timeEncoder() {
 
 function lengthCodedEncoder(encoding) {
   return (value) => {
-    const buffer = Buffer.isBuffer(value)
-      ? value
-      : StringParser.encode(
-          typeof value === 'string' ? value : String(value),
-          encoding
-        );
+    if (!Buffer.isBuffer(value)) {
+      const string = typeof value === 'string' ? value : String(value);
+      if (
+        StringParser.hasFastUtf8Write &&
+        (encoding === 'utf8' || encoding === 'utf-8')
+      ) {
+        const byteLength = Buffer.byteLength(string, 'utf8');
+        return {
+          value: string,
+          length: Packet.lengthCodedNumberLength(byteLength) + byteLength,
+          byteLength,
+          writer: Packet.prototype.writeLengthCodedUtf8String,
+        };
+      }
+      value = StringParser.encode(string, encoding);
+    }
     return {
-      value: buffer,
-      length: Packet.lengthCodedNumberLength(buffer.length) + buffer.length,
+      value,
+      length: Packet.lengthCodedNumberLength(value.length) + value.length,
       writer: Packet.prototype.writeLengthCodedBuffer,
     };
   };

--- a/lib/parsers/string.js
+++ b/lib/parsers/string.js
@@ -15,6 +15,10 @@ const hasFastSlices =
   typeof Buffer.prototype.latin1Slice === 'function' &&
   typeof Buffer.prototype.asciiSlice === 'function';
 
+// utf8Write skips the per-call encoding normalization and dispatch inside
+// buffer.write(); same stability story as the slice methods above
+exports.hasFastUtf8Write = typeof Buffer.prototype.utf8Write === 'function';
+
 exports.decode = function (buffer, encoding, start, end, options) {
   if (hasFastSlices) {
     // replicate buffer.toString() bounds coercion exactly (the *Slice

--- a/test/unit/packets/test-prepare-statement.test.mts
+++ b/test/unit/packets/test-prepare-statement.test.mts
@@ -6,7 +6,7 @@ const LATIN1_CHARSET = 8; // latin1_swedish_ci
 
 describe('COM_STMT_PREPARE serialization', () => {
   it('should serialize utf8 SQL of varied lengths exactly', () => {
-    for (const sql of ['SELECT ?', 'SELECT "é🚀" -- ' + 'x'.repeat(5000)]) {
+    for (const sql of ['SELECT ?', `SELECT "é🚀" -- ${'x'.repeat(5000)}`]) {
       const packet = new PrepareStatement(sql, UTF8MB4_CHARSET).toPacket();
 
       strict.strictEqual(packet.end, packet.buffer.length);

--- a/test/unit/packets/test-prepare-statement.test.mts
+++ b/test/unit/packets/test-prepare-statement.test.mts
@@ -1,0 +1,28 @@
+import { describe, it, strict } from 'poku';
+import PrepareStatement from '../../../lib/packets/prepare_statement.js';
+
+const UTF8MB4_CHARSET = 224; // utf8mb4_unicode_ci
+const LATIN1_CHARSET = 8; // latin1_swedish_ci
+
+describe('COM_STMT_PREPARE serialization', () => {
+  it('should serialize utf8 SQL of varied lengths exactly', () => {
+    for (const sql of ['SELECT ?', 'SELECT "é🚀" -- ' + 'x'.repeat(5000)]) {
+      const packet = new PrepareStatement(sql, UTF8MB4_CHARSET).toPacket();
+
+      strict.strictEqual(packet.end, packet.buffer.length);
+      packet.offset = 4;
+      strict.strictEqual(packet.readInt8(), 0x16); // COM_STMT_PREPARE
+      strict.strictEqual(packet.readString(undefined, 'utf8'), sql);
+    }
+  });
+
+  it('should serialize SQL for a non-utf8 encoding', () => {
+    const sql = 'SELECT "café"';
+    const packet = new PrepareStatement(sql, LATIN1_CHARSET).toPacket();
+
+    strict.strictEqual(packet.end, packet.buffer.length);
+    packet.offset = 4;
+    strict.strictEqual(packet.readInt8(), 0x16);
+    strict.strictEqual(packet.readString(undefined, 'latin1'), sql);
+  });
+});

--- a/test/unit/packets/test-query-attributes.test.mts
+++ b/test/unit/packets/test-query-attributes.test.mts
@@ -91,7 +91,7 @@ describe('COM_QUERY with query attributes', () => {
     strict.strictEqual(sql, 'SELECT 1');
   });
 
-  it('should serialize SQL around the single-pass length threshold exactly', () => {
+  it('should serialize multibyte SQL of varied lengths exactly', () => {
     const base = 'SELECT "é🚀"; -- ';
     for (const length of [8, 127, 128, 129, 130, 4000]) {
       const sql = base + 'x'.repeat(length);

--- a/test/unit/packets/test-query-attributes.test.mts
+++ b/test/unit/packets/test-query-attributes.test.mts
@@ -8,6 +8,7 @@ import Query from '../../../lib/packets/query.js';
 const { Types, TypedParameter } = mysql;
 const CLIENT_QUERY_ATTRIBUTES = ClientConstants.CLIENT_QUERY_ATTRIBUTES;
 const UTF8_CHARSET = 33; // utf8_general_ci
+const UTF8MB4_CHARSET = 224; // utf8mb4_unicode_ci
 
 describe('COM_QUERY with query attributes', () => {
   it('should produce the legacy format when CLIENT_QUERY_ATTRIBUTES is not set', () => {
@@ -88,6 +89,31 @@ describe('COM_QUERY with query attributes', () => {
     strict.strictEqual(packet.readLengthCodedNumber(), 1); // parameter_set_count
     const sql = packet.readString(undefined, 'utf8');
     strict.strictEqual(sql, 'SELECT 1');
+  });
+
+  it('should serialize SQL around the single-pass length threshold exactly', () => {
+    const base = 'SELECT "é🚀"; -- ';
+    for (const length of [8, 127, 128, 129, 130, 4000]) {
+      const sql = base + 'x'.repeat(length);
+      for (const flags of [0, CLIENT_QUERY_ATTRIBUTES]) {
+        const packet = new Query(
+          sql,
+          UTF8MB4_CHARSET,
+          undefined,
+          flags
+        ).toPacket();
+
+        strict.strictEqual(packet.end, packet.buffer.length);
+        strict.strictEqual(packet.offset, packet.end);
+        packet.offset = 4;
+        strict.strictEqual(packet.readInt8(), 0x03);
+        if (flags) {
+          strict.strictEqual(packet.readLengthCodedNumber(), 0);
+          strict.strictEqual(packet.readLengthCodedNumber(), 1);
+        }
+        strict.strictEqual(packet.readString(undefined, 'utf8'), sql);
+      }
+    }
   });
 
   it('should handle null attribute values', () => {

--- a/test/unit/packets/test-query-attributes.test.mts
+++ b/test/unit/packets/test-query-attributes.test.mts
@@ -116,6 +116,28 @@ describe('COM_QUERY with query attributes', () => {
     }
   });
 
+  it('should serialize SQL for a non-utf8 Buffer encoding', () => {
+    const LATIN1_CHARSET = 8; // latin1_swedish_ci
+    const sql = 'SELECT "café"';
+    for (const flags of [0, CLIENT_QUERY_ATTRIBUTES]) {
+      const packet = new Query(
+        sql,
+        LATIN1_CHARSET,
+        undefined,
+        flags
+      ).toPacket();
+
+      strict.strictEqual(packet.end, packet.buffer.length);
+      packet.offset = 4;
+      strict.strictEqual(packet.readInt8(), 0x03);
+      if (flags) {
+        strict.strictEqual(packet.readLengthCodedNumber(), 0);
+        strict.strictEqual(packet.readLengthCodedNumber(), 1);
+      }
+      strict.strictEqual(packet.readString(undefined, 'latin1'), sql);
+    }
+  });
+
   it('should handle null attribute values', () => {
     const attrs = { gone: null };
     const q = new Query(

--- a/test/unit/packets/test-typed-parameter.test.mts
+++ b/test/unit/packets/test-typed-parameter.test.mts
@@ -195,6 +195,24 @@ describe('TypedParameter: non-integer encoders', () => {
     );
   });
 
+  it('writes a length coded string for a non-utf8 encoding', () => {
+    const parameter = toParameter(
+      TypedParameter.VARCHAR('café'),
+      'latin1',
+      'local',
+      false
+    );
+    const buffer = Buffer.alloc(64);
+    const packet = new Packet(0, buffer, 0, buffer.length);
+    packet.offset = 0;
+    parameter.writer.call(packet, parameter.value);
+    strict.equal(packet.offset, parameter.length);
+    strict.deepEqual(
+      buffer.subarray(0, packet.offset),
+      Buffer.from([4, 0x63, 0x61, 0x66, 0xe9])
+    );
+  });
+
   it('has no encoder for a type outside the supported set', () => {
     strict.throws(() => encode(new Container(Types.BIT, 1, false)));
   });


### PR DESCRIPTION
## Problem

Benchmarking showed text-protocol `query()` is 7–12% slower in 3.24.0 than in 3.16.3 when `CLIENT_QUERY_ATTRIBUTES` is negotiated but no attributes are passed — the overwhelmingly common case. The regression is not the two extra QA header bytes: the fast path used `Buffer.byteLength()` + `buffer.write(sql, offset, encoding)`, and `buffer.write`'s per-call encoding normalization/dispatch (plus a per-packet `Buffer.isEncoding()`) loses to 3.16.3's `Buffer.from()` + copy. The gap scales with SQL length.

The same encode-to-intermediate-buffer + memcpy pattern also sits under every string parameter in the binary protocol (`COM_STMT_EXECUTE`, typed parameters, query attributes) and under `COM_STMT_PREPARE`.

## Change

Everywhere the outgoing path serializes a utf8 string (feature-detected `Buffer.prototype.utf8Write`, exported as `StringParser.hasFastUtf8Write`, with the previous paths kept for other runtimes and encodings):

- **COM_QUERY / COM_STMT_PREPARE**: size with `Buffer.byteLength`, then `utf8Write` the SQL straight into the exact-size packet — no intermediate buffer, no memcpy, no `write()` dispatch.
- **String parameters** (`encode_parameter.js`, `typed_parameter.js`): keep the string in the parameter with its precomputed byte length and write it directly into the packet via a new `Packet#writeLengthCodedUtf8String(string, byteLength)`; the writer contract becomes `writer.call(packet, value, byteLength)`, and the writer recomputes `byteLength` when not passed so one-argument callers still work. Non-string values (e.g. `Uint8Array` parameters) keep the `StringParser.encode` / `Buffer.from` coercion.

An earlier revision used a single-pass worst-case over-allocation (`length * 3` + `subarray`) for short SQL; cross-runtime measurement showed it is **~3× slower on Bun 1.4.0** and only wins in a narrow band around 120 chars on Node, so every utf8 path now uses the exact-size two-pass form.

## Results

`serialize-ab.js`, stable across reps, vs released versions:

| Scenario | v3.16.3 | v3.24.0 | this PR (Node 26) | this PR (Bun 1.4) |
| --- | --- | --- | --- | --- |
| query-select-1 | 8.9M ops/s | 8.9M | **12.1M** | **21.7M** (stock: 4.3M) |
| query-insert-120b | 5.9M ops/s | 4.9M | **5.8M** | **16.3M** (stock: 3.8M) |
| execute-3-params | 2.8M ops/s | 3.4M | **4.1M** | |
| execute-10-strings | 350K ops/s | 585K | **725K** | |
| execute-3-dates / blob-16k | | | unchanged | |

## Verification

- Differential tests against released 3.24.0: COM_QUERY (201 combinations of charset — including iconv-only cesu8/big5 — flags, attributes, astral chars, lone surrogates, 5KB multibyte), COM_STMT_EXECUTE (param sets with strings, numbers, dates, buffers, JSON, typed parameters, attributes), and COM_STMT_PREPARE are all byte-identical from byte 4 on (bytes 0–3 are filled later by `writeHeader()`, as before).
- New unit tests: multibyte COM_QUERY at varied lengths, non-utf8 (latin1) COM_QUERY and typed-parameter encoding, and first unit coverage for `PrepareStatement.toPacket()`.
- Full suite green (238 pass / 0 fail / 1 pre-existing skip) on MySQL 8-family, lint + typecheck clean.
- No uninitialized memory can reach the wire: every byte of each packet buffer is written before send.