### PR TITLE
fix: correct length-coded number size for the 3-byte range

### DIFF
--- a/lib/packets/packet.js
+++ b/lib/packets/packet.js
@@ -1135,7 +1135,7 @@ class Packet {
       return 3;
     }
     if (n < 0xffffff) {
-      return 5;
+      return 4;
     }
     return 9;
   }

--- a/test/unit/packets/test-length-coded-number.test.mts
+++ b/test/unit/packets/test-length-coded-number.test.mts
@@ -53,14 +53,14 @@ describe('lengthCodedNumberLength matches the bytes writeLengthCodedNumber emits
     strict.strictEqual(Packet.lengthCodedNumberLength(250), writtenBytes(250));
   });
 
-  it('3-byte range (0xFC tag)', () => {
+  it('0xFC tag', () => {
     strict.strictEqual(
       Packet.lengthCodedNumberLength(0xfffe),
       writtenBytes(0xfffe)
     );
   });
 
-  it('4-byte range (0xFD tag)', () => {
+  it('0xFD tag', () => {
     strict.strictEqual(
       Packet.lengthCodedNumberLength(0xffff),
       writtenBytes(0xffff)
@@ -71,7 +71,7 @@ describe('lengthCodedNumberLength matches the bytes writeLengthCodedNumber emits
     );
   });
 
-  it('9-byte range (0xFE tag)', () => {
+  it('0xFE tag', () => {
     strict.strictEqual(
       Packet.lengthCodedNumberLength(0xffffff),
       writtenBytes(0xffffff)

--- a/test/unit/packets/test-length-coded-number.test.mts
+++ b/test/unit/packets/test-length-coded-number.test.mts
@@ -39,3 +39,42 @@ describe('writeLengthCodedNumber / readLengthCodedNumber roundtrip', () => {
     strict.strictEqual(roundtrip(0x1ffffffffff), 2199023255551);
   });
 });
+
+describe('lengthCodedNumberLength matches the bytes writeLengthCodedNumber emits', () => {
+  const writtenBytes = (n: number): number => {
+    const buffer = Buffer.alloc(16);
+    const packet = new Packet(0, buffer, 0, buffer.length);
+    packet.offset = 0;
+    packet.writeLengthCodedNumber(n);
+    return packet.offset;
+  };
+
+  it('1-byte range', () => {
+    strict.strictEqual(Packet.lengthCodedNumberLength(250), writtenBytes(250));
+  });
+
+  it('3-byte range (0xFC tag)', () => {
+    strict.strictEqual(
+      Packet.lengthCodedNumberLength(0xfffe),
+      writtenBytes(0xfffe)
+    );
+  });
+
+  it('4-byte range (0xFD tag)', () => {
+    strict.strictEqual(
+      Packet.lengthCodedNumberLength(0xffff),
+      writtenBytes(0xffff)
+    );
+    strict.strictEqual(
+      Packet.lengthCodedNumberLength(0xfffffe),
+      writtenBytes(0xfffffe)
+    );
+  });
+
+  it('9-byte range (0xFE tag)', () => {
+    strict.strictEqual(
+      Packet.lengthCodedNumberLength(0xffffff),
+      writtenBytes(0xffffff)
+    );
+  });
+});


### PR DESCRIPTION
`Packet.lengthCodedNumberLength()` returns 5 for the `0xffff <= n < 0xffffff` range, but `writeLengthCodedNumber()` only ever writes 4 bytes there (a 1-byte `0xfd` marker plus a 3-byte Int24). Before #4494, packet sizes were measured with a real dry-run write, so this drift never surfaced. Since #4494 switched to computing sizes arithmetically from `lengthCodedNumberLength()`, any string/JSON/blob parameter whose encoded length falls in that range now throws `COM_STMT_EXECUTE serialized N bytes, expected N+1`. This fixes the length function to match what the writer actually emits.

Fixes #4499