### PR TITLE
fix(typings): PoolCluster node events emit a string nodeId

### DIFF
--- a/promise.d.ts
+++ b/promise.d.ts
@@ -126,7 +126,7 @@ export interface PoolCluster extends EventEmitter {
   of(pattern: string, selector?: string): PoolNamespace;
 
   on(event: string, listener: (...args: any[]) => void): this;
-  on(event: 'remove', listener: (nodeId: number) => void): this;
+  on(event: 'remove', listener: (nodeId: string) => void): this;
   on(event: 'warn', listener: (err: Error) => void): this;
 }
 

--- a/test/tsc-build/mysql/createPoolCluster/events.test.ts
+++ b/test/tsc-build/mysql/createPoolCluster/events.test.ts
@@ -1,0 +1,10 @@
+import { mysql } from '../../index.test.js';
+
+const poolCluster = mysql.createPoolCluster();
+
+poolCluster.on('online', (nodeId) => nodeId.toUpperCase());
+poolCluster.on('offline', (nodeId) => nodeId.toUpperCase());
+poolCluster.on('remove', (nodeId) => nodeId.toUpperCase());
+
+// @ts-expect-error: The node id is a string
+poolCluster.on('remove', (nodeId) => nodeId.toFixed(2));

--- a/test/tsc-build/promise/createPoolCluster/events.test.ts
+++ b/test/tsc-build/promise/createPoolCluster/events.test.ts
@@ -1,0 +1,8 @@
+import { mysqlp as mysql } from '../../index.test.js';
+
+const poolCluster = mysql.createPoolCluster();
+
+poolCluster.on('remove', (nodeId) => nodeId.toUpperCase());
+
+// @ts-expect-error: The node id is a string
+poolCluster.on('remove', (nodeId) => nodeId.toFixed(2));

--- a/typings/mysql/lib/PoolCluster.d.ts
+++ b/typings/mysql/lib/PoolCluster.d.ts
@@ -83,9 +83,9 @@ declare class PoolCluster extends EventEmitter {
   of(pattern: string, selector?: string): PoolNamespace;
 
   on(event: string, listener: (...args: any[]) => void): this;
-  on(event: 'online', listener: (nodeId: number) => void): this;
-  on(event: 'offline', listener: (nodeId: number) => void): this;
-  on(event: 'remove', listener: (nodeId: number) => void): this;
+  on(event: 'online', listener: (nodeId: string) => void): this;
+  on(event: 'offline', listener: (nodeId: string) => void): this;
+  on(event: 'remove', listener: (nodeId: string) => void): this;
   on(event: 'warn', listener: (err: Error) => void): this;
 }
 


### PR DESCRIPTION
The pool cluster unit tests already treat the node id as a string - `test-connection-error-remove.test.mts` asserts the removed id equals `'SLAVE1'`, and the restore-events one checks `'MASTER'` for both online and offline. The typings say `number`, on all three events.

Wrong in both directions:

- `nodeId.toUpperCase()` is the call that actually works, and tsc rejects it with TS2339
- `nodeId.toFixed(2)` type-checks fine, then dies with `nodeId.toFixed is not a function`

`add()` sets the id to either the group name you passed or `CLUSTER::${n}`, and it goes out unchanged, so a string is the only thing it can be. A number never gets that far anyway, beacuse the node lookup calls `.match()` on the id first and throws.

Nothing caught it because `test/tsc-build` has no `.on(` calls in it at all. The unit tests do listen, but they annotate the id themselves, which picks the catch-all overload instead. The two files here are that check, and theyre most of the diff.

The promise side only declares `remove`, so that's the only one I touched there.

Its technically source-breaking for anyone who wrote to the old type, though the only code that stops compiling is code that already throws.
