### PR TITLE
fix(promise): honour `trace: false` on every promise-API method

### DIFF
--- a/lib/pool_cluster.js
+++ b/lib/pool_cluster.js
@@ -141,6 +141,17 @@ class PoolNamespace {
     });
   }
 
+  get trace() {
+    const nodeIds = this._cluster._findNodeIds(this._pattern, true);
+    for (let i = 0; i < nodeIds.length; i++) {
+      const node = this._cluster._getNode(nodeIds[i]);
+      if (node?.pool.config.connectionConfig.trace) {
+        return true;
+      }
+    }
+    return nodeIds.length === 0;
+  }
+
   _getClusterNode() {
     const foundNodeIds = this._cluster._findNodeIds(this._pattern);
     if (foundNodeIds.length === 0) {

--- a/lib/promise/connection.js
+++ b/lib/promise/connection.js
@@ -82,9 +82,9 @@ class PromiseConnection extends EventEmitter {
 
   beginTransaction() {
     const c = this.connection;
-    const stackHolder = captureStackHolder(
-      PromiseConnection.prototype.beginTransaction
-    );
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.beginTransaction)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, stackHolder);
       c.beginTransaction(done);
@@ -93,7 +93,9 @@ class PromiseConnection extends EventEmitter {
 
   commit() {
     const c = this.connection;
-    const stackHolder = captureStackHolder(PromiseConnection.prototype.commit);
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.commit)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, stackHolder);
       c.commit(done);
@@ -102,9 +104,9 @@ class PromiseConnection extends EventEmitter {
 
   rollback() {
     const c = this.connection;
-    const stackHolder = captureStackHolder(
-      PromiseConnection.prototype.rollback
-    );
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.rollback)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, stackHolder);
       c.rollback(done);
@@ -113,7 +115,9 @@ class PromiseConnection extends EventEmitter {
 
   ping() {
     const c = this.connection;
-    const stackHolder = captureStackHolder(PromiseConnection.prototype.ping);
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.ping)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       c.ping((err) => {
         if (err) {
@@ -128,7 +132,9 @@ class PromiseConnection extends EventEmitter {
 
   reset() {
     const c = this.connection;
-    const stackHolder = captureStackHolder(PromiseConnection.prototype.reset);
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.reset)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       c.reset((err) => {
         if (err) {
@@ -143,7 +149,9 @@ class PromiseConnection extends EventEmitter {
 
   connect() {
     const c = this.connection;
-    const stackHolder = captureStackHolder(PromiseConnection.prototype.connect);
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.connect)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       c.connect((err, param) => {
         if (err) {
@@ -159,7 +167,9 @@ class PromiseConnection extends EventEmitter {
   prepare(options) {
     const c = this.connection;
     const promiseImpl = this.Promise;
-    const stackHolder = captureStackHolder(PromiseConnection.prototype.prepare);
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.prepare)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       c.prepare(options, (err, statement) => {
         if (err) {
@@ -178,9 +188,9 @@ class PromiseConnection extends EventEmitter {
 
   changeUser(options) {
     const c = this.connection;
-    const stackHolder = captureStackHolder(
-      PromiseConnection.prototype.changeUser
-    );
+    const stackHolder = c.config.trace
+      ? captureStackHolder(PromiseConnection.prototype.changeUser)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       c.changeUser(options, (err) => {
         if (err) {

--- a/lib/promise/pool.js
+++ b/lib/promise/pool.js
@@ -77,7 +77,9 @@ class PromisePool extends EventEmitter {
 
   end() {
     const corePool = this.pool;
-    const stackHolder = captureStackHolder(PromisePool.prototype.end);
+    const stackHolder = corePool.config.connectionConfig.trace
+      ? captureStackHolder(PromisePool.prototype.end)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       corePool.end((err) => {
         if (err) {

--- a/lib/promise/pool_cluster.js
+++ b/lib/promise/pool_cluster.js
@@ -25,9 +25,9 @@ class PromisePoolNamespace {
 
   query(sql, values) {
     const corePoolNamespace = this.poolNamespace;
-    const stackHolder = captureStackHolder(
-      PromisePoolNamespace.prototype.query
-    );
+    const stackHolder = corePoolNamespace.trace
+      ? captureStackHolder(PromisePoolNamespace.prototype.query)
+      : undefined;
     if (typeof values === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'
@@ -41,9 +41,9 @@ class PromisePoolNamespace {
 
   execute(sql, values) {
     const corePoolNamespace = this.poolNamespace;
-    const stackHolder = captureStackHolder(
-      PromisePoolNamespace.prototype.execute
-    );
+    const stackHolder = corePoolNamespace.trace
+      ? captureStackHolder(PromisePoolNamespace.prototype.execute)
+      : undefined;
     if (typeof values === 'function') {
       throw new Error(
         'Callback function is not available with promise clients.'

--- a/lib/promise/prepared_statement_info.js
+++ b/lib/promise/prepared_statement_info.js
@@ -11,9 +11,9 @@ class PromisePreparedStatementInfo {
 
   execute(parameters) {
     const s = this.statement;
-    const stackHolder = captureStackHolder(
-      PromisePreparedStatementInfo.prototype.execute
-    );
+    const stackHolder = s._connection.config.trace
+      ? captureStackHolder(PromisePreparedStatementInfo.prototype.execute)
+      : undefined;
     return new this.Promise((resolve, reject) => {
       const done = makeDoneCb(resolve, reject, stackHolder);
       if (parameters) {

--- a/test/integration/promise-wrappers/test-trace-option.test.mts
+++ b/test/integration/promise-wrappers/test-trace-option.test.mts
@@ -1,0 +1,106 @@
+import type { ConnectionOptions } from '../../../index.js';
+import process from 'node:process';
+import { describe, it, strict } from 'poku';
+import promiseDriver from '../../../promise.js';
+import { config } from '../../common.test.mjs';
+
+const testFileMarker = 'test-trace-option.test.mts';
+
+const { createConnection, createPoolCluster } = promiseDriver;
+
+const options = (trace: boolean): ConnectionOptions =>
+  process.env.MYSQL_CONNECTION_URL
+    ? { uri: process.env.MYSQL_CONNECTION_URL, trace }
+    : { ...config, trace };
+
+async function rejection(operation: Promise<unknown>): Promise<Error> {
+  try {
+    await operation;
+  } catch (error) {
+    return error as Error;
+  }
+
+  throw new Error('Expected the operation to reject');
+}
+
+function assertPointsAtCaller(error: Error) {
+  strict(
+    error.stack?.includes(testFileMarker),
+    `Expected the stack to reference ${testFileMarker}; got:\n${error.stack}`
+  );
+}
+
+function assertDoesNotPointAtCaller(error: Error) {
+  strict(
+    !error.stack?.includes(testFileMarker),
+    `Expected \`trace: false\` to leave the stack alone; got:\n${error.stack}`
+  );
+}
+
+await describe('trace option: prepared statement execute', async () => {
+  const traced = await createConnection(options(true));
+  const untraced = await createConnection(options(false));
+  const tracedStatement = await traced.prepare('SELECT ? AS a');
+  const untracedStatement = await untraced.prepare('SELECT ? AS a');
+
+  await it('should capture the caller stack by default', async () => {
+    assertPointsAtCaller(await rejection(tracedStatement.execute([])));
+  });
+
+  await it('should not capture the caller stack with trace: false', async () => {
+    assertDoesNotPointAtCaller(await rejection(untracedStatement.execute([])));
+  });
+
+  await traced.end();
+  await untraced.end();
+});
+
+await describe('trace option: connection lifecycle methods', async () => {
+  const traced = await createConnection(options(true));
+  const untraced = await createConnection(options(false));
+
+  await it('should capture the caller stack by default', async () => {
+    assertPointsAtCaller(await rejection(traced.prepare('syntax error')));
+  });
+
+  await it('should not capture the caller stack with trace: false', async () => {
+    assertDoesNotPointAtCaller(
+      await rejection(untraced.prepare('syntax error'))
+    );
+  });
+
+  await traced.end();
+  await untraced.end();
+});
+
+await describe('trace option: pool cluster namespace', async () => {
+  const traced = createPoolCluster();
+  const untraced = createPoolCluster();
+
+  traced.add('MASTER', options(true));
+  untraced.add('MASTER', options(false));
+
+  const tracedNamespace = traced.of('MASTER');
+  const untracedNamespace = untraced.of('MASTER');
+
+  await it('should capture the caller stack by default', async () => {
+    assertPointsAtCaller(
+      await rejection(tracedNamespace.query('SELECT * FROM trace_no_table'))
+    );
+    assertPointsAtCaller(
+      await rejection(tracedNamespace.execute('SELECT * FROM trace_no_table'))
+    );
+  });
+
+  await it('should not capture the caller stack with trace: false', async () => {
+    assertDoesNotPointAtCaller(
+      await rejection(untracedNamespace.query('SELECT * FROM trace_no_table'))
+    );
+    assertDoesNotPointAtCaller(
+      await rejection(untracedNamespace.execute('SELECT * FROM trace_no_table'))
+    );
+  });
+
+  await traced.end();
+  await untraced.end();
+});

--- a/test/unit/pool-cluster/test-trace-flag.test.mts
+++ b/test/unit/pool-cluster/test-trace-flag.test.mts
@@ -1,0 +1,43 @@
+import { describe, it, strict } from 'poku';
+import { createPoolCluster } from '../../common.test.mjs';
+
+function traceOf(
+  cluster: ReturnType<typeof createPoolCluster>,
+  pattern: string
+): boolean {
+  // @ts-expect-error: internal access
+  return cluster.of(pattern).trace;
+}
+
+describe('pool cluster trace flag', () => {
+  const empty = createPoolCluster();
+
+  const disabled = createPoolCluster();
+  disabled.add('MASTER', { host: '127.0.0.1', trace: false });
+  disabled.add('SLAVE', { host: '127.0.0.1', trace: false });
+
+  const mixed = createPoolCluster();
+  mixed.add('MASTER', { host: '127.0.0.1' });
+  mixed.add('SLAVE', { host: '127.0.0.1', trace: false });
+
+  it('should keep the capture enabled while no node was added', () => {
+    strict.equal(traceOf(empty, '*'), true);
+  });
+
+  it('should disable the capture when every node opted out', () => {
+    strict.equal(traceOf(disabled, '*'), false);
+  });
+
+  it('should keep the capture enabled when a node still wants it', () => {
+    strict.equal(traceOf(mixed, '*'), true);
+  });
+
+  it('should resolve the flag per namespace pattern', () => {
+    strict.equal(traceOf(mixed, 'SLAVE'), false);
+    strict.equal(traceOf(mixed, 'MASTER'), true);
+  });
+
+  empty.end();
+  disabled.end();
+  mixed.end();
+});


### PR DESCRIPTION
Closes #4501.

`trace: false` was only honoured by `PromiseConnection#query`/`#execute` and `PromisePool#query`/`#execute`. Every other promise wrapper called `captureStackHolder()` unconditionally, so the per-call `Error.captureStackTrace` could not be opted out of — including three per-query paths.

### Now gated on `trace`

| site | reads |
| --- | --- |
| `PromisePreparedStatementInfo#execute` | `statement._connection.config.trace` |
| `PromisePoolNamespace#query` / `#execute` | `poolNamespace.trace` |
| `PromiseConnection#beginTransaction`, `commit`, `rollback`, `ping`, `reset`, `connect`, `prepare`, `changeUser` | `connection.config.trace` |
| `PromisePool#end` | `pool.config.connectionConfig.trace` |

### Pool cluster

A namespace spans several nodes, each with its own connection config, so `PoolNamespace` gets a `trace` getter that resolves the flag across the nodes matching the pattern: the capture is skipped only when **every** matching node opted out. A namespace with no nodes yet keeps capturing, so the `POOL_NOEXIST` rejection still points at the caller.

### Compatibility

`ConnectionConfig` sets `this.trace = options.trace !== false`, so only an explicit `false` opts out — unset, `true`, `0`, `null` and `undefined` keep today's behaviour. `makeDoneCb` / `applyCapturedStack` already handle `stackHolder === undefined`.

### Measured

8 concurrent `stmt.execute()` of a single-row prepared query, MySQL 8.3 in local Docker, node v26.0.0, client CPU µs/query over 40k queries, three interleaved runs each:

| | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| default | 38.8 | 38.0 | 38.9 |
| `trace: false` | 33.6 | 32.5 | 32.2 |

~15% less client CPU per query on the prepared-statement path, matching the numbers reported in the issue for the already-gated `pool.execute()` path.

### Tests

- `test/integration/promise-wrappers/test-trace-option.test.mts` — asserts the rejection stack points at the caller by default and does not with `trace: false`, for prepared-statement `execute`, `connection.prepare`, and pool-cluster `query`/`execute`. Verified to fail without the fix.
- `test/unit/pool-cluster/test-trace-flag.test.mts` — namespace flag resolution: empty cluster, all nodes opted out, mixed nodes, per-pattern scoping.

Full suite green locally against MySQL 8.3 (241 files); the new integration test also passes against MySQL 5.7, 9.x and MariaDB.
