### PR TITLE
test: cover length-coded parameter sizes at the 0xFD boundary

### DIFF
--- a/test/integration/regressions/test-#4499.test.mts
+++ b/test/integration/regressions/test-#4499.test.mts
@@ -28,7 +28,9 @@ if (!supportsQueryAttributes) {
 
 await describe('Regression #4499 — parameter byte lengths at the 0xFD boundary', async () => {
   await describe('COM_STMT_EXECUTE', async () => {
-    const connection = createConnection().promise();
+    // MySQL 5.7 projects a bound JSON parameter as a JSON column, which the
+    // driver would parse back into an object; 8.0+ and MariaDB return text.
+    const connection = createConnection({ jsonStrings: true }).promise();
 
     await it('should bind a string of exactly 0xFFFF bytes', async () => {
       const value = 'x'.repeat(BOUNDARY);

--- a/test/integration/regressions/test-#4499.test.mts
+++ b/test/integration/regressions/test-#4499.test.mts
@@ -1,0 +1,111 @@
+import type { RowDataPacket } from '../../../index.js';
+import { describe, it, strict } from 'poku';
+import { createConnection, getMysqlVersion } from '../../common.test.mjs';
+
+type ValueRow = RowDataPacket & { value: string };
+type LengthRow = RowDataPacket & { byteLength: number };
+type OkRow = RowDataPacket & { ok: number };
+
+// A length-coded integer in [0xFFFF, 0xFFFFFF) is written as the 0xFD tag plus
+// a 3-byte integer. Any parameter whose encoded byte length lands in that range
+// exercises the branch where the packet size is computed.
+const BOUNDARY = 0xffff;
+
+const probe = createConnection().promise();
+const server = await getMysqlVersion(probe);
+await probe.end();
+
+const supportsQueryAttributes =
+  !server.isMariaDB &&
+  (server.major > 8 ||
+    (server.major === 8 && (server.minor > 0 || server.patch >= 23)));
+
+if (!supportsQueryAttributes) {
+  console.log(
+    `Skipping query attribute tests: requires MySQL 8.0.23+, got ${server.version}`
+  );
+}
+
+await describe('Regression #4499 — parameter byte lengths at the 0xFD boundary', async () => {
+  await describe('COM_STMT_EXECUTE', async () => {
+    const connection = createConnection().promise();
+
+    await it('should bind a string of exactly 0xFFFF bytes', async () => {
+      const value = 'x'.repeat(BOUNDARY);
+      const [rows] = await connection.execute<ValueRow[]>('SELECT ? AS value', [
+        value,
+      ]);
+
+      strict.equal(rows[0].value, value);
+    });
+
+    await it('should bind a string whose byte length alone passes 0xFFFF', async () => {
+      const value = 'ä'.repeat(40000);
+
+      strict.ok(value.length < BOUNDARY);
+      strict.ok(Buffer.byteLength(value, 'utf8') > BOUNDARY);
+
+      const [rows] = await connection.execute<ValueRow[]>('SELECT ? AS value', [
+        value,
+      ]);
+
+      strict.equal(rows[0].value, value);
+    });
+
+    await it('should bind a JSON parameter above 0xFFFF bytes', async () => {
+      const value = { payload: 'x'.repeat(BOUNDARY) };
+      const [rows] = await connection.execute<ValueRow[]>('SELECT ? AS value', [
+        value,
+      ]);
+
+      strict.deepEqual(JSON.parse(rows[0].value), value);
+    });
+
+    await it('should bind a Buffer above 0xFFFF bytes', async () => {
+      const value = Buffer.alloc(BOUNDARY + 1, 0x61);
+      const [rows] = await connection.execute<LengthRow[]>(
+        'SELECT LENGTH(?) AS byteLength',
+        [value]
+      );
+
+      strict.equal(Number(rows[0].byteLength), value.length);
+    });
+
+    await connection.end();
+  });
+
+  if (!supportsQueryAttributes) {
+    return;
+  }
+
+  await describe('COM_QUERY attributes', async () => {
+    const connection = createConnection().promise();
+
+    await it('should send an attribute above 0xFFFF bytes', async () => {
+      const [rows] = await connection.query<OkRow[]>({
+        sql: 'SELECT 1 AS ok',
+        attributes: { payload: 'x'.repeat(BOUNDARY) },
+      });
+
+      strict.equal(rows[0].ok, 1);
+    });
+
+    await connection.end();
+  });
+
+  await describe('COM_STMT_EXECUTE attributes', async () => {
+    const connection = createConnection().promise();
+
+    await it('should send an attribute above 0xFFFF bytes', async () => {
+      const [rows] = await connection.execute<OkRow[]>({
+        sql: 'SELECT ? AS ok',
+        values: [1],
+        attributes: { payload: 'x'.repeat(BOUNDARY) },
+      });
+
+      strict.equal(rows[0].ok, 1);
+    });
+
+    await connection.end();
+  });
+});


### PR DESCRIPTION
Test-only PR. **It is expected to fail on `master`** — it is the failing reproduction for #4499. Once #4500 lands, a rebase should turn it green with no changes to the tests themselves.

### What it covers

`Packet.lengthCodedNumberLength()` reports **5** bytes for the `0xffff <= n < 0xffffff` range, but `writeLengthCodedNumber()` emits **4** there (the `0xfd` tag plus an Int24). Per the [protocol spec](https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_basic_dt_integers.html), `0xFD` is followed by a 3-byte integer, so 4 is correct and the size function is the wrong side of the mismatch.

Since #4494 computes packet sizes arithmetically instead of via a dry-run write, that 1-byte drift is no longer self-correcting and the `offset !== length` guard throws.

`test/integration/regressions/test-#4499.test.mts` adds six end-to-end cases:

**COM_STMT_EXECUTE bind parameters**
- a string of exactly `0xFFFF` bytes — the first failing value
- a string whose *byte* length passes `0xFFFF` while its *character* length stays below it, pinning the boundary to bytes rather than characters
- a JSON object parameter
- a `Buffer` parameter, which goes through `writeLengthCodedBuffer` rather than the string writer

**Query attributes** — the paths not mentioned in #4500's description, which fail identically
- a COM_QUERY attribute above `0xFFFF` bytes
- a COM_STMT_EXECUTE attribute above `0xFFFF` bytes

Each block gets its own connection: the serialization error is fatal to the connection, so a shared one would cascade and mask the real cause of later cases.

### Verified

On `master`, all six fail with the reported error, each reporting its own genuine cause:

```
COM_STMT_EXECUTE serialized 65555 bytes, expected 65556
COM_STMT_EXECUTE serialized 80020 bytes, expected 80021
COM_STMT_EXECUTE serialized 65569 bytes, expected 65570
COM_STMT_EXECUTE serialized 65556 bytes, expected 65557
COM_QUERY serialized 65568 bytes, expected 65569
COM_STMT_EXECUTE serialized 65573 bytes, expected 65574
```

With #4500's one-line change applied, all six pass against MySQL 5.7, 8.3, 9, and MariaDB 12.3, including the compression and static-parser variants. The rest of `test/integration/regressions` is unaffected (7 pass / 1 fail on master, that one being this file).

The query attribute cases are skipped with a printed reason on MariaDB and on MySQL below 8.0.23, which do not negotiate `CLIENT_QUERY_ATTRIBUTES` — without the guard they would pass vacuously, since the attribute is silently dropped before serialization.

Refs #4499, #4500